### PR TITLE
wayland: Add support for wl_fixes.ack_global_remove

### DIFF
--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -112,7 +112,9 @@
 #define SDL_WL_DATA_DEVICE_VERSION 3
 
 // wl_fixes was introduced in 1.24.0
-#if SDL_WAYLAND_CHECK_VERSION(1, 24, 0)
+#if SDL_WAYLAND_CHECK_VERSION(1, 26, 0)
+#define SDL_WL_FIXES_VERSION 2
+#elif SDL_WAYLAND_CHECK_VERSION(1, 24, 0)
 #define SDL_WL_FIXES_VERSION 1
 #endif
 
@@ -561,7 +563,11 @@ static void wayland_preferred_check_handle_global(void *data, struct wl_registry
 
 static void wayland_preferred_check_remove_global(void *data, struct wl_registry *registry, uint32_t id)
 {
-    // No need to do anything here.
+    SDL_WaylandPreferredData *d = (SDL_WaylandPreferredData *)data;
+
+    if (d->wl_fixes && wl_fixes_get_version(d->wl_fixes) >= WL_FIXES_ACK_GLOBAL_REMOVE_SINCE_VERSION) {
+        wl_fixes_ack_global_remove(d->wl_fixes, registry, id);
+    }
 }
 
 static const struct wl_registry_listener preferred_registry_listener = {
@@ -1537,17 +1543,21 @@ static void handle_registry_remove_global(void *data, struct wl_registry *regist
             }
 
             d->output_count--;
-            return;
+            goto ack_remove;
         }
     }
 
     SDL_WaylandSeat *seat, *temp;
-    wl_list_for_each_safe (seat, temp, &d->seat_list, link)
-    {
+    wl_list_for_each_safe (seat, temp, &d->seat_list, link) {
         if (seat->registry_id == id) {
             Wayland_SeatDestroy(seat, false);
-            return;
+            goto ack_remove;
         }
+    }
+
+ack_remove:
+    if (d->wl_fixes && wl_fixes_get_version(d->wl_fixes) >= WL_FIXES_ACK_GLOBAL_REMOVE_SINCE_VERSION) {
+        wl_fixes_ack_global_remove(d->wl_fixes, registry, id);
     }
 }
 

--- a/wayland-protocols/wayland.xml
+++ b/wayland-protocols/wayland.xml
@@ -36,47 +36,47 @@
 
     <request name="sync">
       <description summary="asynchronous roundtrip">
-	The sync request asks the server to emit the 'done' event
-	on the returned wl_callback object.  Since requests are
-	handled in-order and events are delivered in-order, this can
-	be used as a barrier to ensure all previous requests and the
-	resulting events have been handled.
+        The sync request asks the server to emit the 'done' event
+        on the returned wl_callback object.  Since requests are
+        handled in-order and events are delivered in-order, this can
+        be used as a barrier to ensure all previous requests and the
+        resulting events have been handled.
 
-	The object returned by this request will be destroyed by the
-	compositor after the callback is fired and as such the client must not
-	attempt to use it after that point.
+        The object returned by this request will be destroyed by the
+        compositor after the callback is fired and as such the client must not
+        attempt to use it after that point.
 
-	The callback_data passed in the callback is undefined and should be ignored.
+        The callback_data passed in the callback is undefined and should be ignored.
       </description>
       <arg name="callback" type="new_id" interface="wl_callback"
-	   summary="callback object for the sync request"/>
+           summary="callback object for the sync request"/>
     </request>
 
     <request name="get_registry">
       <description summary="get global registry object">
-	This request creates a registry object that allows the client
-	to list and bind the global objects available from the
-	compositor.
+        This request creates a registry object that allows the client
+        to list and bind the global objects available from the
+        compositor.
 
-	It should be noted that the server side resources consumed in
-	response to a get_registry request can only be released when the
-	client disconnects, not when the client side proxy is destroyed.
-	Therefore, clients should invoke get_registry as infrequently as
-	possible to avoid wasting memory.
+        It should be noted that the server side resources consumed in
+        response to a get_registry request can only be released when the
+        client disconnects, not when the client side proxy is destroyed.
+        Therefore, clients should invoke get_registry as infrequently as
+        possible to avoid wasting memory.
       </description>
       <arg name="registry" type="new_id" interface="wl_registry"
-	   summary="global registry object"/>
+           summary="global registry object"/>
     </request>
 
     <event name="error">
       <description summary="fatal error event">
-	The error event is sent out when a fatal (non-recoverable)
-	error has occurred.  The object_id argument is the object
-	where the error occurred, most often in response to a request
-	to that object.  The code identifies the error and is defined
-	by the object interface.  As such, each interface defines its
-	own set of error codes.  The message is a brief description
-	of the error, for (debugging) convenience.
+        The error event is sent out when a fatal (non-recoverable)
+        error has occurred.  The object_id argument is the object
+        where the error occurred, most often in response to a request
+        to that object.  The code identifies the error and is defined
+        by the object interface.  As such, each interface defines its
+        own set of error codes.  The message is a brief description
+        of the error, for (debugging) convenience.
       </description>
       <arg name="object_id" type="object" summary="object where the error occurred"/>
       <arg name="code" type="uint" summary="error code"/>
@@ -85,26 +85,30 @@
 
     <enum name="error">
       <description summary="global error values">
-	These errors are global and can be emitted in response to any
-	server request.
+        These errors are global and can be emitted in response to any
+        server request.
       </description>
       <entry name="invalid_object" value="0"
-	     summary="server couldn't find object"/>
+             summary="server couldn't find object"/>
       <entry name="invalid_method" value="1"
-	     summary="method doesn't exist on the specified interface or malformed request"/>
+             summary="method doesn't exist on the specified interface or malformed request"/>
       <entry name="no_memory" value="2"
-	     summary="server is out of memory"/>
+             summary="server is out of memory"/>
       <entry name="implementation" value="3"
-	     summary="implementation error in compositor"/>
+             summary="implementation error in compositor"/>
     </enum>
 
     <event name="delete_id">
       <description summary="acknowledge object ID deletion">
-	This event is used internally by the object ID management
-	logic. When a client deletes an object that it had created,
-	the server will send this event to acknowledge that it has
-	seen the delete request. When the client receives this event,
-	it will know that it can safely reuse the object ID.
+        This event is used internally by the object ID management logic.
+
+        When the server stops using an object created by the client, the server
+        sends this event. In particular, after sending this event, the server
+        will no longer send any events that contain the object as the receiver
+        or as an argument.
+
+        When the client receives this event, it knows that it can reuse the
+        object ID.
       </description>
       <arg name="id" type="uint" summary="deleted object ID"/>
     </event>
@@ -136,20 +140,20 @@
 
     <request name="bind">
       <description summary="bind an object to the display">
-	Binds a new, client-created object to the server using the
-	specified name as the identifier.
+        Binds a new, client-created object to the server using the
+        specified name as the identifier.
       </description>
       <arg name="name" type="uint" summary="unique numeric name of the object"/>
-      <arg name="id" type="new_id" summary="bounded object"/>
+      <arg name="id" type="new_id" summary="bound object"/>
     </request>
 
     <event name="global">
       <description summary="announce global object">
-	Notify the client of global objects.
+        Notify the client of global objects.
 
-	The event notifies the client that a global object with
-	the given name is now available, and it implements the
-	given version of the given interface.
+        The event notifies the client that a global object with
+        the given name is now available, and it implements the
+        given version of the given interface.
       </description>
       <arg name="name" type="uint" summary="numeric name of the global object"/>
       <arg name="interface" type="string" summary="interface implemented by the object"/>
@@ -158,22 +162,22 @@
 
     <event name="global_remove">
       <description summary="announce removal of global object">
-	Notify the client of removed global objects.
+        Notify the client of removed global objects.
 
-	This event notifies the client that the global identified
-	by name is no longer available.  If the client bound to
-	the global using the bind request, the client should now
-	destroy that object.
+        This event notifies the client that the global identified
+        by name is no longer available.  If the client bound to
+        the global using the bind request, the client should now
+        destroy that object.
 
-	The object remains valid and requests to the object will be
-	ignored until the client destroys it, to avoid races between
-	the global going away and a client sending a request to it.
+        The object remains valid and requests to the object will be
+        ignored until the client destroys it, to avoid races between
+        the global going away and a client sending a request to it.
       </description>
       <arg name="name" type="uint" summary="numeric name of the global object"/>
     </event>
   </interface>
 
-  <interface name="wl_callback" version="1">
+  <interface name="wl_callback" version="1" frozen="true">
     <description summary="callback object">
       Clients can handle the 'done' event to get notified when
       the related request is done.
@@ -184,13 +188,13 @@
 
     <event name="done" type="destructor">
       <description summary="done event">
-	Notify the client when the related request is done.
+        Notify the client when the related request is done.
       </description>
       <arg name="callback_data" type="uint" summary="request-specific data for the callback"/>
     </event>
   </interface>
 
-  <interface name="wl_compositor" version="6">
+  <interface name="wl_compositor" version="7">
     <description summary="the compositor singleton">
       A compositor.  This object is a singleton global.  The
       compositor is in charge of combining the contents of multiple
@@ -199,20 +203,28 @@
 
     <request name="create_surface">
       <description summary="create new surface">
-	Ask the compositor to create a new surface.
+        Ask the compositor to create a new surface.
       </description>
       <arg name="id" type="new_id" interface="wl_surface" summary="the new surface"/>
     </request>
 
     <request name="create_region">
       <description summary="create new region">
-	Ask the compositor to create a new region.
+        Ask the compositor to create a new region.
       </description>
       <arg name="id" type="new_id" interface="wl_region" summary="the new region"/>
     </request>
+
+    <!-- Version 7 additions -->
+
+    <request name="release" type="destructor" since="7">
+      <description summary="destroy wl_compositor">
+        This request destroys the wl_compositor. This has no effect on any other objects.
+      </description>
+    </request>
   </interface>
 
-  <interface name="wl_shm_pool" version="2">
+  <interface name="wl_shm_pool" version="3">
     <description summary="a shared memory pool">
       The wl_shm_pool object encapsulates a piece of memory shared
       between the compositor and client.  Through the wl_shm_pool
@@ -223,19 +235,27 @@
       a surface or for many small buffers.
     </description>
 
+    <enum name="error" since="3">
+      <description summary="wl_shm_pool error values">
+        These errors can be emitted in response to wl_shm_pool requests.
+      </description>
+      <entry name="invalid_format" value="0" summary="buffer format is not known"/>
+      <entry name="invalid_stride" value="1" summary="invalid size or stride during buffer creation"/>
+    </enum>
+
     <request name="create_buffer">
       <description summary="create a buffer from the pool">
-	Create a wl_buffer object from the pool.
+        Create a wl_buffer object from the pool.
 
-	The buffer is created offset bytes into the pool and has
-	width and height as specified.  The stride argument specifies
-	the number of bytes from the beginning of one row to the beginning
-	of the next.  The format is the pixel format of the buffer and
-	must be one of those advertised through the wl_shm.format event.
+        The buffer is created offset bytes into the pool and has
+        width and height as specified.  The stride argument specifies
+        the number of bytes from the beginning of one row to the beginning
+        of the next.  The format is the pixel format of the buffer and
+        must be one of those advertised through the wl_shm.format event.
 
-	A buffer will keep a reference to the pool it was created from
-	so it is valid to destroy the pool immediately after creating
-	a buffer from it.
+        A buffer will keep a reference to the pool it was created from
+        so it is valid to destroy the pool immediately after creating
+        a buffer from it.
       </description>
       <arg name="id" type="new_id" interface="wl_buffer" summary="buffer to create"/>
       <arg name="offset" type="int" summary="buffer byte offset within the pool"/>
@@ -247,32 +267,32 @@
 
     <request name="destroy" type="destructor">
       <description summary="destroy the pool">
-	Destroy the shared memory pool.
+        Destroy the shared memory pool.
 
-	The mmapped memory will be released when all
-	buffers that have been created from this pool
-	are gone.
+        The mmapped memory will be released when all
+        buffers that have been created from this pool
+        are gone.
       </description>
     </request>
 
     <request name="resize">
       <description summary="change the size of the pool mapping">
-	This request will cause the server to remap the backing memory
-	for the pool from the file descriptor passed when the pool was
-	created, but using the new size.  This request can only be
-	used to make the pool bigger.
+        This request will cause the server to remap the backing memory
+        for the pool from the file descriptor passed when the pool was
+        created, but using the new size.  This request can only be
+        used to make the pool bigger.
 
-	This request only changes the amount of bytes that are mmapped
-	by the server and does not touch the file corresponding to the
-	file descriptor passed at creation time. It is the client's
-	responsibility to ensure that the file is at least as big as
-	the new pool size.
+        This request only changes the amount of bytes that are mmapped
+        by the server and does not touch the file corresponding to the
+        file descriptor passed at creation time. It is the client's
+        responsibility to ensure that the file is at least as big as
+        the new pool size.
       </description>
       <arg name="size" type="int" summary="new size of the pool, in bytes"/>
     </request>
   </interface>
 
-  <interface name="wl_shm" version="2">
+  <interface name="wl_shm" version="3">
     <description summary="shared memory support">
       A singleton global object that provides support for shared
       memory.
@@ -285,32 +305,33 @@
       that can be used for buffers.
     </description>
 
-    <enum name="error">
+    <enum name="error" since="3">
       <description summary="wl_shm error values">
-	These errors can be emitted in response to wl_shm requests.
+        These errors can be emitted in response to wl_shm requests.
       </description>
-      <entry name="invalid_format" value="0" summary="buffer format is not known"/>
-      <entry name="invalid_stride" value="1" summary="invalid size or stride during pool or buffer creation"/>
+      <entry name="invalid_format" value="0" summary="buffer format is not known" deprecated-since="3"/>
+      <entry name="invalid_stride" value="1" summary="invalid size or stride during pool creation"/>
       <entry name="invalid_fd" value="2" summary="mmapping the file descriptor failed"/>
     </enum>
 
     <enum name="format">
       <description summary="pixel formats">
-	This describes the memory layout of an individual pixel.
+        This describes the memory layout of an individual pixel.
 
-	All renderers should support argb8888 and xrgb8888 but any other
-	formats are optional and may not be supported by the particular
-	renderer in use.
+        All renderers should support argb8888 and xrgb8888 but any other
+        formats are optional and may not be supported by the particular
+        renderer in use.
 
-	The drm format codes match the macros defined in drm_fourcc.h, except
-	argb8888 and xrgb8888. The formats actually supported by the compositor
-	will be reported by the format event.
+        The drm format codes match the macros defined in drm_fourcc.h, except
+        argb8888 and xrgb8888. The formats actually supported by the compositor
+        will be reported by the format event. See drm_fourcc.h for more detailed
+        format descriptions.
 
-	For all wl_shm formats and unless specified in another protocol
-	extension, pre-multiplied alpha is used for pixel values.
+        For all wl_shm formats and unless specified in another protocol
+        extension, pre-multiplied alpha is used for pixel values.
       </description>
       <!-- Note to protocol writers: don't update this list manually, instead
-	   run the automated script that keeps it in sync with drm_fourcc.h. -->
+           run the automated script that keeps it in sync with drm_fourcc.h. -->
       <entry name="argb8888" value="0" summary="32-bit ARGB format, [31:0] A:R:G:B 8:8:8:8 little endian"/>
       <entry name="xrgb8888" value="1" summary="32-bit RGB format, [31:0] x:R:G:B 8:8:8:8 little endian"/>
       <entry name="c8" value="0x20203843" summary="8-bit color index format, [7:0] C"/>
@@ -322,7 +343,7 @@
       <entry name="bgrx4444" value="0x32315842" summary="16-bit BGRx format, [15:0] B:G:R:x 4:4:4:4 little endian"/>
       <entry name="argb4444" value="0x32315241" summary="16-bit ARGB format, [15:0] A:R:G:B 4:4:4:4 little endian"/>
       <entry name="abgr4444" value="0x32314241" summary="16-bit ABGR format, [15:0] A:B:G:R 4:4:4:4 little endian"/>
-      <entry name="rgba4444" value="0x32314152" summary="16-bit RBGA format, [15:0] R:G:B:A 4:4:4:4 little endian"/>
+      <entry name="rgba4444" value="0x32314152" summary="16-bit RGBA format, [15:0] R:G:B:A 4:4:4:4 little endian"/>
       <entry name="bgra4444" value="0x32314142" summary="16-bit BGRA format, [15:0] B:G:R:A 4:4:4:4 little endian"/>
       <entry name="xrgb1555" value="0x35315258" summary="16-bit xRGB format, [15:0] x:R:G:B 1:5:5:5 little endian"/>
       <entry name="xbgr1555" value="0x35314258" summary="16-bit xBGR 1555 format, [15:0] x:B:G:R 1:5:5:5 little endian"/>
@@ -434,15 +455,40 @@
       <entry name="avuy8888" value="0x59555641" summary="[31:0] A:Cr:Cb:Y 8:8:8:8 little endian"/>
       <entry name="xvuy8888" value="0x59555658" summary="[31:0] X:Cr:Cb:Y 8:8:8:8 little endian"/>
       <entry name="p030" value="0x30333050" summary="2x2 subsampled Cr:Cb plane 10 bits per channel packed"/>
+      <entry name="rgb161616" value="0x38344752" summary="[47:0] R:G:B 16:16:16 little endian"/>
+      <entry name="bgr161616" value="0x38344742" summary="[47:0] B:G:R 16:16:16 little endian"/>
+      <entry name="r16f" value="0x48202052" summary="[15:0] R 16 little endian"/>
+      <entry name="gr1616f" value="0x48205247" summary="[31:0] G:R 16:16 little endian"/>
+      <entry name="bgr161616f" value="0x48524742" summary="[47:0] B:G:R 16:16:16 little endian"/>
+      <entry name="r32f" value="0x46202052" summary="[31:0] R 32 little endian"/>
+      <entry name="gr3232f" value="0x46205247" summary="[63:0] G:R 32:32 little endian"/>
+      <entry name="bgr323232f" value="0x46524742" summary="[95:0] B:G:R 32:32:32 little endian"/>
+      <entry name="abgr32323232f" value="0x46384241" summary="[127:0] A:B:G:R 32:32:32:32 little endian"/>
+      <entry name="nv20" value="0x3032564e" summary="2x1 subsampled Cr:Cb plane"/>
+      <entry name="nv30" value="0x3033564e" summary="non-subsampled Cr:Cb plane"/>
+      <entry name="s010" value="0x30313053" summary="2x2 subsampled Cb (1) and Cr (2) planes 10 bits per channel"/>
+      <entry name="s210" value="0x30313253" summary="2x1 subsampled Cb (1) and Cr (2) planes 10 bits per channel"/>
+      <entry name="s410" value="0x30313453" summary="non-subsampled Cb (1) and Cr (2) planes 10 bits per channel"/>
+      <entry name="s012" value="0x32313053" summary="2x2 subsampled Cb (1) and Cr (2) planes 12 bits per channel"/>
+      <entry name="s212" value="0x32313253" summary="2x1 subsampled Cb (1) and Cr (2) planes 12 bits per channel"/>
+      <entry name="s412" value="0x32313453" summary="non-subsampled Cb (1) and Cr (2) planes 12 bits per channel"/>
+      <entry name="s016" value="0x36313053" summary="2x2 subsampled Cb (1) and Cr (2) planes 16 bits per channel"/>
+      <entry name="s216" value="0x36313253" summary="2x1 subsampled Cb (1) and Cr (2) planes 16 bits per channel"/>
+      <entry name="s416" value="0x36313453" summary="non-subsampled Cb (1) and Cr (2) planes 16 bits per channel"/>
+      <entry name="xvuy2101010" value="0x30335958" summary="[31:0] x:Cr:Cb:Y 2:10:10:10 little endian"/>
+      <entry name="p230" value="0x30333250" summary="2x1 subsampled Cr:Cb plane 10 bits per channel packed"/>
+      <entry name="t430" value="0x30333454"/>
+      <entry name="y8" value="0x59455247" summary="8-bit Y-only"/>
+      <entry name="xyyy2101010" value="0x34415059" summary="[31:0] x:Y2:Y1:Y0 2:10:10:10 little endian"/>
     </enum>
 
     <request name="create_pool">
       <description summary="create a shm pool">
-	Create a new wl_shm_pool object.
+        Create a new wl_shm_pool object.
 
-	The pool can be used to create shared memory based buffer
-	objects.  The server will mmap size bytes of the passed file
-	descriptor, to use as backing memory for the pool.
+        The pool can be used to create shared memory based buffer
+        objects.  The server will mmap size bytes of the passed file
+        descriptor, to use as backing memory for the pool.
       </description>
       <arg name="id" type="new_id" interface="wl_shm_pool" summary="pool to create"/>
       <arg name="fd" type="fd" summary="file descriptor for the pool"/>
@@ -451,9 +497,13 @@
 
     <event name="format">
       <description summary="pixel format description">
-	Informs the client about a valid pixel format that
-	can be used for buffers. Known formats include
-	argb8888 and xrgb8888.
+        Informs the client about a valid pixel format that
+        can be used for buffers. Known formats include
+        argb8888 and xrgb8888.
+
+        Extensions to drm_fourcc.h (or the format enum) do not require
+        increasing the wl_shm version; as a result, clients may receive format
+        codes which were not in the list at the time the client was made.
       </description>
       <arg name="format" type="uint" enum="format" summary="buffer pixel format"/>
     </event>
@@ -462,15 +512,15 @@
 
     <request name="release" type="destructor" since="2">
       <description summary="release the shm object">
-	Using this request a client can tell the server that it is not going to
-	use the shm object anymore.
+        Using this request a client can tell the server that it is not going to
+        use the shm object anymore.
 
-	Objects created via this interface remain unaffected.
+        Objects created via this interface remain unaffected.
       </description>
     </request>
   </interface>
 
-  <interface name="wl_buffer" version="1">
+  <interface name="wl_buffer" version="1" frozen="true">
     <description summary="content for a wl_surface">
       A buffer provides the content for a wl_surface. Buffers are
       created through factory interfaces such as wl_shm, wp_linux_buffer_params
@@ -491,34 +541,34 @@
 
     <request name="destroy" type="destructor">
       <description summary="destroy a buffer">
-	Destroy a buffer. If and how you need to release the backing
-	storage is defined by the buffer factory interface.
+        Destroy a buffer. If and how you need to release the backing
+        storage is defined by the buffer factory interface.
 
-	For possible side-effects to a surface, see wl_surface.attach.
+        For possible side-effects to a surface, see wl_surface.attach.
       </description>
     </request>
 
     <event name="release">
       <description summary="compositor releases buffer">
-	Sent when this wl_buffer is no longer used by the compositor.
+        Sent when this wl_buffer is no longer used by the compositor.
 
-	For more information on when release events may or may not be sent,
-	and what consequences it has, please see the description of
-	wl_surface.attach.
+        For more information on when release events may or may not be sent,
+        and what consequences it has, please see the description of
+        wl_surface.attach.
 
-	If a client receives a release event before the frame callback
-	requested in the same wl_surface.commit that attaches this
-	wl_buffer to a surface, then the client is immediately free to
-	reuse the buffer and its backing storage, and does not need a
-	second buffer for the next surface content update. Typically
-	this is possible, when the compositor maintains a copy of the
-	wl_surface contents, e.g. as a GL texture. This is an important
-	optimization for GL(ES) compositors with wl_shm clients.
+        If a client receives a release event before the frame callback
+        requested in the same wl_surface.commit that attaches this
+        wl_buffer to a surface, then the client is immediately free to
+        reuse the buffer and its backing storage, and does not need a
+        second buffer for the next surface content update. Typically
+        this is possible, when the compositor maintains a copy of the
+        wl_surface contents, e.g. as a GL texture. This is an important
+        optimization for GL(ES) compositors with wl_shm clients.
       </description>
     </event>
   </interface>
 
-  <interface name="wl_data_offer" version="3">
+  <interface name="wl_data_offer" version="4">
     <description summary="offer to transfer data">
       A wl_data_offer represents a piece of data offered for transfer
       by another client (the source client).  It is used by the
@@ -530,31 +580,31 @@
 
     <enum name="error">
       <entry name="invalid_finish" value="0"
-	     summary="finish request was called untimely"/>
+             summary="finish request was called untimely"/>
       <entry name="invalid_action_mask" value="1"
-	     summary="action mask contains invalid values"/>
+             summary="action mask contains invalid values"/>
       <entry name="invalid_action" value="2"
-	     summary="action argument has an invalid value"/>
+             summary="action argument has an invalid value"/>
       <entry name="invalid_offer" value="3"
-	     summary="offer doesn't accept this request"/>
+             summary="offer doesn't accept this request"/>
     </enum>
 
     <request name="accept">
       <description summary="accept one of the offered mime types">
-	Indicate that the client can accept the given mime type, or
-	NULL for not accepted.
+        Indicate that the client can accept the given mime type, or
+        NULL for not accepted.
 
-	For objects of version 2 or older, this request is used by the
-	client to give feedback whether the client can receive the given
-	mime type, or NULL if none is accepted; the feedback does not
-	determine whether the drag-and-drop operation succeeds or not.
+        For objects of version 2 or older, this request is used by the
+        client to give feedback whether the client can receive the given
+        mime type, or NULL if none is accepted; the feedback does not
+        determine whether the drag-and-drop operation succeeds or not.
 
-	For objects of version 3 or newer, this request determines the
-	final result of the drag-and-drop operation. If the end result
-	is that no mime types were accepted, the drag-and-drop operation
-	will be cancelled and the corresponding drag source will receive
-	wl_data_source.cancelled. Clients may still use this event in
-	conjunction with wl_data_source.action for feedback.
+        For objects of version 3 or newer, this request determines the
+        final result of the drag-and-drop operation. If the end result
+        is that no mime types were accepted, the drag-and-drop operation
+        will be cancelled and the corresponding drag source will receive
+        wl_data_source.cancelled. Clients may still use this event in
+        conjunction with wl_data_source.action for feedback.
       </description>
       <arg name="serial" type="uint" summary="serial number of the accept request"/>
       <arg name="mime_type" type="string" allow-null="true" summary="mime type accepted by the client"/>
@@ -562,21 +612,21 @@
 
     <request name="receive">
       <description summary="request that the data is transferred">
-	To transfer the offered data, the client issues this request
-	and indicates the mime type it wants to receive.  The transfer
-	happens through the passed file descriptor (typically created
-	with the pipe system call).  The source client writes the data
-	in the mime type representation requested and then closes the
-	file descriptor.
+        To transfer the offered data, the client issues this request
+        and indicates the mime type it wants to receive.  The transfer
+        happens through the passed file descriptor (typically created
+        with the pipe system call).  The source client writes the data
+        in the mime type representation requested and then closes the
+        file descriptor.
 
-	The receiving client reads from the read end of the pipe until
-	EOF and then closes its end, at which point the transfer is
-	complete.
+        The receiving client reads from the read end of the pipe until
+        EOF and then closes its end, at which point the transfer is
+        complete.
 
-	This request may happen multiple times for different mime types,
-	both before and after wl_data_device.drop. Drag-and-drop destination
-	clients may preemptively fetch data or examine it more closely to
-	determine acceptance.
+        This request may happen multiple times for different mime types,
+        both before and after wl_data_device.drop. Drag-and-drop destination
+        clients may preemptively fetch data or examine it more closely to
+        determine acceptance.
       </description>
       <arg name="mime_type" type="string" summary="mime type desired by receiver"/>
       <arg name="fd" type="fd" summary="file descriptor for data transfer"/>
@@ -584,14 +634,14 @@
 
     <request name="destroy" type="destructor">
       <description summary="destroy data offer">
-	Destroy the data offer.
+        Destroy the data offer.
       </description>
     </request>
 
     <event name="offer">
       <description summary="advertise offered mime type">
-	Sent immediately after creating the wl_data_offer object.  One
-	event per offered mime type.
+        Sent immediately after creating the wl_data_offer object.  One
+        event per offered mime type.
       </description>
       <arg name="mime_type" type="string" summary="offered mime type"/>
     </event>
@@ -600,118 +650,118 @@
 
     <request name="finish" since="3">
       <description summary="the offer will no longer be used">
-	Notifies the compositor that the drag destination successfully
-	finished the drag-and-drop operation.
+        Notifies the compositor that the drag destination successfully
+        finished the drag-and-drop operation.
 
-	Upon receiving this request, the compositor will emit
-	wl_data_source.dnd_finished on the drag source client.
+        Upon receiving this request, the compositor will emit
+        wl_data_source.dnd_finished on the drag source client.
 
-	It is a client error to perform other requests than
-	wl_data_offer.destroy after this one. It is also an error to perform
-	this request after a NULL mime type has been set in
-	wl_data_offer.accept or no action was received through
-	wl_data_offer.action.
+        It is a client error to perform other requests than
+        wl_data_offer.destroy after this one. It is also an error to perform
+        this request after a NULL mime type has been set in
+        wl_data_offer.accept or no action was received through
+        wl_data_offer.action.
 
-	If wl_data_offer.finish request is received for a non drag and drop
-	operation, the invalid_finish protocol error is raised.
+        If wl_data_offer.finish request is received for a non drag and drop
+        operation, the invalid_finish protocol error is raised.
       </description>
     </request>
 
     <request name="set_actions" since="3">
       <description summary="set the available/preferred drag-and-drop actions">
-	Sets the actions that the destination side client supports for
-	this operation. This request may trigger the emission of
-	wl_data_source.action and wl_data_offer.action events if the compositor
-	needs to change the selected action.
+        Sets the actions that the destination side client supports for
+        this operation. This request may trigger the emission of
+        wl_data_source.action and wl_data_offer.action events if the compositor
+        needs to change the selected action.
 
-	This request can be called multiple times throughout the
-	drag-and-drop operation, typically in response to wl_data_device.enter
-	or wl_data_device.motion events.
+        This request can be called multiple times throughout the
+        drag-and-drop operation, typically in response to wl_data_device.enter
+        or wl_data_device.motion events.
 
-	This request determines the final result of the drag-and-drop
-	operation. If the end result is that no action is accepted,
-	the drag source will receive wl_data_source.cancelled.
+        This request determines the final result of the drag-and-drop
+        operation. If the end result is that no action is accepted,
+        the drag source will receive wl_data_source.cancelled.
 
-	The dnd_actions argument must contain only values expressed in the
-	wl_data_device_manager.dnd_actions enum, and the preferred_action
-	argument must only contain one of those values set, otherwise it
-	will result in a protocol error.
+        The dnd_actions argument must contain only values expressed in the
+        wl_data_device_manager.dnd_actions enum, and the preferred_action
+        argument must only contain one of those values set, otherwise it
+        will result in a protocol error.
 
-	While managing an "ask" action, the destination drag-and-drop client
-	may perform further wl_data_offer.receive requests, and is expected
-	to perform one last wl_data_offer.set_actions request with a preferred
-	action other than "ask" (and optionally wl_data_offer.accept) before
-	requesting wl_data_offer.finish, in order to convey the action selected
-	by the user. If the preferred action is not in the
-	wl_data_offer.source_actions mask, an error will be raised.
+        While managing an "ask" action, the destination drag-and-drop client
+        may perform further wl_data_offer.receive requests, and is expected
+        to perform one last wl_data_offer.set_actions request with a preferred
+        action other than "ask" (and optionally wl_data_offer.accept) before
+        requesting wl_data_offer.finish, in order to convey the action selected
+        by the user. If the preferred action is not in the
+        wl_data_offer.source_actions mask, an error will be raised.
 
-	If the "ask" action is dismissed (e.g. user cancellation), the client
-	is expected to perform wl_data_offer.destroy right away.
+        If the "ask" action is dismissed (e.g. user cancellation), the client
+        is expected to perform wl_data_offer.destroy right away.
 
-	This request can only be made on drag-and-drop offers, a protocol error
-	will be raised otherwise.
+        This request can only be made on drag-and-drop offers, a protocol error
+        will be raised otherwise.
       </description>
       <arg name="dnd_actions" type="uint" summary="actions supported by the destination client"
-	   enum="wl_data_device_manager.dnd_action"/>
+           enum="wl_data_device_manager.dnd_action"/>
       <arg name="preferred_action" type="uint" summary="action preferred by the destination client"
-	   enum="wl_data_device_manager.dnd_action"/>
+           enum="wl_data_device_manager.dnd_action"/>
     </request>
 
     <event name="source_actions" since="3">
       <description summary="notify the source-side available actions">
-	This event indicates the actions offered by the data source. It
-	will be sent immediately after creating the wl_data_offer object,
-	or anytime the source side changes its offered actions through
-	wl_data_source.set_actions.
+        This event indicates the actions offered by the data source. It
+        will be sent immediately after creating the wl_data_offer object,
+        or anytime the source side changes its offered actions through
+        wl_data_source.set_actions.
       </description>
       <arg name="source_actions" type="uint" summary="actions offered by the data source"
-	   enum="wl_data_device_manager.dnd_action"/>
+           enum="wl_data_device_manager.dnd_action"/>
     </event>
 
     <event name="action" since="3">
       <description summary="notify the selected action">
-	This event indicates the action selected by the compositor after
-	matching the source/destination side actions. Only one action (or
-	none) will be offered here.
+        This event indicates the action selected by the compositor after
+        matching the source/destination side actions. Only one action (or
+        none) will be offered here.
 
-	This event can be emitted multiple times during the drag-and-drop
-	operation in response to destination side action changes through
-	wl_data_offer.set_actions.
+        This event can be emitted multiple times during the drag-and-drop
+        operation in response to destination side action changes through
+        wl_data_offer.set_actions.
 
-	This event will no longer be emitted after wl_data_device.drop
-	happened on the drag-and-drop destination, the client must
-	honor the last action received, or the last preferred one set
-	through wl_data_offer.set_actions when handling an "ask" action.
+        This event will no longer be emitted after wl_data_device.drop
+        happened on the drag-and-drop destination, the client must
+        honor the last action received, or the last preferred one set
+        through wl_data_offer.set_actions when handling an "ask" action.
 
-	Compositors may also change the selected action on the fly, mainly
-	in response to keyboard modifier changes during the drag-and-drop
-	operation.
+        Compositors may also change the selected action on the fly, mainly
+        in response to keyboard modifier changes during the drag-and-drop
+        operation.
 
-	The most recent action received is always the valid one. Prior to
-	receiving wl_data_device.drop, the chosen action may change (e.g.
-	due to keyboard modifiers being pressed). At the time of receiving
-	wl_data_device.drop the drag-and-drop destination must honor the
-	last action received.
+        The most recent action received is always the valid one. Prior to
+        receiving wl_data_device.drop, the chosen action may change (e.g.
+        due to keyboard modifiers being pressed). At the time of receiving
+        wl_data_device.drop the drag-and-drop destination must honor the
+        last action received.
 
-	Action changes may still happen after wl_data_device.drop,
-	especially on "ask" actions, where the drag-and-drop destination
-	may choose another action afterwards. Action changes happening
-	at this stage are always the result of inter-client negotiation, the
-	compositor shall no longer be able to induce a different action.
+        Action changes may still happen after wl_data_device.drop,
+        especially on "ask" actions, where the drag-and-drop destination
+        may choose another action afterwards. Action changes happening
+        at this stage are always the result of inter-client negotiation, the
+        compositor shall no longer be able to induce a different action.
 
-	Upon "ask" actions, it is expected that the drag-and-drop destination
-	may potentially choose a different action and/or mime type,
-	based on wl_data_offer.source_actions and finally chosen by the
-	user (e.g. popping up a menu with the available options). The
-	final wl_data_offer.set_actions and wl_data_offer.accept requests
-	must happen before the call to wl_data_offer.finish.
+        Upon "ask" actions, it is expected that the drag-and-drop destination
+        may potentially choose a different action and/or mime type,
+        based on wl_data_offer.source_actions and finally chosen by the
+        user (e.g. popping up a menu with the available options). The
+        final wl_data_offer.set_actions and wl_data_offer.accept requests
+        must happen before the call to wl_data_offer.finish.
       </description>
       <arg name="dnd_action" type="uint" summary="action selected by the compositor"
-	   enum="wl_data_device_manager.dnd_action"/>
+           enum="wl_data_device_manager.dnd_action"/>
     </event>
   </interface>
 
-  <interface name="wl_data_source" version="3">
+  <interface name="wl_data_source" version="4">
     <description summary="offer to transfer data">
       The wl_data_source object is the source side of a wl_data_offer.
       It is created by the source client in a data transfer and
@@ -721,41 +771,41 @@
 
     <enum name="error">
       <entry name="invalid_action_mask" value="0"
-	     summary="action mask contains invalid values"/>
+             summary="action mask contains invalid values"/>
       <entry name="invalid_source" value="1"
-	     summary="source doesn't accept this request"/>
+             summary="source doesn't accept this request"/>
     </enum>
 
     <request name="offer">
       <description summary="add an offered mime type">
-	This request adds a mime type to the set of mime types
-	advertised to targets.  Can be called several times to offer
-	multiple types.
+        This request adds a mime type to the set of mime types
+        advertised to targets.  Can be called several times to offer
+        multiple types.
       </description>
       <arg name="mime_type" type="string" summary="mime type offered by the data source"/>
     </request>
 
     <request name="destroy" type="destructor">
       <description summary="destroy the data source">
-	Destroy the data source.
+        Destroy the data source.
       </description>
     </request>
 
     <event name="target">
       <description summary="a target accepts an offered mime type">
-	Sent when a target accepts pointer_focus or motion events.  If
-	a target does not accept any of the offered types, type is NULL.
+        Sent when a target accepts pointer_focus or motion events.  If
+        a target does not accept any of the offered types, type is NULL.
 
-	Used for feedback during drag-and-drop.
+        Used for feedback during drag-and-drop.
       </description>
       <arg name="mime_type" type="string" allow-null="true" summary="mime type accepted by the target"/>
     </event>
 
     <event name="send">
       <description summary="send the data">
-	Request for data from the client.  Send the data as the
-	specified mime type over the passed file descriptor, then
-	close it.
+        Request for data from the client.  Send the data as the
+        specified mime type over the passed file descriptor, then
+        close it.
       </description>
       <arg name="mime_type" type="string" summary="mime type for the data"/>
       <arg name="fd" type="fd" summary="file descriptor for the data"/>
@@ -763,26 +813,26 @@
 
     <event name="cancelled">
       <description summary="selection was cancelled">
-	This data source is no longer valid. There are several reasons why
-	this could happen:
+        This data source is no longer valid. There are several reasons why
+        this could happen:
 
-	- The data source has been replaced by another data source.
-	- The drag-and-drop operation was performed, but the drop destination
-	  did not accept any of the mime types offered through
-	  wl_data_source.target.
-	- The drag-and-drop operation was performed, but the drop destination
-	  did not select any of the actions present in the mask offered through
-	  wl_data_source.action.
-	- The drag-and-drop operation was performed but didn't happen over a
-	  surface.
-	- The compositor cancelled the drag-and-drop operation (e.g. compositor
-	  dependent timeouts to avoid stale drag-and-drop transfers).
+        - The data source has been replaced by another data source.
+        - The drag-and-drop operation was performed, but the drop destination
+          did not accept any of the mime types offered through
+          wl_data_source.target.
+        - The drag-and-drop operation was performed, but the drop destination
+          did not select any of the actions present in the mask offered through
+          wl_data_source.action.
+        - The drag-and-drop operation was performed but didn't happen over a
+          surface.
+        - The compositor cancelled the drag-and-drop operation (e.g. compositor
+          dependent timeouts to avoid stale drag-and-drop transfers).
 
-	The client should clean up and destroy this data source.
+        The client should clean up and destroy this data source.
 
-	For objects of version 2 or older, wl_data_source.cancelled will
-	only be emitted if the data source was replaced by another data
-	source.
+        For objects of version 2 or older, wl_data_source.cancelled will
+        only be emitted if the data source was replaced by another data
+        source.
       </description>
     </event>
 
@@ -790,83 +840,83 @@
 
     <request name="set_actions" since="3">
       <description summary="set the available drag-and-drop actions">
-	Sets the actions that the source side client supports for this
-	operation. This request may trigger wl_data_source.action and
-	wl_data_offer.action events if the compositor needs to change the
-	selected action.
+        Sets the actions that the source side client supports for this
+        operation. This request may trigger wl_data_source.action and
+        wl_data_offer.action events if the compositor needs to change the
+        selected action.
 
-	The dnd_actions argument must contain only values expressed in the
-	wl_data_device_manager.dnd_actions enum, otherwise it will result
-	in a protocol error.
+        The dnd_actions argument must contain only values expressed in the
+        wl_data_device_manager.dnd_actions enum, otherwise it will result
+        in a protocol error.
 
-	This request must be made once only, and can only be made on sources
-	used in drag-and-drop, so it must be performed before
-	wl_data_device.start_drag. Attempting to use the source other than
-	for drag-and-drop will raise a protocol error.
+        This request must be made once only, and can only be made on sources
+        used in drag-and-drop, so it must be performed before
+        wl_data_device.start_drag. Attempting to use the source other than
+        for drag-and-drop will raise a protocol error.
       </description>
       <arg name="dnd_actions" type="uint" summary="actions supported by the data source"
-	   enum="wl_data_device_manager.dnd_action"/>
+           enum="wl_data_device_manager.dnd_action"/>
     </request>
 
     <event name="dnd_drop_performed" since="3">
       <description summary="the drag-and-drop operation physically finished">
-	The user performed the drop action. This event does not indicate
-	acceptance, wl_data_source.cancelled may still be emitted afterwards
-	if the drop destination does not accept any mime type.
+        The user performed the drop action. This event does not indicate
+        acceptance, wl_data_source.cancelled may still be emitted afterwards
+        if the drop destination does not accept any mime type.
 
-	However, this event might however not be received if the compositor
-	cancelled the drag-and-drop operation before this event could happen.
+        However, this event might not be received if the compositor cancelled
+        the drag-and-drop operation before this event could happen.
 
-	Note that the data_source may still be used in the future and should
-	not be destroyed here.
+        Note that the data_source may still be used in the future and should
+        not be destroyed here.
       </description>
     </event>
 
     <event name="dnd_finished" since="3">
       <description summary="the drag-and-drop operation concluded">
-	The drop destination finished interoperating with this data
-	source, so the client is now free to destroy this data source and
-	free all associated data.
+        The drop destination finished interoperating with this data
+        source, so the client is now free to destroy this data source and
+        free all associated data.
 
-	If the action used to perform the operation was "move", the
-	source can now delete the transferred data.
+        If the action used to perform the operation was "move", the
+        source can now delete the transferred data.
       </description>
     </event>
 
     <event name="action" since="3">
       <description summary="notify the selected action">
-	This event indicates the action selected by the compositor after
-	matching the source/destination side actions. Only one action (or
-	none) will be offered here.
+        This event indicates the action selected by the compositor after
+        matching the source/destination side actions. Only one action (or
+        none) will be offered here.
 
-	This event can be emitted multiple times during the drag-and-drop
-	operation, mainly in response to destination side changes through
-	wl_data_offer.set_actions, and as the data device enters/leaves
-	surfaces.
+        This event can be emitted multiple times during the drag-and-drop
+        operation, mainly in response to destination side changes through
+        wl_data_offer.set_actions, and as the data device enters/leaves
+        surfaces.
 
-	It is only possible to receive this event after
-	wl_data_source.dnd_drop_performed if the drag-and-drop operation
-	ended in an "ask" action, in which case the final wl_data_source.action
-	event will happen immediately before wl_data_source.dnd_finished.
+        It is only possible to receive this event after
+        wl_data_source.dnd_drop_performed if the drag-and-drop operation
+        ended in an "ask" action, in which case the final wl_data_source.action
+        event will happen immediately before wl_data_source.dnd_finished.
 
-	Compositors may also change the selected action on the fly, mainly
-	in response to keyboard modifier changes during the drag-and-drop
-	operation.
+        Compositors may also change the selected action on the fly, mainly
+        in response to keyboard modifier changes during the drag-and-drop
+        operation.
 
-	The most recent action received is always the valid one. The chosen
-	action may change alongside negotiation (e.g. an "ask" action can turn
-	into a "move" operation), so the effects of the final action must
-	always be applied in wl_data_offer.dnd_finished.
+        The most recent action received is always the valid one. The chosen
+        action may change alongside negotiation (e.g. an "ask" action can turn
+        into a "move" operation), so the effects of the final action must
+        always be applied in wl_data_source.dnd_finished.
 
-	Clients can trigger cursor surface changes from this point, so
-	they reflect the current action.
+        Clients can trigger cursor surface changes from this point, so
+        they reflect the current action.
       </description>
       <arg name="dnd_action" type="uint" summary="action selected by the compositor"
-	   enum="wl_data_device_manager.dnd_action"/>
+           enum="wl_data_device_manager.dnd_action"/>
     </event>
   </interface>
 
-  <interface name="wl_data_device" version="3">
+  <interface name="wl_data_device" version="4">
     <description summary="data transfer device">
       There is one wl_data_device per seat which can be obtained
       from the global wl_data_device_manager singleton.
@@ -882,35 +932,35 @@
 
     <request name="start_drag">
       <description summary="start drag-and-drop operation">
-	This request asks the compositor to start a drag-and-drop
-	operation on behalf of the client.
+        This request asks the compositor to start a drag-and-drop
+        operation on behalf of the client.
 
-	The source argument is the data source that provides the data
-	for the eventual data transfer. If source is NULL, enter, leave
-	and motion events are sent only to the client that initiated the
-	drag and the client is expected to handle the data passing
-	internally. If source is destroyed, the drag-and-drop session will be
-	cancelled.
+        The source argument is the data source that provides the data
+        for the eventual data transfer. If source is NULL, enter, leave
+        and motion events are sent only to the client that initiated the
+        drag and the client is expected to handle the data passing
+        internally. If source is destroyed, the drag-and-drop session will be
+        cancelled.
 
-	The origin surface is the surface where the drag originates and
-	the client must have an active implicit grab that matches the
-	serial.
+        The origin surface is the surface where the drag originates and
+        the client must have an active implicit grab that matches the
+        serial.
 
-	The icon surface is an optional (can be NULL) surface that
-	provides an icon to be moved around with the cursor.  Initially,
-	the top-left corner of the icon surface is placed at the cursor
-	hotspot, but subsequent wl_surface.offset requests can move the
-	relative position. Attach requests must be confirmed with
-	wl_surface.commit as usual. The icon surface is given the role of
-	a drag-and-drop icon. If the icon surface already has another role,
-	it raises a protocol error.
+        The icon surface is an optional (can be NULL) surface that
+        provides an icon to be moved around with the cursor.  Initially,
+        the top-left corner of the icon surface is placed at the cursor
+        hotspot, but subsequent wl_surface.offset requests can move the
+        relative position. Attach requests must be confirmed with
+        wl_surface.commit as usual. The icon surface is given the role of
+        a drag-and-drop icon. If the icon surface already has another role,
+        it raises a protocol error.
 
-	The input region is ignored for wl_surfaces with the role of a
-	drag-and-drop icon.
+        The input region is ignored for wl_surfaces with the role of a
+        drag-and-drop icon.
 
-	The given source may not be used in any further set_selection or
-	start_drag requests. Attempting to reuse a previously-used source
-	may send a used_source error.
+        The given source may not be used in any further set_selection or
+        start_drag requests. Attempting to reuse a previously-used source
+        may send a used_source error.
       </description>
       <arg name="source" type="object" interface="wl_data_source" allow-null="true" summary="data source for the eventual transfer"/>
       <arg name="origin" type="object" interface="wl_surface" summary="surface where the drag originates"/>
@@ -920,14 +970,14 @@
 
     <request name="set_selection">
       <description summary="copy data to the selection">
-	This request asks the compositor to set the selection
-	to the data from the source on behalf of the client.
+        This request asks the compositor to set the selection
+        to the data from the source on behalf of the client.
 
-	To unset the selection, set the source to NULL.
+        To unset the selection, set the source to NULL.
 
-	The given source may not be used in any further set_selection or
-	start_drag requests. Attempting to reuse a previously-used source
-	may send a used_source error.
+        The given source may not be used in any further set_selection or
+        start_drag requests. Attempting to reuse a previously-used source
+        may send a used_source error.
       </description>
       <arg name="source" type="object" interface="wl_data_source" allow-null="true" summary="data source for the selection"/>
       <arg name="serial" type="uint" summary="serial number of the event that triggered this request"/>
@@ -935,46 +985,46 @@
 
     <event name="data_offer">
       <description summary="introduce a new wl_data_offer">
-	The data_offer event introduces a new wl_data_offer object,
-	which will subsequently be used in either the
-	data_device.enter event (for drag-and-drop) or the
-	data_device.selection event (for selections).  Immediately
-	following the data_device.data_offer event, the new data_offer
-	object will send out data_offer.offer events to describe the
-	mime types it offers.
+        The data_offer event introduces a new wl_data_offer object,
+        which will subsequently be used in either the
+        data_device.enter event (for drag-and-drop) or the
+        data_device.selection event (for selections).  Immediately
+        following the data_device.data_offer event, the new data_offer
+        object will send out data_offer.offer events to describe the
+        mime types it offers.
       </description>
       <arg name="id" type="new_id" interface="wl_data_offer" summary="the new data_offer object"/>
     </event>
 
     <event name="enter">
       <description summary="initiate drag-and-drop session">
-	This event is sent when an active drag-and-drop pointer enters
-	a surface owned by the client.  The position of the pointer at
-	enter time is provided by the x and y arguments, in surface-local
-	coordinates.
+        This event is sent when an active drag-and-drop pointer enters
+        a surface owned by the client.  The position of the pointer at
+        enter time is provided by the x and y arguments, in surface-local
+        coordinates.
       </description>
       <arg name="serial" type="uint" summary="serial number of the enter event"/>
       <arg name="surface" type="object" interface="wl_surface" summary="client surface entered"/>
       <arg name="x" type="fixed" summary="surface-local x coordinate"/>
       <arg name="y" type="fixed" summary="surface-local y coordinate"/>
       <arg name="id" type="object" interface="wl_data_offer" allow-null="true"
-	   summary="source data_offer object"/>
+           summary="source data_offer object"/>
     </event>
 
     <event name="leave">
       <description summary="end drag-and-drop session">
-	This event is sent when the drag-and-drop pointer leaves the
-	surface and the session ends.  The client must destroy the
-	wl_data_offer introduced at enter time at this point.
+        This event is sent when the drag-and-drop pointer leaves the
+        surface and the session ends.  The client must destroy the
+        wl_data_offer introduced at enter time at this point.
       </description>
     </event>
 
     <event name="motion">
       <description summary="drag-and-drop session motion">
-	This event is sent when the drag-and-drop pointer moves within
-	the currently focused surface. The new position of the pointer
-	is provided by the x and y arguments, in surface-local
-	coordinates.
+        This event is sent when the drag-and-drop pointer moves within
+        the currently focused surface. The new position of the pointer
+        is provided by the x and y arguments, in surface-local
+        coordinates.
       </description>
       <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
       <arg name="x" type="fixed" summary="surface-local x coordinate"/>
@@ -983,51 +1033,51 @@
 
     <event name="drop">
       <description summary="end drag-and-drop session successfully">
-	The event is sent when a drag-and-drop operation is ended
-	because the implicit grab is removed.
+        The event is sent when a drag-and-drop operation is ended
+        because the implicit grab is removed.
 
-	The drag-and-drop destination is expected to honor the last action
-	received through wl_data_offer.action, if the resulting action is
-	"copy" or "move", the destination can still perform
-	wl_data_offer.receive requests, and is expected to end all
-	transfers with a wl_data_offer.finish request.
+        The drag-and-drop destination is expected to honor the last action
+        received through wl_data_offer.action, if the resulting action is
+        "copy" or "move", the destination can still perform
+        wl_data_offer.receive requests, and is expected to end all
+        transfers with a wl_data_offer.finish request.
 
-	If the resulting action is "ask", the action will not be considered
-	final. The drag-and-drop destination is expected to perform one last
-	wl_data_offer.set_actions request, or wl_data_offer.destroy in order
-	to cancel the operation.
+        If the resulting action is "ask", the action will not be considered
+        final. The drag-and-drop destination is expected to perform one last
+        wl_data_offer.set_actions request, or wl_data_offer.destroy in order
+        to cancel the operation.
       </description>
     </event>
 
     <event name="selection">
       <description summary="advertise new selection">
-	The selection event is sent out to notify the client of a new
-	wl_data_offer for the selection for this device.  The
-	data_device.data_offer and the data_offer.offer events are
-	sent out immediately before this event to introduce the data
-	offer object.  The selection event is sent to a client
-	immediately before receiving keyboard focus and when a new
-	selection is set while the client has keyboard focus.  The
-	data_offer is valid until a new data_offer or NULL is received
-	or until the client loses keyboard focus.  Switching surface with
-	keyboard focus within the same client doesn't mean a new selection
-	will be sent.  The client must destroy the previous selection
-	data_offer, if any, upon receiving this event.
+        The selection event is sent out to notify the client of a new
+        wl_data_offer for the selection for this device.  The
+        data_device.data_offer and the data_offer.offer events are
+        sent out immediately before this event to introduce the data
+        offer object.  The selection event is sent to a client
+        immediately before receiving keyboard focus and when a new
+        selection is set while the client has keyboard focus.  The
+        data_offer is valid until a new data_offer or NULL is received
+        or until the client loses keyboard focus.  Switching surface with
+        keyboard focus within the same client doesn't mean a new selection
+        will be sent.  The client must destroy the previous selection
+        data_offer, if any, upon receiving this event.
       </description>
       <arg name="id" type="object" interface="wl_data_offer" allow-null="true"
-	   summary="selection data_offer object"/>
+           summary="selection data_offer object"/>
     </event>
 
     <!-- Version 2 additions -->
 
     <request name="release" type="destructor" since="2">
       <description summary="destroy data device">
-	This request destroys the data device.
+        This request destroys the data device.
       </description>
     </request>
   </interface>
 
-  <interface name="wl_data_device_manager" version="3">
+  <interface name="wl_data_device_manager" version="4">
     <description summary="data transfer interface">
       The wl_data_device_manager is a singleton global object that
       provides access to inter-client data transfer mechanisms such as
@@ -1043,14 +1093,14 @@
 
     <request name="create_data_source">
       <description summary="create a new data source">
-	Create a new data source.
+        Create a new data source.
       </description>
       <arg name="id" type="new_id" interface="wl_data_source" summary="data source to create"/>
     </request>
 
     <request name="get_data_device">
       <description summary="create a new data device">
-	Create a new data device for a given seat.
+        Create a new data device for a given seat.
       </description>
       <arg name="id" type="new_id" interface="wl_data_device" summary="data device to create"/>
       <arg name="seat" type="object" interface="wl_seat" summary="seat associated with the data device"/>
@@ -1060,35 +1110,44 @@
 
     <enum name="dnd_action" bitfield="true" since="3">
       <description summary="drag and drop actions">
-	This is a bitmask of the available/preferred actions in a
-	drag-and-drop operation.
+        This is a bitmask of the available/preferred actions in a
+        drag-and-drop operation.
 
-	In the compositor, the selected action is a result of matching the
-	actions offered by the source and destination sides.  "action" events
-	with a "none" action will be sent to both source and destination if
-	there is no match. All further checks will effectively happen on
-	(source actions ∩ destination actions).
+        In the compositor, the selected action is a result of matching the
+        actions offered by the source and destination sides.  "action" events
+        with a "none" action will be sent to both source and destination if
+        there is no match. All further checks will effectively happen on
+        (source actions ∩ destination actions).
 
-	In addition, compositors may also pick different actions in
-	reaction to key modifiers being pressed. One common design that
-	is used in major toolkits (and the behavior recommended for
-	compositors) is:
+        In addition, compositors may also pick different actions in
+        reaction to key modifiers being pressed. One common design that
+        is used in major toolkits (and the behavior recommended for
+        compositors) is:
 
-	- If no modifiers are pressed, the first match (in bit order)
-	  will be used.
-	- Pressing Shift selects "move", if enabled in the mask.
-	- Pressing Control selects "copy", if enabled in the mask.
+        - If no modifiers are pressed, the first match (in bit order)
+          will be used.
+        - Pressing Shift selects "move", if enabled in the mask.
+        - Pressing Control selects "copy", if enabled in the mask.
 
-	Behavior beyond that is considered implementation-dependent.
-	Compositors may for example bind other modifiers (like Alt/Meta)
-	or drags initiated with other buttons than BTN_LEFT to specific
-	actions (e.g. "ask").
+        Behavior beyond that is considered implementation-dependent.
+        Compositors may for example bind other modifiers (like Alt/Meta)
+        or drags initiated with other buttons than BTN_LEFT to specific
+        actions (e.g. "ask").
       </description>
       <entry name="none" value="0" summary="no action"/>
       <entry name="copy" value="1" summary="copy action"/>
       <entry name="move" value="2" summary="move action"/>
       <entry name="ask" value="4" summary="ask action"/>
     </enum>
+
+    <!-- Version 4 additions -->
+
+    <request name="release" type="destructor" since="4">
+      <description summary="destroy wl_data_device_manager">
+        This request destroys the wl_data_device_manager. This has no effect on any other
+        objects.
+      </description>
+    </request>
   </interface>
 
   <interface name="wl_shell" version="1">
@@ -1110,11 +1169,11 @@
 
     <request name="get_shell_surface">
       <description summary="create a shell surface from a surface">
-	Create a shell surface for an existing surface. This gives
-	the wl_surface the role of a shell surface. If the wl_surface
-	already has another role, it raises a protocol error.
+        Create a shell surface for an existing surface. This gives
+        the wl_surface the role of a shell surface. If the wl_surface
+        already has another role, it raises a protocol error.
 
-	Only one shell surface can be associated with a given surface.
+        Only one shell surface can be associated with a given surface.
       </description>
       <arg name="id" type="new_id" interface="wl_shell_surface" summary="shell surface to create"/>
       <arg name="surface" type="object" interface="wl_surface" summary="surface to be given the shell surface role"/>
@@ -1138,19 +1197,19 @@
 
     <request name="pong">
       <description summary="respond to a ping event">
-	A client must respond to a ping event with a pong request or
-	the client may be deemed unresponsive.
+        A client must respond to a ping event with a pong request or
+        the client may be deemed unresponsive.
       </description>
       <arg name="serial" type="uint" summary="serial number of the ping event"/>
     </request>
 
     <request name="move">
       <description summary="start an interactive move">
-	Start a pointer-driven move of the surface.
+        Start a pointer-driven move of the surface.
 
-	This request must be used in response to a button press event.
-	The server may ignore move requests depending on the state of
-	the surface (e.g. fullscreen or maximized).
+        This request must be used in response to a button press event.
+        The server may ignore move requests depending on the state of
+        the surface (e.g. fullscreen or maximized).
       </description>
       <arg name="seat" type="object" interface="wl_seat" summary="seat whose pointer is used"/>
       <arg name="serial" type="uint" summary="serial number of the implicit grab on the pointer"/>
@@ -1158,10 +1217,10 @@
 
     <enum name="resize" bitfield="true">
       <description summary="edge values for resizing">
-	These values are used to indicate which edge of a surface
-	is being dragged in a resize operation. The server may
-	use this information to adapt its behavior, e.g. choose
-	an appropriate cursor image.
+        These values are used to indicate which edge of a surface
+        is being dragged in a resize operation. The server may
+        use this information to adapt its behavior, e.g. choose
+        an appropriate cursor image.
       </description>
       <entry name="none" value="0" summary="no edge"/>
       <entry name="top" value="1" summary="top edge"/>
@@ -1176,11 +1235,11 @@
 
     <request name="resize">
       <description summary="start an interactive resize">
-	Start a pointer-driven resizing of the surface.
+        Start a pointer-driven resizing of the surface.
 
-	This request must be used in response to a button press event.
-	The server may ignore resize requests depending on the state of
-	the surface (e.g. fullscreen or maximized).
+        This request must be used in response to a button press event.
+        The server may ignore resize requests depending on the state of
+        the surface (e.g. fullscreen or maximized).
       </description>
       <arg name="seat" type="object" interface="wl_seat" summary="seat whose pointer is used"/>
       <arg name="serial" type="uint" summary="serial number of the implicit grab on the pointer"/>
@@ -1189,29 +1248,29 @@
 
     <request name="set_toplevel">
       <description summary="make the surface a toplevel surface">
-	Map the surface as a toplevel surface.
+        Map the surface as a toplevel surface.
 
-	A toplevel surface is not fullscreen, maximized or transient.
+        A toplevel surface is not fullscreen, maximized or transient.
       </description>
     </request>
 
     <enum name="transient" bitfield="true">
       <description summary="details of transient behaviour">
-	These flags specify details of the expected behaviour
-	of transient surfaces. Used in the set_transient request.
+        These flags specify details of the expected behaviour
+        of transient surfaces. Used in the set_transient request.
       </description>
       <entry name="inactive" value="0x1" summary="do not set keyboard focus"/>
     </enum>
 
     <request name="set_transient">
       <description summary="make the surface a transient surface">
-	Map the surface relative to an existing surface.
+        Map the surface relative to an existing surface.
 
-	The x and y arguments specify the location of the upper left
-	corner of the surface relative to the upper left corner of the
-	parent surface, in surface-local coordinates.
+        The x and y arguments specify the location of the upper left
+        corner of the surface relative to the upper left corner of the
+        parent surface, in surface-local coordinates.
 
-	The flags argument controls details of the transient behaviour.
+        The flags argument controls details of the transient behaviour.
       </description>
       <arg name="parent" type="object" interface="wl_surface" summary="parent surface"/>
       <arg name="x" type="int" summary="surface-local x coordinate"/>
@@ -1221,9 +1280,9 @@
 
     <enum name="fullscreen_method">
       <description summary="different method to set the surface fullscreen">
-	Hints to indicate to the compositor how to deal with a conflict
-	between the dimensions of the surface and the dimensions of the
-	output. The compositor is free to ignore this parameter.
+        Hints to indicate to the compositor how to deal with a conflict
+        between the dimensions of the surface and the dimensions of the
+        output. The compositor is free to ignore this parameter.
       </description>
       <entry name="default" value="0" summary="no preference, apply default policy"/>
       <entry name="scale" value="1" summary="scale, preserve the surface's aspect ratio and center on output"/>
@@ -1233,67 +1292,67 @@
 
     <request name="set_fullscreen">
       <description summary="make the surface a fullscreen surface">
-	Map the surface as a fullscreen surface.
+        Map the surface as a fullscreen surface.
 
-	If an output parameter is given then the surface will be made
-	fullscreen on that output. If the client does not specify the
-	output then the compositor will apply its policy - usually
-	choosing the output on which the surface has the biggest surface
-	area.
+        If an output parameter is given then the surface will be made
+        fullscreen on that output. If the client does not specify the
+        output then the compositor will apply its policy - usually
+        choosing the output on which the surface has the biggest surface
+        area.
 
-	The client may specify a method to resolve a size conflict
-	between the output size and the surface size - this is provided
-	through the method parameter.
+        The client may specify a method to resolve a size conflict
+        between the output size and the surface size - this is provided
+        through the method parameter.
 
-	The framerate parameter is used only when the method is set
-	to "driver", to indicate the preferred framerate. A value of 0
-	indicates that the client does not care about framerate.  The
-	framerate is specified in mHz, that is framerate of 60000 is 60Hz.
+        The framerate parameter is used only when the method is set
+        to "driver", to indicate the preferred framerate. A value of 0
+        indicates that the client does not care about framerate.  The
+        framerate is specified in mHz, that is framerate of 60000 is 60Hz.
 
-	A method of "scale" or "driver" implies a scaling operation of
-	the surface, either via a direct scaling operation or a change of
-	the output mode. This will override any kind of output scaling, so
-	that mapping a surface with a buffer size equal to the mode can
-	fill the screen independent of buffer_scale.
+        A method of "scale" or "driver" implies a scaling operation of
+        the surface, either via a direct scaling operation or a change of
+        the output mode. This will override any kind of output scaling, so
+        that mapping a surface with a buffer size equal to the mode can
+        fill the screen independent of buffer_scale.
 
-	A method of "fill" means we don't scale up the buffer, however
-	any output scale is applied. This means that you may run into
-	an edge case where the application maps a buffer with the same
-	size of the output mode but buffer_scale 1 (thus making a
-	surface larger than the output). In this case it is allowed to
-	downscale the results to fit the screen.
+        A method of "fill" means we don't scale up the buffer, however
+        any output scale is applied. This means that you may run into
+        an edge case where the application maps a buffer with the same
+        size of the output mode but buffer_scale 1 (thus making a
+        surface larger than the output). In this case it is allowed to
+        downscale the results to fit the screen.
 
-	The compositor must reply to this request with a configure event
-	with the dimensions for the output on which the surface will
-	be made fullscreen.
+        The compositor must reply to this request with a configure event
+        with the dimensions for the output on which the surface will
+        be made fullscreen.
       </description>
       <arg name="method" type="uint" enum="fullscreen_method" summary="method for resolving size conflict"/>
       <arg name="framerate" type="uint" summary="framerate in mHz"/>
       <arg name="output" type="object" interface="wl_output" allow-null="true"
-	   summary="output on which the surface is to be fullscreen"/>
+           summary="output on which the surface is to be fullscreen"/>
     </request>
 
     <request name="set_popup">
       <description summary="make the surface a popup surface">
-	Map the surface as a popup.
+        Map the surface as a popup.
 
-	A popup surface is a transient surface with an added pointer
-	grab.
+        A popup surface is a transient surface with an added pointer
+        grab.
 
-	An existing implicit grab will be changed to owner-events mode,
-	and the popup grab will continue after the implicit grab ends
-	(i.e. releasing the mouse button does not cause the popup to
-	be unmapped).
+        An existing implicit grab will be changed to owner-events mode,
+        and the popup grab will continue after the implicit grab ends
+        (i.e. releasing the mouse button does not cause the popup to
+        be unmapped).
 
-	The popup grab continues until the window is destroyed or a
-	mouse button is pressed in any other client's window. A click
-	in any of the client's surfaces is reported as normal, however,
-	clicks in other clients' surfaces will be discarded and trigger
-	the callback.
+        The popup grab continues until the window is destroyed or a
+        mouse button is pressed in any other client's window. A click
+        in any of the client's surfaces is reported as normal, however,
+        clicks in other clients' surfaces will be discarded and trigger
+        the callback.
 
-	The x and y arguments specify the location of the upper left
-	corner of the surface relative to the upper left corner of the
-	parent surface, in surface-local coordinates.
+        The x and y arguments specify the location of the upper left
+        corner of the surface relative to the upper left corner of the
+        parent surface, in surface-local coordinates.
       </description>
       <arg name="seat" type="object" interface="wl_seat" summary="seat whose pointer is used"/>
       <arg name="serial" type="uint" summary="serial number of the implicit grab on the pointer"/>
@@ -1305,81 +1364,81 @@
 
     <request name="set_maximized">
       <description summary="make the surface a maximized surface">
-	Map the surface as a maximized surface.
+        Map the surface as a maximized surface.
 
-	If an output parameter is given then the surface will be
-	maximized on that output. If the client does not specify the
-	output then the compositor will apply its policy - usually
-	choosing the output on which the surface has the biggest surface
-	area.
+        If an output parameter is given then the surface will be
+        maximized on that output. If the client does not specify the
+        output then the compositor will apply its policy - usually
+        choosing the output on which the surface has the biggest surface
+        area.
 
-	The compositor will reply with a configure event telling
-	the expected new surface size. The operation is completed
-	on the next buffer attach to this surface.
+        The compositor will reply with a configure event telling
+        the expected new surface size. The operation is completed
+        on the next buffer attach to this surface.
 
-	A maximized surface typically fills the entire output it is
-	bound to, except for desktop elements such as panels. This is
-	the main difference between a maximized shell surface and a
-	fullscreen shell surface.
+        A maximized surface typically fills the entire output it is
+        bound to, except for desktop elements such as panels. This is
+        the main difference between a maximized shell surface and a
+        fullscreen shell surface.
 
-	The details depend on the compositor implementation.
+        The details depend on the compositor implementation.
       </description>
       <arg name="output" type="object" interface="wl_output" allow-null="true"
-	   summary="output on which the surface is to be maximized"/>
+           summary="output on which the surface is to be maximized"/>
     </request>
 
     <request name="set_title">
       <description summary="set surface title">
-	Set a short title for the surface.
+        Set a short title for the surface.
 
-	This string may be used to identify the surface in a task bar,
-	window list, or other user interface elements provided by the
-	compositor.
+        This string may be used to identify the surface in a task bar,
+        window list, or other user interface elements provided by the
+        compositor.
 
-	The string must be encoded in UTF-8.
+        The string must be encoded in UTF-8.
       </description>
       <arg name="title" type="string" summary="surface title"/>
     </request>
 
     <request name="set_class">
       <description summary="set surface class">
-	Set a class for the surface.
+        Set a class for the surface.
 
-	The surface class identifies the general class of applications
-	to which the surface belongs. A common convention is to use the
-	file name (or the full path if it is a non-standard location) of
-	the application's .desktop file as the class.
+        The surface class identifies the general class of applications
+        to which the surface belongs. A common convention is to use the
+        file name (or the full path if it is a non-standard location) of
+        the application's .desktop file as the class.
       </description>
       <arg name="class_" type="string" summary="surface class"/>
     </request>
 
     <event name="ping">
       <description summary="ping client">
-	Ping a client to check if it is receiving events and sending
-	requests. A client is expected to reply with a pong request.
+        Ping a client to check if it is receiving events and sending
+        requests. A client is expected to reply with a pong request.
       </description>
       <arg name="serial" type="uint" summary="serial number of the ping"/>
     </event>
 
     <event name="configure">
       <description summary="suggest resize">
-	The configure event asks the client to resize its surface.
+        The configure event asks the client to resize its surface.
 
-	The size is a hint, in the sense that the client is free to
-	ignore it if it doesn't resize, pick a smaller size (to
-	satisfy aspect ratio or resize in steps of NxM pixels).
+        The size is a hint, in the sense that the client is free to
+        ignore it if it doesn't resize, pick a smaller size (to
+        satisfy aspect ratio or resize in steps of NxM pixels).
 
-	The edges parameter provides a hint about how the surface
-	was resized. The client may use this information to decide
-	how to adjust its content to the new size (e.g. a scrolling
-	area might adjust its content position to leave the viewable
-	content unmoved).
+        The edges parameter provides a hint about how the surface
+        was resized. The client may use this information to decide
+        how to adjust its content to the new size (e.g. a scrolling
+        area might adjust its content position to leave the viewable
+        content unmoved).
 
-	The client is free to dismiss all but the last configure
-	event it received.
+        The client is free to dismiss all but the last configure
+        event it received.
 
-	The width and height arguments specify the size of the window
-	in surface-local coordinates.
+        The width and height arguments specify the size of the window
+        in surface-local coordinates.
       </description>
       <arg name="edges" type="uint" enum="resize" summary="how the surface was resized"/>
       <arg name="width" type="int" summary="new width of the surface"/>
@@ -1388,14 +1447,14 @@
 
     <event name="popup_done">
       <description summary="popup interaction is done">
-	The popup_done event is sent out when a popup grab is broken,
-	that is, when the user clicks a surface that doesn't belong
-	to the client owning the popup surface.
+        The popup_done event is sent out when a popup grab is broken,
+        that is, when the user clicks a surface that doesn't belong
+        to the client owning the popup surface.
       </description>
     </event>
   </interface>
 
-  <interface name="wl_surface" version="6">
+  <interface name="wl_surface" version="7">
     <description summary="an onscreen surface">
       A surface is a rectangular area that may be displayed on zero
       or more outputs, and shown any number of times at the compositor's
@@ -1443,119 +1502,122 @@
 
     <enum name="error">
       <description summary="wl_surface error values">
-	These errors can be emitted in response to wl_surface requests.
+        These errors can be emitted in response to wl_surface requests.
       </description>
       <entry name="invalid_scale" value="0" summary="buffer scale value is invalid"/>
       <entry name="invalid_transform" value="1" summary="buffer transform value is invalid"/>
       <entry name="invalid_size" value="2" summary="buffer size is invalid"/>
       <entry name="invalid_offset" value="3" summary="buffer offset is invalid"/>
       <entry name="defunct_role_object" value="4"
-	     summary="surface was destroyed before its role object"/>
+             summary="surface was destroyed before its role object"/>
+      <entry name="no_buffer" value="5" summary="no buffer was attached"/>
     </enum>
 
     <request name="destroy" type="destructor">
       <description summary="delete surface">
-	Deletes the surface and invalidates its object ID.
+        Deletes the surface and invalidates its object ID.
       </description>
     </request>
 
     <request name="attach">
       <description summary="set the surface contents">
-	Set a buffer as the content of this surface.
+        Set a buffer as the content of this surface.
 
-	The new size of the surface is calculated based on the buffer
-	size transformed by the inverse buffer_transform and the
-	inverse buffer_scale. This means that at commit time the supplied
-	buffer size must be an integer multiple of the buffer_scale. If
-	that's not the case, an invalid_size error is sent.
+        The new size of the surface is calculated based on the buffer
+        size transformed by the inverse buffer_transform and the
+        inverse buffer_scale. This means that at commit time the supplied
+        buffer size must be an integer multiple of the buffer_scale. If
+        that's not the case, an invalid_size error is sent.
 
-	The x and y arguments specify the location of the new pending
-	buffer's upper left corner, relative to the current buffer's upper
-	left corner, in surface-local coordinates. In other words, the
-	x and y, combined with the new surface size define in which
-	directions the surface's size changes. Setting anything other than 0
-	as x and y arguments is discouraged, and should instead be replaced
-	with using the separate wl_surface.offset request.
+        The x and y arguments specify the location of the new pending
+        buffer's upper left corner, relative to the current buffer's upper
+        left corner, in surface-local coordinates. In other words, the
+        x and y, combined with the new surface size define in which
+        directions the surface's size changes. Setting anything other than 0
+        as x and y arguments is discouraged, and should instead be replaced
+        with using the separate wl_surface.offset request.
 
-	When the bound wl_surface version is 5 or higher, passing any
-	non-zero x or y is a protocol violation, and will result in an
-	'invalid_offset' error being raised. The x and y arguments are ignored
-	and do not change the pending state. To achieve equivalent semantics,
-	use wl_surface.offset.
+        When the bound wl_surface version is 5 or higher, passing any
+        non-zero x or y is a protocol violation, and will result in an
+        'invalid_offset' error being raised. The x and y arguments are ignored
+        and do not change the pending state. To achieve equivalent semantics,
+        use wl_surface.offset.
 
-	Surface contents are double-buffered state, see wl_surface.commit.
+        Surface contents are double-buffered state, see wl_surface.commit.
 
-	The initial surface contents are void; there is no content.
-	wl_surface.attach assigns the given wl_buffer as the pending
-	wl_buffer. wl_surface.commit makes the pending wl_buffer the new
-	surface contents, and the size of the surface becomes the size
-	calculated from the wl_buffer, as described above. After commit,
-	there is no pending buffer until the next attach.
+        The initial surface contents are void; there is no content.
+        wl_surface.attach assigns the given wl_buffer as the pending
+        wl_buffer. wl_surface.commit makes the pending wl_buffer the new
+        surface contents, and the size of the surface becomes the size
+        calculated from the wl_buffer, as described above. After commit,
+        there is no pending buffer until the next attach.
 
-	Committing a pending wl_buffer allows the compositor to read the
-	pixels in the wl_buffer. The compositor may access the pixels at
-	any time after the wl_surface.commit request. When the compositor
-	will not access the pixels anymore, it will send the
-	wl_buffer.release event. Only after receiving wl_buffer.release,
-	the client may reuse the wl_buffer. A wl_buffer that has been
-	attached and then replaced by another attach instead of committed
-	will not receive a release event, and is not used by the
-	compositor.
+        Committing a pending wl_buffer allows the compositor to read the
+        pixels in the wl_buffer. The compositor may access the pixels at
+        any time after the wl_surface.commit request. When the compositor
+        will not access the pixels anymore, it will send the
+        wl_buffer.release event. Only after receiving wl_buffer.release,
+        the client may reuse the wl_buffer. A wl_buffer that has been
+        attached and then replaced by another attach instead of committed
+        will not receive a release event, and is not used by the
+        compositor.
 
-	If a pending wl_buffer has been committed to more than one wl_surface,
-	the delivery of wl_buffer.release events becomes undefined. A well
-	behaved client should not rely on wl_buffer.release events in this
-	case. Alternatively, a client could create multiple wl_buffer objects
-	from the same backing storage or use a protocol extension providing
-	per-commit release notifications.
+        If a pending wl_buffer has been committed to more than one wl_surface,
+        the delivery of wl_buffer.release events becomes undefined. A well
+        behaved client should not rely on wl_buffer.release events in this
+        case. Instead, clients hitting this case should use
+        wl_surface.get_release or use a protocol extension providing per-commit
+        release notifications (if none of these options are available, a
+        fallback can be implemented by creating multiple wl_buffer objects from
+        the same backing storage).
 
-	Destroying the wl_buffer after wl_buffer.release does not change
-	the surface contents. Destroying the wl_buffer before wl_buffer.release
-	is allowed as long as the underlying buffer storage isn't re-used (this
-	can happen e.g. on client process termination). However, if the client
-	destroys the wl_buffer before receiving the wl_buffer.release event and
-	mutates the underlying buffer storage, the surface contents become
-	undefined immediately.
+        Destroying the wl_buffer after wl_buffer.release does not change
+        the surface contents. Destroying the wl_buffer before wl_buffer.release
+        is allowed as long as the underlying buffer storage isn't re-used (this
+        can happen e.g. on client process termination). However, if the client
+        destroys the wl_buffer before receiving the wl_buffer.release event and
+        mutates the underlying buffer storage, the surface contents become
+        undefined immediately.
 
-	If wl_surface.attach is sent with a NULL wl_buffer, the
-	following wl_surface.commit will remove the surface content.
+        If wl_surface.attach is sent with a NULL wl_buffer, the
+        following wl_surface.commit will remove the surface content.
 
-	If a pending wl_buffer has been destroyed, the result is not specified.
-	Many compositors are known to remove the surface content on the following
-	wl_surface.commit, but this behaviour is not universal. Clients seeking to
-	maximise compatibility should not destroy pending buffers and should
-	ensure that they explicitly remove content from surfaces, even after
-	destroying buffers.
+        If a pending wl_buffer has been destroyed, the result is not specified.
+        Many compositors are known to remove the surface content on the following
+        wl_surface.commit, but this behaviour is not universal. Clients seeking to
+        maximise compatibility should not destroy pending buffers and should
+        ensure that they explicitly remove content from surfaces, even after
+        destroying buffers.
       </description>
       <arg name="buffer" type="object" interface="wl_buffer" allow-null="true"
-	   summary="buffer of surface contents"/>
+           summary="buffer of surface contents"/>
       <arg name="x" type="int" summary="surface-local x coordinate"/>
       <arg name="y" type="int" summary="surface-local y coordinate"/>
     </request>
 
     <request name="damage">
       <description summary="mark part of the surface damaged">
-	This request is used to describe the regions where the pending
-	buffer is different from the current surface contents, and where
-	the surface therefore needs to be repainted. The compositor
-	ignores the parts of the damage that fall outside of the surface.
+        This request is used to describe the regions where the pending
+        buffer is different from the current surface contents, and where
+        the surface therefore needs to be repainted. The compositor
+        ignores the parts of the damage that fall outside of the surface.
 
-	Damage is double-buffered state, see wl_surface.commit.
+        Damage is double-buffered state, see wl_surface.commit.
 
-	The damage rectangle is specified in surface-local coordinates,
-	where x and y specify the upper left corner of the damage rectangle.
+        The damage rectangle is specified in surface-local coordinates,
+        where x and y specify the upper left corner of the damage rectangle.
 
-	The initial value for pending damage is empty: no damage.
-	wl_surface.damage adds pending damage: the new pending damage
-	is the union of old pending damage and the given rectangle.
+        The initial value for pending damage is empty: no damage.
+        wl_surface.damage adds pending damage: the new pending damage
+        is the union of old pending damage and the given rectangle.
 
-	wl_surface.commit assigns pending damage as the current damage,
-	and clears pending damage. The server will clear the current
-	damage as it repaints the surface.
+        wl_surface.commit assigns pending damage as the current damage,
+        and clears pending damage. The server will clear the current
+        damage as it repaints the surface.
 
-	Note! New clients should not use this request. Instead damage can be
-	posted with wl_surface.damage_buffer which uses buffer coordinates
-	instead of surface coordinates.
+        Note! New clients should not use this request. Instead damage can be
+        posted with wl_surface.damage_buffer which uses buffer coordinates
+        instead of surface coordinates.
       </description>
       <arg name="x" type="int" summary="surface-local x coordinate"/>
       <arg name="y" type="int" summary="surface-local y coordinate"/>
@@ -1565,148 +1627,175 @@
 
     <request name="frame">
       <description summary="request a frame throttling hint">
-	Request a notification when it is a good time to start drawing a new
-	frame, by creating a frame callback. This is useful for throttling
-	redrawing operations, and driving animations.
+        Request a notification when it is a good time to start drawing a new
+        frame, by creating a frame callback. This is useful for throttling
+        redrawing operations, and driving animations.
 
-	When a client is animating on a wl_surface, it can use the 'frame'
-	request to get notified when it is a good time to draw and commit the
-	next frame of animation. If the client commits an update earlier than
-	that, it is likely that some updates will not make it to the display,
-	and the client is wasting resources by drawing too often.
+        When a client is animating on a wl_surface, it can use the 'frame'
+        request to get notified when it is a good time to draw and commit the
+        next frame of animation. If the client commits an update earlier than
+        that, it is likely that some updates will not make it to the display,
+        and the client is wasting resources by drawing too often.
 
-	The frame request will take effect on the next wl_surface.commit.
-	The notification will only be posted for one frame unless
-	requested again. For a wl_surface, the notifications are posted in
-	the order the frame requests were committed.
+        The frame request will take effect on the next wl_surface.commit.
+        The notification will only be posted for one frame unless
+        requested again. For a wl_surface, the notifications are posted in
+        the order the frame requests were committed.
 
-	The server must send the notifications so that a client
-	will not send excessive updates, while still allowing
-	the highest possible update rate for clients that wait for the reply
-	before drawing again. The server should give some time for the client
-	to draw and commit after sending the frame callback events to let it
-	hit the next output refresh.
+        The server must send the notifications so that a client
+        will not send excessive updates, while still allowing
+        the highest possible update rate for clients that wait for the reply
+        before drawing again. The server should give some time for the client
+        to draw and commit after sending the frame callback events to let it
+        hit the next output refresh.
 
-	A server should avoid signaling the frame callbacks if the
-	surface is not visible in any way, e.g. the surface is off-screen,
-	or completely obscured by other opaque surfaces.
+        A server should avoid signaling the frame callbacks if the
+        surface is not visible in any way, e.g. the surface is off-screen,
+        or completely obscured by other opaque surfaces.
 
-	The object returned by this request will be destroyed by the
-	compositor after the callback is fired and as such the client must not
-	attempt to use it after that point.
+        The object returned by this request will be destroyed by the
+        compositor after the callback is fired and as such the client must not
+        attempt to use it after that point.
 
-	The callback_data passed in the callback is the current time, in
-	milliseconds, with an undefined base.
+        The callback_data passed in the callback is the current time, in
+        milliseconds, with an undefined base.
       </description>
       <arg name="callback" type="new_id" interface="wl_callback" summary="callback object for the frame request"/>
     </request>
 
     <request name="set_opaque_region">
       <description summary="set opaque region">
-	This request sets the region of the surface that contains
-	opaque content.
+        This request sets the region of the surface that contains
+        opaque content.
 
-	The opaque region is an optimization hint for the compositor
-	that lets it optimize the redrawing of content behind opaque
-	regions.  Setting an opaque region is not required for correct
-	behaviour, but marking transparent content as opaque will result
-	in repaint artifacts.
+        The opaque region is an optimization hint for the compositor
+        that lets it optimize the redrawing of content behind opaque
+        regions.  Setting an opaque region is not required for correct
+        behaviour, but marking transparent content as opaque will result
+        in repaint artifacts.
 
-	The opaque region is specified in surface-local coordinates.
+        The opaque region is specified in surface-local coordinates.
 
-	The compositor ignores the parts of the opaque region that fall
-	outside of the surface.
+        The compositor ignores the parts of the opaque region that fall
+        outside of the surface.
 
-	Opaque region is double-buffered state, see wl_surface.commit.
+        Opaque region is double-buffered state, see wl_surface.commit.
 
-	wl_surface.set_opaque_region changes the pending opaque region.
-	wl_surface.commit copies the pending region to the current region.
-	Otherwise, the pending and current regions are never changed.
+        wl_surface.set_opaque_region changes the pending opaque region.
+        wl_surface.commit copies the pending region to the current region.
+        Otherwise, the pending and current regions are never changed.
 
-	The initial value for an opaque region is empty. Setting the pending
-	opaque region has copy semantics, and the wl_region object can be
-	destroyed immediately. A NULL wl_region causes the pending opaque
-	region to be set to empty.
+        The initial value for an opaque region is empty. Setting the pending
+        opaque region has copy semantics, and the wl_region object can be
+        destroyed immediately. A NULL wl_region causes the pending opaque
+        region to be set to empty.
       </description>
       <arg name="region" type="object" interface="wl_region" allow-null="true"
-	   summary="opaque region of the surface"/>
+           summary="opaque region of the surface"/>
     </request>
 
     <request name="set_input_region">
       <description summary="set input region">
-	This request sets the region of the surface that can receive
-	pointer and touch events.
+        This request sets the region of the surface that can receive
+        pointer and touch events.
 
-	Input events happening outside of this region will try the next
-	surface in the server surface stack. The compositor ignores the
-	parts of the input region that fall outside of the surface.
+        Input events happening outside of this region will try the next
+        surface in the server surface stack. The compositor ignores the
+        parts of the input region that fall outside of the surface.
 
-	The input region is specified in surface-local coordinates.
+        The input region is specified in surface-local coordinates.
 
-	Input region is double-buffered state, see wl_surface.commit.
+        Input region is double-buffered state, see wl_surface.commit.
 
-	wl_surface.set_input_region changes the pending input region.
-	wl_surface.commit copies the pending region to the current region.
-	Otherwise the pending and current regions are never changed,
-	except cursor and icon surfaces are special cases, see
-	wl_pointer.set_cursor and wl_data_device.start_drag.
+        wl_surface.set_input_region changes the pending input region.
+        wl_surface.commit copies the pending region to the current region.
+        Otherwise the pending and current regions are never changed,
+        except cursor and icon surfaces are special cases, see
+        wl_pointer.set_cursor and wl_data_device.start_drag.
 
-	The initial value for an input region is infinite. That means the
-	whole surface will accept input. Setting the pending input region
-	has copy semantics, and the wl_region object can be destroyed
-	immediately. A NULL wl_region causes the input region to be set
-	to infinite.
+        The initial value for an input region is infinite. That means the
+        whole surface will accept input. Setting the pending input region
+        has copy semantics, and the wl_region object can be destroyed
+        immediately. A NULL wl_region causes the input region to be set
+        to infinite.
       </description>
       <arg name="region" type="object" interface="wl_region" allow-null="true"
-	   summary="input region of the surface"/>
+           summary="input region of the surface"/>
     </request>
 
     <request name="commit">
       <description summary="commit pending surface state">
-	Surface state (input, opaque, and damage regions, attached buffers,
-	etc.) is double-buffered. Protocol requests modify the pending state,
-	as opposed to the active state in use by the compositor.
+        Surface state (input, opaque, and damage regions, attached buffers,
+        etc.) is double-buffered. Protocol requests modify the pending state,
+        as opposed to the active state in use by the compositor.
 
-	A commit request atomically creates a content update from the pending
-	state, even if the pending state has not been touched. The content
-	update is placed in a queue until it becomes active. After commit, the
-	new pending state is as documented for each related request.
+        All requests that need a commit to become effective are documented
+        to affect double-buffered state.
 
-	When the content update is applied, the wl_buffer is applied before all
-	other state. This means that all coordinates in double-buffered state
-	are relative to the newly attached wl_buffers, except for
-	wl_surface.attach itself. If there is no newly attached wl_buffer, the
-	coordinates are relative to the previous content update.
+        Other interfaces may add further double-buffered surface state.
 
-	All requests that need a commit to become effective are documented
-	to affect double-buffered state.
+        A commit request atomically creates a Content Update (CU) from the
+        pending state, even if the pending state has not been touched. The
+        content update is placed at the end of a per-surface queue until it
+        becomes active. After commit, the new pending state is as documented for
+        each related request.
 
-	Other interfaces may add further double-buffered surface state.
+        A CU is either a Desync Content Update (DCU) or a Sync Content Update
+        (SCU). If the surface is effectively synchronized at the commit request,
+        it is a SCU, otherwise a DCU.
+
+        When a surface transitions from effectively synchronized to effectively
+        desynchronized, all SCUs in its queue which are not reachable by any
+        DCU become DCUs and dependency edges from outside the queue to these CUs
+        are removed.
+
+        See wl_subsurface for the definition of 'effectively synchronized' and
+        'effectively desynchronized'.
+
+        When a CU is placed in the queue, the CU has a dependency on the CU in
+        front of it and to the SCU at end of the queue of every direct child
+        surface if that SCU exists and does not have another dependent. This can
+        form a directed acyclic graph of CUs with dependencies as edges.
+
+        In addition to surface state, the CU can have constraints that must be
+        satisfied before it can be applied. Other interfaces may add CU
+        constraints.
+
+        All DCUs which do not have a SCU in front of themselves in their queue,
+        are candidates. If the graph that's reachable by a candidate does not
+        have any unsatisfied constraints, the entire graph must be applied
+        atomically.
+
+        When a CU is applied, the wl_buffer is applied before all other state.
+        This means that all coordinates in double-buffered state are relative to
+        the newly attached wl_buffers, except for wl_surface.attach itself. If
+        there is no newly attached wl_buffer, the coordinates are relative to
+        the previous content update.
       </description>
     </request>
 
     <event name="enter">
       <description summary="surface enters an output">
-	This is emitted whenever a surface's creation, movement, or resizing
-	results in some part of it being within the scanout region of an
-	output.
+        This is emitted whenever a surface's creation, movement, or resizing
+        results in some part of it being within the scanout region of an
+        output.
 
-	Note that a surface may be overlapping with zero or more outputs.
+        Note that a surface may be overlapping with zero or more outputs.
       </description>
       <arg name="output" type="object" interface="wl_output" summary="output entered by the surface"/>
     </event>
 
     <event name="leave">
       <description summary="surface leaves an output">
-	This is emitted whenever a surface's creation, movement, or resizing
-	results in it no longer having any part of it within the scanout region
-	of an output.
+        This is emitted whenever a surface's creation, movement, or resizing
+        results in it no longer having any part of it within the scanout region
+        of an output.
 
-	Clients should not use the number of outputs the surface is on for frame
-	throttling purposes. The surface might be hidden even if no leave event
-	has been sent, and the compositor might expect new surface content
-	updates even if no enter event has been sent. The frame event should be
-	used instead.
+        Clients should not use the number of outputs the surface is on for frame
+        throttling purposes. The surface might be hidden even if no leave event
+        has been sent, and the compositor might expect new surface content
+        updates even if no enter event has been sent. The frame event should be
+        used instead.
       </description>
       <arg name="output" type="object" interface="wl_output" summary="output left by the surface"/>
     </event>
@@ -1715,109 +1804,109 @@
 
     <request name="set_buffer_transform" since="2">
       <description summary="sets the buffer transformation">
-	This request sets the transformation that the client has already applied
-	to the content of the buffer. The accepted values for the transform
-	parameter are the values for wl_output.transform.
+        This request sets the transformation that the client has already applied
+        to the content of the buffer. The accepted values for the transform
+        parameter are the values for wl_output.transform.
 
-	The compositor applies the inverse of this transformation whenever it
-	uses the buffer contents.
+        The compositor applies the inverse of this transformation whenever it
+        uses the buffer contents.
 
-	Buffer transform is double-buffered state, see wl_surface.commit.
+        Buffer transform is double-buffered state, see wl_surface.commit.
 
-	A newly created surface has its buffer transformation set to normal.
+        A newly created surface has its buffer transformation set to normal.
 
-	wl_surface.set_buffer_transform changes the pending buffer
-	transformation. wl_surface.commit copies the pending buffer
-	transformation to the current one. Otherwise, the pending and current
-	values are never changed.
+        wl_surface.set_buffer_transform changes the pending buffer
+        transformation. wl_surface.commit copies the pending buffer
+        transformation to the current one. Otherwise, the pending and current
+        values are never changed.
 
-	The purpose of this request is to allow clients to render content
-	according to the output transform, thus permitting the compositor to
-	use certain optimizations even if the display is rotated. Using
-	hardware overlays and scanning out a client buffer for fullscreen
-	surfaces are examples of such optimizations. Those optimizations are
-	highly dependent on the compositor implementation, so the use of this
-	request should be considered on a case-by-case basis.
+        The purpose of this request is to allow clients to render content
+        according to the output transform, thus permitting the compositor to
+        use certain optimizations even if the display is rotated. Using
+        hardware overlays and scanning out a client buffer for fullscreen
+        surfaces are examples of such optimizations. Those optimizations are
+        highly dependent on the compositor implementation, so the use of this
+        request should be considered on a case-by-case basis.
 
-	Note that if the transform value includes 90 or 270 degree rotation,
-	the width of the buffer will become the surface height and the height
-	of the buffer will become the surface width.
+        Note that if the transform value includes 90 or 270 degree rotation,
+        the width of the buffer will become the surface height and the height
+        of the buffer will become the surface width.
 
-	If transform is not one of the values from the
-	wl_output.transform enum the invalid_transform protocol error
-	is raised.
+        If transform is not one of the values from the
+        wl_output.transform enum the invalid_transform protocol error
+        is raised.
       </description>
       <arg name="transform" type="int" enum="wl_output.transform"
-	   summary="transform for interpreting buffer contents"/>
+           summary="transform for interpreting buffer contents"/>
     </request>
 
     <!-- Version 3 additions -->
 
     <request name="set_buffer_scale" since="3">
       <description summary="sets the buffer scaling factor">
-	This request sets an optional scaling factor on how the compositor
-	interprets the contents of the buffer attached to the window.
+        This request sets an optional scaling factor on how the compositor
+        interprets the contents of the buffer attached to the window.
 
-	Buffer scale is double-buffered state, see wl_surface.commit.
+        Buffer scale is double-buffered state, see wl_surface.commit.
 
-	A newly created surface has its buffer scale set to 1.
+        A newly created surface has its buffer scale set to 1.
 
-	wl_surface.set_buffer_scale changes the pending buffer scale.
-	wl_surface.commit copies the pending buffer scale to the current one.
-	Otherwise, the pending and current values are never changed.
+        wl_surface.set_buffer_scale changes the pending buffer scale.
+        wl_surface.commit copies the pending buffer scale to the current one.
+        Otherwise, the pending and current values are never changed.
 
-	The purpose of this request is to allow clients to supply higher
-	resolution buffer data for use on high resolution outputs. It is
-	intended that you pick the same buffer scale as the scale of the
-	output that the surface is displayed on. This means the compositor
-	can avoid scaling when rendering the surface on that output.
+        The purpose of this request is to allow clients to supply higher
+        resolution buffer data for use on high resolution outputs. It is
+        intended that you pick the same buffer scale as the scale of the
+        output that the surface is displayed on. This means the compositor
+        can avoid scaling when rendering the surface on that output.
 
-	Note that if the scale is larger than 1, then you have to attach
-	a buffer that is larger (by a factor of scale in each dimension)
-	than the desired surface size.
+        Note that if the scale is larger than 1, then you have to attach
+        a buffer that is larger (by a factor of scale in each dimension)
+        than the desired surface size.
 
-	If scale is not greater than 0 the invalid_scale protocol error is
-	raised.
+        If scale is not greater than 0 the invalid_scale protocol error is
+        raised.
       </description>
       <arg name="scale" type="int"
-	   summary="scale for interpreting buffer contents"/>
+           summary="scale for interpreting buffer contents"/>
     </request>
 
     <!-- Version 4 additions -->
     <request name="damage_buffer" since="4">
       <description summary="mark part of the surface damaged using buffer coordinates">
-	This request is used to describe the regions where the pending
-	buffer is different from the current surface contents, and where
-	the surface therefore needs to be repainted. The compositor
-	ignores the parts of the damage that fall outside of the surface.
+        This request is used to describe the regions where the pending
+        buffer is different from the current surface contents, and where
+        the surface therefore needs to be repainted. The compositor
+        ignores the parts of the damage that fall outside of the surface.
 
-	Damage is double-buffered state, see wl_surface.commit.
+        Damage is double-buffered state, see wl_surface.commit.
 
-	The damage rectangle is specified in buffer coordinates,
-	where x and y specify the upper left corner of the damage rectangle.
+        The damage rectangle is specified in buffer coordinates,
+        where x and y specify the upper left corner of the damage rectangle.
 
-	The initial value for pending damage is empty: no damage.
-	wl_surface.damage_buffer adds pending damage: the new pending
-	damage is the union of old pending damage and the given rectangle.
+        The initial value for pending damage is empty: no damage.
+        wl_surface.damage_buffer adds pending damage: the new pending
+        damage is the union of old pending damage and the given rectangle.
 
-	wl_surface.commit assigns pending damage as the current damage,
-	and clears pending damage. The server will clear the current
-	damage as it repaints the surface.
+        wl_surface.commit assigns pending damage as the current damage,
+        and clears pending damage. The server will clear the current
+        damage as it repaints the surface.
 
-	This request differs from wl_surface.damage in only one way - it
-	takes damage in buffer coordinates instead of surface-local
-	coordinates. While this generally is more intuitive than surface
-	coordinates, it is especially desirable when using wp_viewport
-	or when a drawing library (like EGL) is unaware of buffer scale
-	and buffer transform.
+        This request differs from wl_surface.damage in only one way - it
+        takes damage in buffer coordinates instead of surface-local
+        coordinates. While this generally is more intuitive than surface
+        coordinates, it is especially desirable when using wp_viewport
+        or when a drawing library (like EGL) is unaware of buffer scale
+        and buffer transform.
 
-	Note: Because buffer transformation changes and damage requests may
-	be interleaved in the protocol stream, it is impossible to determine
-	the actual mapping between surface and buffer damage until
-	wl_surface.commit time. Therefore, compositors wishing to take both
-	kinds of damage into account will have to accumulate damage from the
-	two requests separately and only transform from one to the other
-	after receiving the wl_surface.commit.
+        Note: Because buffer transformation changes and damage requests may
+        be interleaved in the protocol stream, it is impossible to determine
+        the actual mapping between surface and buffer damage until
+        wl_surface.commit time. Therefore, compositors wishing to take both
+        kinds of damage into account will have to accumulate damage from the
+        two requests separately and only transform from one to the other
+        after receiving the wl_surface.commit.
       </description>
       <arg name="x" type="int" summary="buffer-local x coordinate"/>
       <arg name="y" type="int" summary="buffer-local y coordinate"/>
@@ -1829,21 +1918,21 @@
 
     <request name="offset" since="5">
       <description summary="set the surface contents offset">
-	The x and y arguments specify the location of the new pending
-	buffer's upper left corner, relative to the current buffer's upper
-	left corner, in surface-local coordinates. In other words, the
-	x and y, combined with the new surface size define in which
-	directions the surface's size changes.
+        The x and y arguments specify the location of the new pending
+        buffer's upper left corner, relative to the current buffer's upper
+        left corner, in surface-local coordinates. In other words, the
+        x and y, combined with the new surface size define in which
+        directions the surface's size changes.
 
-	The exact semantics of wl_surface.offset are role-specific. Refer to
-	the documentation of specific roles for more information.
+        The exact semantics of wl_surface.offset are role-specific. Refer to
+        the documentation of specific roles for more information.
 
-	Surface location offset is double-buffered state, see
-	wl_surface.commit.
+        Surface location offset is double-buffered state, see
+        wl_surface.commit.
 
-	This request is semantically equivalent to and the replaces the x and y
-	arguments in the wl_surface.attach request in wl_surface versions prior
-	to 5. See wl_surface.attach for details.
+        This request is semantically equivalent to and the replaces the x and y
+        arguments in the wl_surface.attach request in wl_surface versions prior
+        to 5. See wl_surface.attach for details.
       </description>
       <arg name="x" type="int" summary="surface-local x coordinate"/>
       <arg name="y" type="int" summary="surface-local y coordinate"/>
@@ -1853,40 +1942,66 @@
 
     <event name="preferred_buffer_scale" since="6">
       <description summary="preferred buffer scale for the surface">
-	This event indicates the preferred buffer scale for this surface. It is
-	sent whenever the compositor's preference changes.
+        This event indicates the preferred buffer scale for this surface. It is
+        sent whenever the compositor's preference changes.
 
-	Before receiving this event the preferred buffer scale for this surface
-	is 1.
+        Before receiving this event the preferred buffer scale for this surface
+        is 1.
 
-	It is intended that scaling aware clients use this event to scale their
-	content and use wl_surface.set_buffer_scale to indicate the scale they
-	have rendered with. This allows clients to supply a higher detail
-	buffer.
+        It is intended that scaling aware clients use this event to scale their
+        content and use wl_surface.set_buffer_scale to indicate the scale they
+        have rendered with. This allows clients to supply a higher detail
+        buffer.
 
-	The compositor shall emit a scale value greater than 0.
+        The compositor shall emit a scale value greater than 0.
       </description>
       <arg name="factor" type="int" summary="preferred scaling factor"/>
     </event>
 
     <event name="preferred_buffer_transform" since="6">
       <description summary="preferred buffer transform for the surface">
-	This event indicates the preferred buffer transform for this surface.
-	It is sent whenever the compositor's preference changes.
+        This event indicates the preferred buffer transform for this surface.
+        It is sent whenever the compositor's preference changes.
 
-	Before receiving this event the preferred buffer transform for this
-	surface is normal.
+        Before receiving this event the preferred buffer transform for this
+        surface is normal.
 
-	Applying this transformation to the surface buffer contents and using
-	wl_surface.set_buffer_transform might allow the compositor to use the
-	surface buffer more efficiently.
+        Applying this transformation to the surface buffer contents and using
+        wl_surface.set_buffer_transform might allow the compositor to use the
+        surface buffer more efficiently.
       </description>
       <arg name="transform" type="uint" enum="wl_output.transform"
-	   summary="preferred transform"/>
+           summary="preferred transform"/>
     </event>
+
+    <!-- Version 7 additions -->
+
+    <request name="get_release" since="7">
+      <description summary="get a release callback">
+        Create a callback for the release of the buffer attached by the client
+        with wl_surface.attach.
+
+        The compositor will release the buffer when it has finished its usage of
+        the underlying storage for the relevant commit. Once the client receives
+        this event, and assuming the associated buffer is not pending release
+        from other wl_surface.commit requests, the client can safely re-use the
+        buffer.
+
+        Release callbacks are double-buffered state, and will be associated
+        with the pending buffer at wl_surface.commit time.
+
+        The callback_data passed in the wl_callback.done event is unused and
+        is always zero.
+
+        Sending this request without attaching a non-null buffer in the same
+        content update is a protocol error. The compositor will send the
+        no_buffer error in this case.
+      </description>
+      <arg name="callback" type="new_id" interface="wl_callback" summary="callback object for the release"/>
+    </request>
    </interface>
 
-  <interface name="wl_seat" version="10">
+  <interface name="wl_seat" version="11">
     <description summary="group of input devices">
       A seat is a group of keyboards, pointer and touch devices. This
       object is published as a global during start up, or when such a
@@ -1896,8 +2011,8 @@
 
     <enum name="capability" bitfield="true">
       <description summary="seat capability bitmask">
-	This is a bitmask of capabilities this seat has; if a member is
-	set, then it is present on the seat.
+        This is a bitmask of capabilities this seat has; if a member is
+        set, then it is present on the seat.
       </description>
       <entry name="pointer" value="1" summary="the seat has pointer devices"/>
       <entry name="keyboard" value="2" summary="the seat has one or more keyboards"/>
@@ -1906,81 +2021,81 @@
 
     <enum name="error">
       <description summary="wl_seat error values">
-	These errors can be emitted in response to wl_seat requests.
+        These errors can be emitted in response to wl_seat requests.
       </description>
       <entry name="missing_capability" value="0"
-	     summary="get_pointer, get_keyboard or get_touch called on seat without the matching capability"/>
+             summary="get_pointer, get_keyboard or get_touch called on seat without the matching capability"/>
     </enum>
 
     <event name="capabilities">
       <description summary="seat capabilities changed">
-	This is sent on binding to the seat global or whenever a seat gains
-	or loses the pointer, keyboard or touch capabilities.
-	The argument is a capability enum containing the complete set of
-	capabilities this seat has.
+        This is sent on binding to the seat global or whenever a seat gains
+        or loses the pointer, keyboard or touch capabilities.
+        The argument is a capability enum containing the complete set of
+        capabilities this seat has.
 
-	When the pointer capability is added, a client may create a
-	wl_pointer object using the wl_seat.get_pointer request. This object
-	will receive pointer events until the capability is removed in the
-	future.
+        When the pointer capability is added, a client may create a
+        wl_pointer object using the wl_seat.get_pointer request. This object
+        will receive pointer events until the capability is removed in the
+        future.
 
-	When the pointer capability is removed, a client should destroy the
-	wl_pointer objects associated with the seat where the capability was
-	removed, using the wl_pointer.release request. No further pointer
-	events will be received on these objects.
+        When the pointer capability is removed, a client should destroy the
+        wl_pointer objects associated with the seat where the capability was
+        removed, using the wl_pointer.release request. No further pointer
+        events will be received on these objects.
 
-	In some compositors, if a seat regains the pointer capability and a
-	client has a previously obtained wl_pointer object of version 4 or
-	less, that object may start sending pointer events again. This
-	behavior is considered a misinterpretation of the intended behavior
-	and must not be relied upon by the client. wl_pointer objects of
-	version 5 or later must not send events if created before the most
-	recent event notifying the client of an added pointer capability.
+        In some compositors, if a seat regains the pointer capability and a
+        client has a previously obtained wl_pointer object of version 4 or
+        less, that object may start sending pointer events again. This
+        behavior is considered a misinterpretation of the intended behavior
+        and must not be relied upon by the client. wl_pointer objects of
+        version 5 or later must not send events if created before the most
+        recent event notifying the client of an added pointer capability.
 
-	The above behavior also applies to wl_keyboard and wl_touch with the
-	keyboard and touch capabilities, respectively.
+        The above behavior also applies to wl_keyboard and wl_touch with the
+        keyboard and touch capabilities, respectively.
       </description>
       <arg name="capabilities" type="uint" enum="capability" summary="capabilities of the seat"/>
     </event>
 
     <request name="get_pointer">
       <description summary="return pointer object">
-	The ID provided will be initialized to the wl_pointer interface
-	for this seat.
+        The ID provided will be initialized to the wl_pointer interface
+        for this seat.
 
-	This request only takes effect if the seat has the pointer
-	capability, or has had the pointer capability in the past.
-	It is a protocol violation to issue this request on a seat that has
-	never had the pointer capability. The missing_capability error will
-	be sent in this case.
+        This request only takes effect if the seat has the pointer
+        capability, or has had the pointer capability in the past.
+        It is a protocol violation to issue this request on a seat that has
+        never had the pointer capability. The missing_capability error will
+        be sent in this case.
       </description>
       <arg name="id" type="new_id" interface="wl_pointer" summary="seat pointer"/>
     </request>
 
     <request name="get_keyboard">
       <description summary="return keyboard object">
-	The ID provided will be initialized to the wl_keyboard interface
-	for this seat.
+        The ID provided will be initialized to the wl_keyboard interface
+        for this seat.
 
-	This request only takes effect if the seat has the keyboard
-	capability, or has had the keyboard capability in the past.
-	It is a protocol violation to issue this request on a seat that has
-	never had the keyboard capability. The missing_capability error will
-	be sent in this case.
+        This request only takes effect if the seat has the keyboard
+        capability, or has had the keyboard capability in the past.
+        It is a protocol violation to issue this request on a seat that has
+        never had the keyboard capability. The missing_capability error will
+        be sent in this case.
       </description>
       <arg name="id" type="new_id" interface="wl_keyboard" summary="seat keyboard"/>
     </request>
 
     <request name="get_touch">
       <description summary="return touch object">
-	The ID provided will be initialized to the wl_touch interface
-	for this seat.
+        The ID provided will be initialized to the wl_touch interface
+        for this seat.
 
-	This request only takes effect if the seat has the touch
-	capability, or has had the touch capability in the past.
-	It is a protocol violation to issue this request on a seat that has
-	never had the touch capability. The missing_capability error will
-	be sent in this case.
+        This request only takes effect if the seat has the touch
+        capability, or has had the touch capability in the past.
+        It is a protocol violation to issue this request on a seat that has
+        never had the touch capability. The missing_capability error will
+        be sent in this case.
       </description>
       <arg name="id" type="new_id" interface="wl_touch" summary="seat touch interface"/>
     </request>
@@ -1989,22 +2104,22 @@
 
     <event name="name" since="2">
       <description summary="unique identifier for this seat">
-	In a multi-seat configuration the seat name can be used by clients to
-	help identify which physical devices the seat represents.
+        In a multi-seat configuration the seat name can be used by clients to
+        help identify which physical devices the seat represents.
 
-	The seat name is a UTF-8 string with no convention defined for its
-	contents. Each name is unique among all wl_seat globals. The name is
-	only guaranteed to be unique for the current compositor instance.
+        The seat name is a UTF-8 string with no convention defined for its
+        contents. Each name is unique among all wl_seat globals. The name is
+        only guaranteed to be unique for the current compositor instance.
 
-	The same seat names are used for all clients. Thus, the name can be
-	shared across processes to refer to a specific wl_seat global.
+        The same seat names are used for all clients. Thus, the name can be
+        shared across processes to refer to a specific wl_seat global.
 
-	The name event is sent after binding to the seat global, and should be sent
-	before announcing capabilities. This event only sent once per seat object,
-	and the name does not change over the lifetime of the wl_seat global.
+        The name event is sent after binding to the seat global, and should be sent
+        before announcing capabilities. This event is only sent once per seat object,
+        and the name does not change over the lifetime of the wl_seat global.
 
-	Compositors may re-use the same seat name if the wl_seat global is
-	destroyed and re-created later.
+        Compositors may re-use the same seat name if the wl_seat global is
+        destroyed and re-created later.
       </description>
       <arg name="name" type="string" summary="seat identifier"/>
     </event>
@@ -2013,14 +2128,14 @@
 
     <request name="release" type="destructor" since="5">
       <description summary="release the seat object">
-	Using this request a client can tell the server that it is not going to
-	use the seat object anymore.
+        Using this request a client can tell the server that it is not going to
+        use the seat object anymore.
       </description>
     </request>
 
   </interface>
 
-  <interface name="wl_pointer" version="10">
+  <interface name="wl_pointer" version="11">
     <description summary="pointer input device">
       The wl_pointer interface represents one or more input devices,
       such as mice, which control the pointer location and pointer_focus
@@ -2038,55 +2153,55 @@
 
     <request name="set_cursor">
       <description summary="set the pointer surface">
-	Set the pointer surface, i.e., the surface that contains the
-	pointer image (cursor). This request gives the surface the role
-	of a cursor. If the surface already has another role, it raises
-	a protocol error.
+        Set the pointer surface, i.e., the surface that contains the
+        pointer image (cursor). This request gives the surface the role
+        of a cursor. If the surface already has another role, it raises
+        a protocol error.
 
-	The cursor actually changes only if the pointer
-	focus for this device is one of the requesting client's surfaces
-	or the surface parameter is the current pointer surface. If
-	there was a previous surface set with this request it is
-	replaced. If surface is NULL, the pointer image is hidden.
+        The cursor actually changes only if the pointer
+        focus for this device is one of the requesting client's surfaces
+        or the surface parameter is the current pointer surface. If
+        there was a previous surface set with this request it is
+        replaced. If surface is NULL, the pointer image is hidden.
 
-	The parameters hotspot_x and hotspot_y define the position of
-	the pointer surface relative to the pointer location. Its
-	top-left corner is always at (x, y) - (hotspot_x, hotspot_y),
-	where (x, y) are the coordinates of the pointer location, in
-	surface-local coordinates.
+        The parameters hotspot_x and hotspot_y define the position of
+        the pointer surface relative to the pointer location. Its
+        top-left corner is always at (x, y) - (hotspot_x, hotspot_y),
+        where (x, y) are the coordinates of the pointer location, in
+        surface-local coordinates.
 
-	On wl_surface.offset requests to the pointer surface, hotspot_x
-	and hotspot_y are decremented by the x and y parameters
-	passed to the request. The offset must be applied by
-	wl_surface.commit as usual.
+        On wl_surface.offset requests to the pointer surface, hotspot_x
+        and hotspot_y are decremented by the x and y parameters
+        passed to the request. The offset must be applied by
+        wl_surface.commit as usual.
 
-	The hotspot can also be updated by passing the currently set
-	pointer surface to this request with new values for hotspot_x
-	and hotspot_y.
+        The hotspot can also be updated by passing the currently set
+        pointer surface to this request with new values for hotspot_x
+        and hotspot_y.
 
-	The input region is ignored for wl_surfaces with the role of
-	a cursor. When the use as a cursor ends, the wl_surface is
-	unmapped.
+        The input region is ignored for wl_surfaces with the role of
+        a cursor. When the use as a cursor ends, the wl_surface is
+        unmapped.
 
-	The serial parameter must match the latest wl_pointer.enter
-	serial number sent to the client. Otherwise the request will be
-	ignored.
+        The serial parameter must match the latest wl_pointer.enter
+        serial number sent to the client. Otherwise the request will be
+        ignored.
       </description>
       <arg name="serial" type="uint" summary="serial number of the enter event"/>
       <arg name="surface" type="object" interface="wl_surface" allow-null="true"
-	   summary="pointer surface"/>
+           summary="pointer surface"/>
       <arg name="hotspot_x" type="int" summary="surface-local x coordinate"/>
       <arg name="hotspot_y" type="int" summary="surface-local y coordinate"/>
     </request>
 
     <event name="enter">
       <description summary="enter event">
-	Notification that this seat's pointer is focused on a certain
-	surface.
+        Notification that this seat's pointer is focused on a certain
+        surface.
 
-	When a seat's focus enters a surface, the pointer image
-	is undefined and a client should respond to this event by setting
-	an appropriate pointer image with the set_cursor request.
+        When a seat's focus enters a surface, the pointer image
+        is undefined and a client should respond to this event by setting
+        an appropriate pointer image with the set_cursor request.
       </description>
       <arg name="serial" type="uint" summary="serial number of the enter event"/>
       <arg name="surface" type="object" interface="wl_surface" summary="surface entered by the pointer"/>
@@ -2096,11 +2211,11 @@
 
     <event name="leave">
       <description summary="leave event">
-	Notification that this seat's pointer is no longer focused on
-	a certain surface.
+        Notification that this seat's pointer is no longer focused on
+        a certain surface.
 
-	The leave notification is sent before the enter notification
-	for the new focus.
+        The leave notification is sent before the enter notification
+        for the new focus.
       </description>
       <arg name="serial" type="uint" summary="serial number of the leave event"/>
       <arg name="surface" type="object" interface="wl_surface" summary="surface left by the pointer"/>
@@ -2108,9 +2223,9 @@
 
     <event name="motion">
       <description summary="pointer motion event">
-	Notification of pointer location change. The arguments
-	surface_x and surface_y are the location relative to the
-	focused surface.
+        Notification of pointer location change. The arguments
+        surface_x and surface_y are the location relative to the
+        focused surface.
       </description>
       <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
       <arg name="surface_x" type="fixed" summary="surface-local x coordinate"/>
@@ -2119,8 +2234,8 @@
 
     <enum name="button_state">
       <description summary="physical button state">
-	Describes the physical state of a button that produced the button
-	event.
+        Describes the physical state of a button that produced the button
+        event.
       </description>
       <entry name="released" value="0" summary="the button is not pressed"/>
       <entry name="pressed" value="1" summary="the button is pressed"/>
@@ -2128,20 +2243,20 @@
 
     <event name="button">
       <description summary="pointer button event">
-	Mouse button click and release notifications.
+        Mouse button click and release notifications.
 
-	The location of the click is given by the last motion or
-	enter event.
-	The time argument is a timestamp with millisecond
-	granularity, with an undefined base.
+        The location of the click is given by the last motion, warp or
+        enter event.
+        The time argument is a timestamp with millisecond
+        granularity, with an undefined base.
 
-	The button is a button code as defined in the Linux kernel's
-	linux/input-event-codes.h header file, e.g. BTN_LEFT.
+        The button is a button code as defined in the Linux kernel's
+        linux/input-event-codes.h header file, e.g. BTN_LEFT.
 
-	Any 16-bit button code value is reserved for future additions to the
-	kernel's event code list. All other button codes above 0xFFFF are
-	currently undefined but may be used in future versions of this
-	protocol.
+        Any 16-bit button code value is reserved for future additions to the
+        kernel's event code list. All other button codes above 0xFFFF are
+        currently undefined but may be used in future versions of this
+        protocol.
       </description>
       <arg name="serial" type="uint" summary="serial number of the button event"/>
       <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
@@ -2151,7 +2266,7 @@
 
     <enum name="axis">
       <description summary="axis types">
-	Describes the axis types of scroll events.
+        Describes the axis types of scroll events.
       </description>
       <entry name="vertical_scroll" value="0" summary="vertical axis"/>
       <entry name="horizontal_scroll" value="1" summary="horizontal axis"/>
@@ -2159,22 +2274,22 @@
 
     <event name="axis">
       <description summary="axis event">
-	Scroll and other axis notifications.
+        Scroll and other axis notifications.
 
-	For scroll events (vertical and horizontal scroll axes), the
-	value parameter is the length of a vector along the specified
-	axis in a coordinate space identical to those of motion events,
-	representing a relative movement along the specified axis.
+        For scroll events (vertical and horizontal scroll axes), the
+        value parameter is the length of a vector along the specified
+        axis in a coordinate space identical to those of motion events,
+        representing a relative movement along the specified axis.
 
-	For devices that support movements non-parallel to axes multiple
-	axis events will be emitted.
+        For devices that support movements non-parallel to axes multiple
+        axis events will be emitted.
 
-	When applicable, for example for touch pads, the server can
-	choose to emit scroll events where the motion vector is
-	equivalent to a motion event vector.
+        When applicable, for example for touch pads, the server can
+        choose to emit scroll events where the motion vector is
+        equivalent to a motion event vector.
 
-	When applicable, a client can transform its content relative to the
-	scroll distance.
+        When applicable, a client can transform its content relative to the
+        scroll distance.
       </description>
       <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
       <arg name="axis" type="uint" enum="axis" summary="axis type"/>
@@ -2185,11 +2300,11 @@
 
     <request name="release" type="destructor" since="3">
       <description summary="release the pointer object">
-	Using this request a client can tell the server that it is not going to
-	use the pointer object anymore.
+        Using this request a client can tell the server that it is not going to
+        use the pointer object anymore.
 
-	This request destroys the pointer proxy object, so clients must not call
-	wl_pointer_destroy() after using this request.
+        This request destroys the pointer proxy object, so clients must not call
+        wl_pointer_destroy() after using this request.
       </description>
     </request>
 
@@ -2197,61 +2312,61 @@
 
     <event name="frame" since="5">
       <description summary="end of a pointer event sequence">
-	Indicates the end of a set of events that logically belong together.
-	A client is expected to accumulate the data in all events within the
-	frame before proceeding.
+        Indicates the end of a set of events that logically belong together.
+        A client is expected to accumulate the data in all events within the
+        frame before proceeding.
 
-	All wl_pointer events before a wl_pointer.frame event belong
-	logically together. For example, in a diagonal scroll motion the
-	compositor will send an optional wl_pointer.axis_source event, two
-	wl_pointer.axis events (horizontal and vertical) and finally a
-	wl_pointer.frame event. The client may use this information to
-	calculate a diagonal vector for scrolling.
+        All wl_pointer events before a wl_pointer.frame event belong
+        logically together. For example, in a diagonal scroll motion the
+        compositor will send an optional wl_pointer.axis_source event, two
+        wl_pointer.axis events (horizontal and vertical) and finally a
+        wl_pointer.frame event. The client may use this information to
+        calculate a diagonal vector for scrolling.
 
-	When multiple wl_pointer.axis events occur within the same frame,
-	the motion vector is the combined motion of all events.
-	When a wl_pointer.axis and a wl_pointer.axis_stop event occur within
-	the same frame, this indicates that axis movement in one axis has
-	stopped but continues in the other axis.
-	When multiple wl_pointer.axis_stop events occur within the same
-	frame, this indicates that these axes stopped in the same instance.
+        When multiple wl_pointer.axis events occur within the same frame,
+        the motion vector is the combined motion of all events.
+        When a wl_pointer.axis and a wl_pointer.axis_stop event occur within
+        the same frame, this indicates that axis movement in one axis has
+        stopped but continues in the other axis.
+        When multiple wl_pointer.axis_stop events occur within the same
+        frame, this indicates that these axes stopped in the same instance.
 
-	A wl_pointer.frame event is sent for every logical event group,
-	even if the group only contains a single wl_pointer event.
-	Specifically, a client may get a sequence: motion, frame, button,
-	frame, axis, frame, axis_stop, frame.
+        A wl_pointer.frame event is sent for every logical event group,
+        even if the group only contains a single wl_pointer event.
+        Specifically, a client may get a sequence: motion, frame, button,
+        frame, axis, frame, axis_stop, frame.
 
-	The wl_pointer.enter and wl_pointer.leave events are logical events
-	generated by the compositor and not the hardware. These events are
-	also grouped by a wl_pointer.frame. When a pointer moves from one
-	surface to another, a compositor should group the
-	wl_pointer.leave event within the same wl_pointer.frame.
-	However, a client must not rely on wl_pointer.leave and
-	wl_pointer.enter being in the same wl_pointer.frame.
-	Compositor-specific policies may require the wl_pointer.leave and
-	wl_pointer.enter event being split across multiple wl_pointer.frame
-	groups.
+        The wl_pointer.enter and wl_pointer.leave events are logical events
+        generated by the compositor and not the hardware. These events are
+        also grouped by a wl_pointer.frame. When a pointer moves from one
+        surface to another, a compositor should group the
+        wl_pointer.leave event within the same wl_pointer.frame.
+        However, a client must not rely on wl_pointer.leave and
+        wl_pointer.enter being in the same wl_pointer.frame.
+        Compositor-specific policies may require the wl_pointer.leave and
+        wl_pointer.enter event being split across multiple wl_pointer.frame
+        groups.
       </description>
     </event>
 
     <enum name="axis_source">
       <description summary="axis source types">
-	Describes the source types for axis events. This indicates to the
-	client how an axis event was physically generated; a client may
-	adjust the user interface accordingly. For example, scroll events
-	from a "finger" source may be in a smooth coordinate space with
-	kinetic scrolling whereas a "wheel" source may be in discrete steps
-	of a number of lines.
+        Describes the source types for axis events. This indicates to the
+        client how an axis event was physically generated; a client may
+        adjust the user interface accordingly. For example, scroll events
+        from a "finger" source may be in a smooth coordinate space with
+        kinetic scrolling whereas a "wheel" source may be in discrete steps
+        of a number of lines.
 
-	The "continuous" axis source is a device generating events in a
-	continuous coordinate space, but using something other than a
-	finger. One example for this source is button-based scrolling where
-	the vertical motion of a device is converted to scroll events while
-	a button is held down.
+        The "continuous" axis source is a device generating events in a
+        continuous coordinate space, but using something other than a
+        finger. One example for this source is button-based scrolling where
+        the vertical motion of a device is converted to scroll events while
+        a button is held down.
 
-	The "wheel tilt" axis source indicates that the actual device is a
-	wheel but the scroll event is not caused by a rotation but a
-	(usually sideways) tilt of the wheel.
+        The "wheel tilt" axis source indicates that the actual device is a
+        wheel but the scroll event is not caused by a rotation but a
+        (usually sideways) tilt of the wheel.
       </description>
       <entry name="wheel" value="0" summary="a physical wheel rotation" />
       <entry name="finger" value="1" summary="finger on a touch surface" />
@@ -2261,51 +2376,51 @@
 
     <event name="axis_source" since="5">
       <description summary="axis source event">
-	Source information for scroll and other axes.
+        Source information for scroll and other axes.
 
-	This event does not occur on its own. It is sent before a
-	wl_pointer.frame event and carries the source information for
-	all events within that frame.
+        This event does not occur on its own. It is sent before a
+        wl_pointer.frame event and carries the source information for
+        all events within that frame.
 
-	The source specifies how this event was generated. If the source is
-	wl_pointer.axis_source.finger, a wl_pointer.axis_stop event will be
-	sent when the user lifts the finger off the device.
+        The source specifies how this event was generated. If the source is
+        wl_pointer.axis_source.finger, a wl_pointer.axis_stop event will be
+        sent when the user lifts the finger off the device.
 
-	If the source is wl_pointer.axis_source.wheel,
-	wl_pointer.axis_source.wheel_tilt or
-	wl_pointer.axis_source.continuous, a wl_pointer.axis_stop event may
-	or may not be sent. Whether a compositor sends an axis_stop event
-	for these sources is hardware-specific and implementation-dependent;
-	clients must not rely on receiving an axis_stop event for these
-	scroll sources and should treat scroll sequences from these scroll
-	sources as unterminated by default.
+        If the source is wl_pointer.axis_source.wheel,
+        wl_pointer.axis_source.wheel_tilt or
+        wl_pointer.axis_source.continuous, a wl_pointer.axis_stop event may
+        or may not be sent. Whether a compositor sends an axis_stop event
+        for these sources is hardware-specific and implementation-dependent;
+        clients must not rely on receiving an axis_stop event for these
+        scroll sources and should treat scroll sequences from these scroll
+        sources as unterminated by default.
 
-	This event is optional. If the source is unknown for a particular
-	axis event sequence, no event is sent.
-	Only one wl_pointer.axis_source event is permitted per frame.
+        This event is optional. If the source is unknown for a particular
+        axis event sequence, no event is sent.
+        Only one wl_pointer.axis_source event is permitted per frame.
 
-	The order of wl_pointer.axis_discrete and wl_pointer.axis_source is
-	not guaranteed.
+        The order of wl_pointer.axis_discrete and wl_pointer.axis_source is
+        not guaranteed.
       </description>
       <arg name="axis_source" type="uint" enum="axis_source" summary="source of the axis event"/>
     </event>
 
     <event name="axis_stop" since="5">
       <description summary="axis stop event">
-	Stop notification for scroll and other axes.
+        Stop notification for scroll and other axes.
 
-	For some wl_pointer.axis_source types, a wl_pointer.axis_stop event
-	is sent to notify a client that the axis sequence has terminated.
-	This enables the client to implement kinetic scrolling.
-	See the wl_pointer.axis_source documentation for information on when
-	this event may be generated.
+        For some wl_pointer.axis_source types, a wl_pointer.axis_stop event
+        is sent to notify a client that the axis sequence has terminated.
+        This enables the client to implement kinetic scrolling.
+        See the wl_pointer.axis_source documentation for information on when
+        this event may be generated.
 
-	Any wl_pointer.axis events with the same axis_source after this
-	event should be considered as the start of a new axis motion.
+        Any wl_pointer.axis events with the same axis_source after this
+        event should be considered as the start of a new axis motion.
 
-	The timestamp is to be interpreted identical to the timestamp in the
-	wl_pointer.axis event. The timestamp value may be the same as a
-	preceding wl_pointer.axis event.
+        The timestamp is to be interpreted identical to the timestamp in the
+        wl_pointer.axis event. The timestamp value may be the same as a
+        preceding wl_pointer.axis event.
       </description>
       <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
       <arg name="axis" type="uint" enum="axis" summary="the axis stopped with this event"/>
@@ -2313,36 +2428,36 @@
 
     <event name="axis_discrete" since="5" deprecated-since="8">
       <description summary="axis click event">
-	Discrete step information for scroll and other axes.
+        Discrete step information for scroll and other axes.
 
-	This event carries the axis value of the wl_pointer.axis event in
-	discrete steps (e.g. mouse wheel clicks).
+        This event carries the axis value of the wl_pointer.axis event in
+        discrete steps (e.g. mouse wheel clicks).
 
-	This event is deprecated with wl_pointer version 8 - this event is not
-	sent to clients supporting version 8 or later.
+        This event is deprecated with wl_pointer version 8 - this event is not
+        sent to clients supporting version 8 or later.
 
-	This event does not occur on its own, it is coupled with a
-	wl_pointer.axis event that represents this axis value on a
-	continuous scale. The protocol guarantees that each axis_discrete
-	event is always followed by exactly one axis event with the same
-	axis number within the same wl_pointer.frame. Note that the protocol
-	allows for other events to occur between the axis_discrete and
-	its coupled axis event, including other axis_discrete or axis
-	events. A wl_pointer.frame must not contain more than one axis_discrete
-	event per axis type.
+        This event does not occur on its own, it is coupled with a
+        wl_pointer.axis event that represents this axis value on a
+        continuous scale. The protocol guarantees that each axis_discrete
+        event is always followed by exactly one axis event with the same
+        axis number within the same wl_pointer.frame. Note that the protocol
+        allows for other events to occur between the axis_discrete and
+        its coupled axis event, including other axis_discrete or axis
+        events. A wl_pointer.frame must not contain more than one axis_discrete
+        event per axis type.
 
-	This event is optional; continuous scrolling devices
-	like two-finger scrolling on touchpads do not have discrete
-	steps and do not generate this event.
+        This event is optional; continuous scrolling devices
+        like two-finger scrolling on touchpads do not have discrete
+        steps and do not generate this event.
 
-	The discrete value carries the directional information. e.g. a value
-	of -2 is two steps towards the negative direction of this axis.
+        The discrete value carries the directional information. e.g. a value
+        of -2 is two steps towards the negative direction of this axis.
 
-	The axis number is identical to the axis number in the associated
-	axis event.
+        The axis number is identical to the axis number in the associated
+        axis event.
 
-	The order of wl_pointer.axis_discrete and wl_pointer.axis_source is
-	not guaranteed.
+        The order of wl_pointer.axis_discrete and wl_pointer.axis_source is
+        not guaranteed.
       </description>
       <arg name="axis" type="uint" enum="axis" summary="axis type"/>
       <arg name="discrete" type="int" summary="number of steps"/>
@@ -2350,27 +2465,27 @@
 
     <event name="axis_value120" since="8">
       <description summary="axis high-resolution scroll event">
-	Discrete high-resolution scroll information.
+        Discrete high-resolution scroll information.
 
-	This event carries high-resolution wheel scroll information,
-	with each multiple of 120 representing one logical scroll step
-	(a wheel detent). For example, an axis_value120 of 30 is one quarter of
-	a logical scroll step in the positive direction, a value120 of
-	-240 are two logical scroll steps in the negative direction within the
-	same hardware event.
-	Clients that rely on discrete scrolling should accumulate the
-	value120 to multiples of 120 before processing the event.
+        This event carries high-resolution wheel scroll information,
+        with each multiple of 120 representing one logical scroll step
+        (a wheel detent). For example, an axis_value120 of 30 is one quarter of
+        a logical scroll step in the positive direction, a value120 of
+        -240 are two logical scroll steps in the negative direction within the
+        same hardware event.
+        Clients that rely on discrete scrolling should accumulate the
+        value120 to multiples of 120 before processing the event.
 
-	The value120 must not be zero.
+        The value120 must not be zero.
 
-	This event replaces the wl_pointer.axis_discrete event in clients
-	supporting wl_pointer version 8 or later.
+        This event replaces the wl_pointer.axis_discrete event in clients
+        supporting wl_pointer version 8 or later.
 
-	Where a wl_pointer.axis_source event occurs in the same
-	wl_pointer.frame, the axis source applies to this event.
+        Where a wl_pointer.axis_source event occurs in the same
+        wl_pointer.frame, the axis source applies to this event.
 
-	The order of wl_pointer.axis_value120 and wl_pointer.axis_source is
-	not guaranteed.
+        The order of wl_pointer.axis_value120 and wl_pointer.axis_source is
+        not guaranteed.
       </description>
       <arg name="axis" type="uint" enum="axis" summary="axis type"/>
       <arg name="value120" type="int" summary="scroll distance as fraction of 120"/>
@@ -2380,60 +2495,82 @@
 
     <enum name="axis_relative_direction">
       <description summary="axis relative direction">
-	This specifies the direction of the physical motion that caused a
-	wl_pointer.axis event, relative to the wl_pointer.axis direction.
+        This specifies the direction of the physical motion that caused a
+        wl_pointer.axis event, relative to the wl_pointer.axis direction.
       </description>
       <entry name="identical" value="0"
-	  summary="physical motion matches axis direction"/>
+          summary="physical motion matches axis direction"/>
       <entry name="inverted" value="1"
-	  summary="physical motion is the inverse of the axis direction"/>
+          summary="physical motion is the inverse of the axis direction"/>
     </enum>
 
     <event name="axis_relative_direction" since="9">
       <description summary="axis relative physical direction event">
-	Relative directional information of the entity causing the axis
-	motion.
+        Relative directional information of the entity causing the axis
+        motion.
 
-	For a wl_pointer.axis event, the wl_pointer.axis_relative_direction
-	event specifies the movement direction of the entity causing the
-	wl_pointer.axis event. For example:
-	- if a user's fingers on a touchpad move down and this
-	  causes a wl_pointer.axis vertical_scroll down event, the physical
-	  direction is 'identical'
-	- if a user's fingers on a touchpad move down and this causes a
-	  wl_pointer.axis vertical_scroll up scroll up event ('natural
-	  scrolling'), the physical direction is 'inverted'.
+        For a wl_pointer.axis event, the wl_pointer.axis_relative_direction
+        event specifies the movement direction of the entity causing the
+        wl_pointer.axis event. For example:
+        - if a user's fingers on a touchpad move down and this
+          causes a wl_pointer.axis vertical_scroll down event, the physical
+          direction is 'identical'
+        - if a user's fingers on a touchpad move down and this causes a
+          wl_pointer.axis vertical_scroll up scroll up event ('natural
+          scrolling'), the physical direction is 'inverted'.
 
-	A client may use this information to adjust scroll motion of
-	components. Specifically, enabling natural scrolling causes the
-	content to change direction compared to traditional scrolling.
-	Some widgets like volume control sliders should usually match the
-	physical direction regardless of whether natural scrolling is
-	active. This event enables clients to match the scroll direction of
-	a widget to the physical direction.
+        A client may use this information to adjust scroll motion of
+        components. Specifically, enabling natural scrolling causes the
+        content to change direction compared to traditional scrolling.
+        Some widgets like volume control sliders should usually match the
+        physical direction regardless of whether natural scrolling is
+        active. This event enables clients to match the scroll direction of
+        a widget to the physical direction.
 
-	This event does not occur on its own, it is coupled with a
-	wl_pointer.axis event that represents this axis value.
-	The protocol guarantees that each axis_relative_direction event is
-	always followed by exactly one axis event with the same
-	axis number within the same wl_pointer.frame. Note that the protocol
-	allows for other events to occur between the axis_relative_direction
-	and its coupled axis event.
+        This event does not occur on its own, it is coupled with a
+        wl_pointer.axis event that represents this axis value.
+        The protocol guarantees that each axis_relative_direction event is
+        always followed by exactly one axis event with the same
+        axis number within the same wl_pointer.frame. Note that the protocol
+        allows for other events to occur between the axis_relative_direction
+        and its coupled axis event.
 
-	The axis number is identical to the axis number in the associated
-	axis event.
+        The axis number is identical to the axis number in the associated
+        axis event.
 
-	The order of wl_pointer.axis_relative_direction,
-	wl_pointer.axis_discrete and wl_pointer.axis_source is not
-	guaranteed.
+        The order of wl_pointer.axis_relative_direction,
+        wl_pointer.axis_discrete and wl_pointer.axis_source is not
+        guaranteed.
       </description>
       <arg name="axis" type="uint" enum="axis" summary="axis type"/>
       <arg name="direction" type="uint" enum="axis_relative_direction"
-	  summary="physical direction relative to axis motion"/>
+          summary="physical direction relative to axis motion"/>
+    </event>
+
+    <!-- Version 11 additions -->
+
+    <event name="warp" since="11">
+      <description summary="pointer warp event">
+	Notification of pointer location change within a surface.
+
+	This location change is not due to events on the input device,
+	but because either the surface under the pointer was moved and
+	thus the relative position of the pointer changed, or because
+	the compositor changed the pointer position in response to an
+	event like pointer confinement being exited.
+
+	The arguments surface_x and surface_y are the location relative to
+	the focused surface.
+
+	This event must not occur in the same wl_pointer.frame as a
+	wl_pointer.enter or wl_pointer.motion event.
+      </description>
+      <arg name="surface_x" type="fixed" summary="surface-local x coordinate"/>
+      <arg name="surface_y" type="fixed" summary="surface-local y coordinate"/>
     </event>
   </interface>
 
-  <interface name="wl_keyboard" version="10">
+  <interface name="wl_keyboard" version="11">
     <description summary="keyboard input device">
       The wl_keyboard interface represents one or more keyboards
       associated with a seat.
@@ -2451,23 +2588,23 @@
 
     <enum name="keymap_format">
       <description summary="keyboard mapping format">
-	This specifies the format of the keymap provided to the
-	client with the wl_keyboard.keymap event.
+        This specifies the format of the keymap provided to the
+        client with the wl_keyboard.keymap event.
       </description>
       <entry name="no_keymap" value="0"
-	     summary="no keymap; client must understand how to interpret the raw keycode"/>
+             summary="no keymap; client must understand how to interpret the raw keycode"/>
       <entry name="xkb_v1" value="1"
-	     summary="libxkbcommon compatible, null-terminated string; to determine the xkb keycode, clients must add 8 to the key event keycode"/>
+             summary="libxkbcommon compatible, null-terminated string; to determine the xkb keycode, clients must add 8 to the key event keycode"/>
     </enum>
 
     <event name="keymap">
       <description summary="keyboard mapping">
-	This event provides a file descriptor to the client which can be
-	memory-mapped in read-only mode to provide a keyboard mapping
-	description.
+        This event provides a file descriptor to the client which can be
+        memory-mapped in read-only mode to provide a keyboard mapping
+        description.
 
-	From version 7 onwards, the fd must be mapped with MAP_PRIVATE by
-	the recipient, as MAP_SHARED may fail.
+        From version 7 onwards, the fd must be mapped with MAP_PRIVATE by
+        the recipient, as MAP_SHARED may fail.
       </description>
       <arg name="format" type="uint" enum="keymap_format" summary="keymap format"/>
       <arg name="fd" type="fd" summary="keymap file descriptor"/>
@@ -2476,19 +2613,19 @@
 
     <event name="enter">
       <description summary="enter event">
-	Notification that this seat's keyboard focus is on a certain
-	surface.
+        Notification that this seat's keyboard focus is on a certain
+        surface.
 
-	The compositor must send the wl_keyboard.modifiers event after this
-	event.
+        The compositor must send the wl_keyboard.modifiers event after this
+        event.
 
-	In the wl_keyboard logical state, this event sets the active surface to
-	the surface argument and the keys currently logically down to the keys
-	in the keys argument. The compositor must not send this event if the
-	wl_keyboard already had an active surface immediately before this event.
+        In the wl_keyboard logical state, this event sets the active surface to
+        the surface argument and the keys currently logically down to the keys
+        in the keys argument. The compositor must not send this event if the
+        wl_keyboard already had an active surface immediately before this event.
 
-	Clients should not use the list of pressed keys to emulate key-press
-	events. The order of keys in the list is unspecified.
+        Clients should not use the list of pressed keys to emulate key-press
+        events. The order of keys in the list is unspecified.
       </description>
       <arg name="serial" type="uint" summary="serial number of the enter event"/>
       <arg name="surface" type="object" interface="wl_surface" summary="surface gaining keyboard focus"/>
@@ -2497,16 +2634,16 @@
 
     <event name="leave">
       <description summary="leave event">
-	Notification that this seat's keyboard focus is no longer on
-	a certain surface.
+        Notification that this seat's keyboard focus is no longer on
+        a certain surface.
 
-	The leave notification is sent before the enter notification
-	for the new focus.
+        The leave notification is sent before the enter notification
+        for the new focus.
 
-	In the wl_keyboard logical state, this event resets all values to their
-	defaults. The compositor must not send this event if the active surface
-	of the wl_keyboard was not equal to the surface argument immediately
-	before this event.
+        In the wl_keyboard logical state, this event resets all values to their
+        defaults. The compositor must not send this event if the active surface
+        of the wl_keyboard was not equal to the surface argument immediately
+        before this event.
       </description>
       <arg name="serial" type="uint" summary="serial number of the leave event"/>
       <arg name="surface" type="object" interface="wl_surface" summary="surface that lost keyboard focus"/>
@@ -2514,15 +2651,15 @@
 
     <enum name="key_state">
       <description summary="physical key state">
-	Describes the physical state of a key that produced the key event.
+        Describes the physical state of a key that produced the key event.
 
-	Since version 10, the key can be in a "repeated" pseudo-state which
-	means the same as "pressed", but is used to signal repetition in the
-	key event.
+        Since version 10, the key can be in a "repeated" pseudo-state which
+        means the same as "pressed", but is used to signal repetition in the
+        key event.
 
-	The key may only enter the repeated state after entering the pressed
-	state and before entering the released state. This event may be
-	generated multiple times while the key is down.
+        The key may only enter the repeated state after entering the pressed
+        state and before entering the released state. This event may be
+        generated multiple times while the key is down.
       </description>
       <entry name="released" value="0" summary="key is not pressed"/>
       <entry name="pressed" value="1" summary="key is pressed"/>
@@ -2531,29 +2668,29 @@
 
     <event name="key">
       <description summary="key event">
-	A key was pressed or released.
-	The time argument is a timestamp with millisecond
-	granularity, with an undefined base.
+        A key was pressed or released.
+        The time argument is a timestamp with millisecond
+        granularity, with an undefined base.
 
-	The key is a platform-specific key code that can be interpreted
-	by feeding it to the keyboard mapping (see the keymap event).
+        The key is a platform-specific key code that can be interpreted
+        by feeding it to the keyboard mapping (see the keymap event).
 
-	If this event produces a change in modifiers, then the resulting
-	wl_keyboard.modifiers event must be sent after this event.
+        If this event produces a change in modifiers, then the resulting
+        wl_keyboard.modifiers event must be sent after this event.
 
-	In the wl_keyboard logical state, this event adds the key to the keys
-	currently logically down (if the state argument is pressed) or removes
-	the key from the keys currently logically down (if the state argument is
-	released). The compositor must not send this event if the wl_keyboard
-	did not have an active surface immediately before this event. The
-	compositor must not send this event if state is pressed (resp. released)
-	and the key was already logically down (resp. was not logically down)
-	immediately before this event.
+        In the wl_keyboard logical state, this event adds the key to the keys
+        currently logically down (if the state argument is pressed) or removes
+        the key from the keys currently logically down (if the state argument is
+        released). The compositor must not send this event if the wl_keyboard
+        did not have an active surface immediately before this event. The
+        compositor must not send this event if state is pressed (resp. released)
+        and the key was already logically down (resp. was not logically down)
+        immediately before this event.
 
-	Since version 10, compositors may send key events with the "repeated"
-	key state when a wl_keyboard.repeat_info event with a rate argument of
-	0 has been received. This allows the compositor to take over the
-	responsibility of key repetition.
+        Since version 10, compositors may send key events with the "repeated"
+        key state when a wl_keyboard.repeat_info event with a rate argument of
+        0 has been received. This allows the compositor to take over the
+        responsibility of key repetition.
       </description>
       <arg name="serial" type="uint" summary="serial number of the key event"/>
       <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
@@ -2563,19 +2700,19 @@
 
     <event name="modifiers">
       <description summary="modifier and group state">
-	Notifies clients that the modifier and/or group state has
-	changed, and it should update its local state.
+        Notifies clients that the modifier and/or group state has
+        changed, and it should update its local state.
 
-	The compositor may send this event without a surface of the client
-	having keyboard focus, for example to tie modifier information to
-	pointer focus instead. If a modifier event with pressed modifiers is sent
-	without a prior enter event, the client can assume the modifier state is
-	valid until it receives the next wl_keyboard.modifiers event. In order to
-	reset the modifier state again, the compositor can send a
-	wl_keyboard.modifiers event with no pressed modifiers.
+        The compositor may send this event without a surface of the client
+        having keyboard focus, for example to tie modifier information to
+        pointer focus instead. If a modifier event with pressed modifiers is sent
+        without a prior enter event, the client can assume the modifier state is
+        valid until it receives the next wl_keyboard.modifiers event. In order to
+        reset the modifier state again, the compositor can send a
+        wl_keyboard.modifiers event with no pressed modifiers.
 
-	In the wl_keyboard logical state, this event updates the modifiers and
-	group.
+        In the wl_keyboard logical state, this event updates the modifiers and
+        group.
       </description>
       <arg name="serial" type="uint" summary="serial number of the modifiers event"/>
       <arg name="mods_depressed" type="uint" summary="depressed modifiers"/>
@@ -2594,27 +2731,27 @@
 
     <event name="repeat_info" since="4">
       <description summary="repeat rate and delay">
-	Informs the client about the keyboard's repeat rate and delay.
+        Informs the client about the keyboard's repeat rate and delay.
 
-	This event is sent as soon as the wl_keyboard object has been created,
-	and is guaranteed to be received by the client before any key press
-	event.
+        This event is sent as soon as the wl_keyboard object has been created,
+        and is guaranteed to be received by the client before any key press
+        event.
 
-	Negative values for either rate or delay are illegal. A rate of zero
-	will disable any repeating (regardless of the value of delay).
+        Negative values for either rate or delay are illegal. A rate of zero
+        will disable any repeating (regardless of the value of delay).
 
-	This event can be sent later on as well with a new value if necessary,
-	so clients should continue listening for the event past the creation
-	of wl_keyboard.
+        This event can be sent later on as well with a new value if necessary,
+        so clients should continue listening for the event past the creation
+        of wl_keyboard.
       </description>
       <arg name="rate" type="int"
-	   summary="the rate of repeating keys in characters per second"/>
+           summary="the rate of repeating keys in characters per second"/>
       <arg name="delay" type="int"
-	   summary="delay in milliseconds since key down until repeating starts"/>
+           summary="delay in milliseconds since key down until repeating starts"/>
     </event>
   </interface>
 
-  <interface name="wl_touch" version="10">
+  <interface name="wl_touch" version="11">
     <description summary="touchscreen input device">
       The wl_touch interface represents a touchscreen
       associated with a seat.
@@ -2628,10 +2765,10 @@
 
     <event name="down">
       <description summary="touch down event and beginning of a touch sequence">
-	A new touch point has appeared on the surface. This touch point is
-	assigned a unique ID. Future events from this touch point reference
-	this ID. The ID ceases to be valid after a touch up event and may be
-	reused in the future.
+        A new touch point has appeared on the surface. This touch point is
+        assigned a unique ID. Future events from this touch point reference
+        this ID. The ID ceases to be valid after a touch up event and may be
+        reused in the future.
       </description>
       <arg name="serial" type="uint" summary="serial number of the touch down event"/>
       <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
@@ -2643,9 +2780,9 @@
 
     <event name="up">
       <description summary="end of a touch event sequence">
-	The touch point has disappeared. No further events will be sent for
-	this touch point and the touch point's ID is released and may be
-	reused in a future touch down event.
+        The touch point has disappeared. No further events will be sent for
+        this touch point and the touch point's ID is released and may be
+        reused in a future touch down event.
       </description>
       <arg name="serial" type="uint" summary="serial number of the touch up event"/>
       <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
@@ -2654,7 +2791,7 @@
 
     <event name="motion">
       <description summary="update of touch point coordinates">
-	A touch point has changed coordinates.
+        A touch point has changed coordinates.
       </description>
       <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
       <arg name="id" type="int" summary="the unique ID of this touch point"/>
@@ -2664,27 +2801,27 @@
 
     <event name="frame">
       <description summary="end of touch frame event">
-	Indicates the end of a set of events that logically belong together.
-	A client is expected to accumulate the data in all events within the
-	frame before proceeding.
+        Indicates the end of a set of events that logically belong together.
+        A client is expected to accumulate the data in all events within the
+        frame before proceeding.
 
-	A wl_touch.frame terminates at least one event but otherwise no
-	guarantee is provided about the set of events within a frame. A client
-	must assume that any state not updated in a frame is unchanged from the
-	previously known state.
+        A wl_touch.frame terminates at least one event but otherwise no
+        guarantee is provided about the set of events within a frame. A client
+        must assume that any state not updated in a frame is unchanged from the
+        previously known state.
       </description>
     </event>
 
     <event name="cancel">
       <description summary="touch session cancelled">
-	Sent if the compositor decides the touch stream is a global
-	gesture. No further events are sent to the clients from that
-	particular gesture. Touch cancellation applies to all touch points
-	currently active on this client's surface. The client is
-	responsible for finalizing the touch points, future touch points on
-	this surface may reuse the touch point ID.
+        Sent if the compositor decides the touch stream is a global
+        gesture. No further events are sent to the clients from that
+        particular gesture. Touch cancellation applies to all touch points
+        currently active on this client's surface. The client is
+        responsible for finalizing the touch points, future touch points on
+        this surface may reuse the touch point ID.
 
-	No frame event is required after the cancel event.
+        No frame event is required after the cancel event.
       </description>
     </event>
 
@@ -2698,31 +2835,31 @@
 
     <event name="shape" since="6">
       <description summary="update shape of touch point">
-	Sent when a touchpoint has changed its shape.
+        Sent when a touchpoint has changed its shape.
 
-	This event does not occur on its own. It is sent before a
-	wl_touch.frame event and carries the new shape information for
-	any previously reported, or new touch points of that frame.
+        This event does not occur on its own. It is sent before a
+        wl_touch.frame event and carries the new shape information for
+        any previously reported, or new touch points of that frame.
 
-	Other events describing the touch point such as wl_touch.down,
-	wl_touch.motion or wl_touch.orientation may be sent within the
-	same wl_touch.frame. A client should treat these events as a single
-	logical touch point update. The order of wl_touch.shape,
-	wl_touch.orientation and wl_touch.motion is not guaranteed.
-	A wl_touch.down event is guaranteed to occur before the first
-	wl_touch.shape event for this touch ID but both events may occur within
-	the same wl_touch.frame.
+        Other events describing the touch point such as wl_touch.down,
+        wl_touch.motion or wl_touch.orientation may be sent within the
+        same wl_touch.frame. A client should treat these events as a single
+        logical touch point update. The order of wl_touch.shape,
+        wl_touch.orientation and wl_touch.motion is not guaranteed.
+        A wl_touch.down event is guaranteed to occur before the first
+        wl_touch.shape event for this touch ID but both events may occur within
+        the same wl_touch.frame.
 
-	A touchpoint shape is approximated by an ellipse through the major and
-	minor axis length. The major axis length describes the longer diameter
-	of the ellipse, while the minor axis length describes the shorter
-	diameter. Major and minor are orthogonal and both are specified in
-	surface-local coordinates. The center of the ellipse is always at the
-	touchpoint location as reported by wl_touch.down or wl_touch.move.
+        A touchpoint shape is approximated by an ellipse through the major and
+        minor axis length. The major axis length describes the longer diameter
+        of the ellipse, while the minor axis length describes the shorter
+        diameter. Major and minor are orthogonal and both are specified in
+        surface-local coordinates. The center of the ellipse is always at the
+        touchpoint location as reported by wl_touch.down or wl_touch.motion.
 
-	This event is only sent by the compositor if the touch device supports
-	shape reports. The client has to make reasonable assumptions about the
-	shape if it did not receive this event.
+        This event is only sent by the compositor if the touch device supports
+        shape reports. The client has to make reasonable assumptions about the
+        shape if it did not receive this event.
       </description>
       <arg name="id" type="int" summary="the unique ID of this touch point"/>
       <arg name="major" type="fixed" summary="length of the major axis in surface-local coordinates"/>
@@ -2731,29 +2868,29 @@
 
     <event name="orientation" since="6">
       <description summary="update orientation of touch point">
-	Sent when a touchpoint has changed its orientation.
+        Sent when a touchpoint has changed its orientation.
 
-	This event does not occur on its own. It is sent before a
-	wl_touch.frame event and carries the new shape information for
-	any previously reported, or new touch points of that frame.
+        This event does not occur on its own. It is sent before a
+        wl_touch.frame event and carries the new shape information for
+        any previously reported, or new touch points of that frame.
 
-	Other events describing the touch point such as wl_touch.down,
-	wl_touch.motion or wl_touch.shape may be sent within the
-	same wl_touch.frame. A client should treat these events as a single
-	logical touch point update. The order of wl_touch.shape,
-	wl_touch.orientation and wl_touch.motion is not guaranteed.
-	A wl_touch.down event is guaranteed to occur before the first
-	wl_touch.orientation event for this touch ID but both events may occur
-	within the same wl_touch.frame.
+        Other events describing the touch point such as wl_touch.down,
+        wl_touch.motion or wl_touch.shape may be sent within the
+        same wl_touch.frame. A client should treat these events as a single
+        logical touch point update. The order of wl_touch.shape,
+        wl_touch.orientation and wl_touch.motion is not guaranteed.
+        A wl_touch.down event is guaranteed to occur before the first
+        wl_touch.orientation event for this touch ID but both events may occur
+        within the same wl_touch.frame.
 
-	The orientation describes the clockwise angle of a touchpoint's major
-	axis to the positive surface y-axis and is normalized to the -180 to
-	+180 degree range. The granularity of orientation depends on the touch
-	device, some devices only support binary rotation values between 0 and
-	90 degrees.
+        The orientation describes the clockwise angle of a touchpoint's major
+        axis to the positive surface y-axis and is normalized to the -180 to
+        +180 degree range. The granularity of orientation depends on the touch
+        device, some devices only support binary rotation values between 0 and
+        90 degrees.
 
-	This event is only sent by the compositor if the touch device supports
-	orientation reports.
+        This event is only sent by the compositor if the touch device supports
+        orientation reports.
       </description>
       <arg name="id" type="int" summary="the unique ID of this touch point"/>
       <arg name="orientation" type="fixed" summary="angle between major axis and positive surface y-axis in degrees"/>
@@ -2772,8 +2909,8 @@
 
     <enum name="subpixel">
       <description summary="subpixel geometry information">
-	This enumeration describes how the physical
-	pixels on an output are laid out.
+        This enumeration describes how the physical
+        pixels on an output are laid out.
       </description>
       <entry name="unknown" value="0" summary="unknown geometry"/>
       <entry name="none" value="1" summary="no geometry"/>
@@ -2785,16 +2922,16 @@
 
     <enum name="transform">
       <description summary="transformation applied to buffer contents">
-	This describes transformations that clients and compositors apply to
-	buffer contents.
+        This describes transformations that clients and compositors apply to
+        buffer contents.
 
-	The flipped values correspond to an initial flip around a
-	vertical axis followed by rotation.
+        The flipped values correspond to an initial flip around a
+        vertical axis followed by rotation.
 
-	The purpose is mainly to allow clients to render accordingly and
-	tell the compositor, so that for fullscreen surfaces, the
-	compositor will still be able to scan out directly from client
-	surfaces.
+        The purpose is mainly to allow clients to render accordingly and
+        tell the compositor, so that for fullscreen surfaces, the
+        compositor will still be able to scan out directly from client
+        surfaces.
       </description>
       <entry name="normal" value="0" summary="no transform"/>
       <entry name="90" value="1" summary="90 degrees counter-clockwise"/>
@@ -2808,91 +2945,91 @@
 
     <event name="geometry">
       <description summary="properties of the output">
-	The geometry event describes geometric properties of the output.
-	The event is sent when binding to the output object and whenever
-	any of the properties change.
+        The geometry event describes geometric properties of the output.
+        The event is sent when binding to the output object and whenever
+        any of the properties change.
 
-	The physical size can be set to zero if it doesn't make sense for this
-	output (e.g. for projectors or virtual outputs).
+        The physical size can be set to zero if it doesn't make sense for this
+        output (e.g. for projectors or virtual outputs).
 
-	The geometry event will be followed by a done event (starting from
-	version 2).
+        The geometry event will be followed by a done event (starting from
+        version 2).
 
-	Clients should use wl_surface.preferred_buffer_transform instead of the
-	transform advertised by this event to find the preferred buffer
-	transform to use for a surface.
+        Clients should use wl_surface.preferred_buffer_transform instead of the
+        transform advertised by this event to find the preferred buffer
+        transform to use for a surface.
 
-	Note: wl_output only advertises partial information about the output
-	position and identification. Some compositors, for instance those not
-	implementing a desktop-style output layout or those exposing virtual
-	outputs, might fake this information. Instead of using x and y, clients
-	should use xdg_output.logical_position. Instead of using make and model,
-	clients should use name and description.
+        Note: wl_output only advertises partial information about the output
+        position and identification. Some compositors, for instance those not
+        implementing a desktop-style output layout or those exposing virtual
+        outputs, might fake this information. Instead of using x and y, clients
+        should use xdg_output.logical_position. Instead of using make and model,
+        clients should use name and description.
       </description>
       <arg name="x" type="int"
-	   summary="x position within the global compositor space"/>
+           summary="x position within the global compositor space"/>
       <arg name="y" type="int"
-	   summary="y position within the global compositor space"/>
+           summary="y position within the global compositor space"/>
       <arg name="physical_width" type="int"
-	   summary="width in millimeters of the output"/>
+           summary="width in millimeters of the output"/>
       <arg name="physical_height" type="int"
-	   summary="height in millimeters of the output"/>
+           summary="height in millimeters of the output"/>
       <arg name="subpixel" type="int" enum="subpixel"
-	   summary="subpixel orientation of the output"/>
+           summary="subpixel orientation of the output"/>
       <arg name="make" type="string"
-	   summary="textual description of the manufacturer"/>
+           summary="textual description of the manufacturer"/>
       <arg name="model" type="string"
-	   summary="textual description of the model"/>
+           summary="textual description of the model"/>
       <arg name="transform" type="int" enum="transform"
-	   summary="additional transformation applied to buffer contents during presentation"/>
+           summary="additional transformation applied to buffer contents during presentation"/>
     </event>
 
     <enum name="mode" bitfield="true">
       <description summary="mode information">
-	These flags describe properties of an output mode.
-	They are used in the flags bitfield of the mode event.
+        These flags describe properties of an output mode.
+        They are used in the flags bitfield of the mode event.
       </description>
       <entry name="current" value="0x1"
-	     summary="indicates this is the current mode"/>
+             summary="indicates this is the current mode"/>
       <entry name="preferred" value="0x2"
-	     summary="indicates this is the preferred mode"/>
+             summary="indicates this is the preferred mode"/>
     </enum>
 
     <event name="mode">
       <description summary="advertise available modes for the output">
-	The mode event describes an available mode for the output.
+        The mode event describes an available mode for the output.
 
-	The event is sent when binding to the output object and there
-	will always be one mode, the current mode.  The event is sent
-	again if an output changes mode, for the mode that is now
-	current.  In other words, the current mode is always the last
-	mode that was received with the current flag set.
+        The event is sent when binding to the output object and there
+        will always be one mode, the current mode.  The event is sent
+        again if an output changes mode, for the mode that is now
+        current.  In other words, the current mode is always the last
+        mode that was received with the current flag set.
 
-	Non-current modes are deprecated. A compositor can decide to only
-	advertise the current mode and never send other modes. Clients
-	should not rely on non-current modes.
+        Non-current modes are deprecated. A compositor can decide to only
+        advertise the current mode and never send other modes. Clients
+        should not rely on non-current modes.
 
-	The size of a mode is given in physical hardware units of
-	the output device. This is not necessarily the same as
-	the output size in the global compositor space. For instance,
-	the output may be scaled, as described in wl_output.scale,
-	or transformed, as described in wl_output.transform. Clients
-	willing to retrieve the output size in the global compositor
-	space should use xdg_output.logical_size instead.
+        The size of a mode is given in physical hardware units of
+        the output device. This is not necessarily the same as
+        the output size in the global compositor space. For instance,
+        the output may be scaled, as described in wl_output.scale,
+        or transformed, as described in wl_output.transform. Clients
+        willing to retrieve the output size in the global compositor
+        space should use xdg_output.logical_size instead.
 
-	The vertical refresh rate can be set to zero if it doesn't make
-	sense for this output (e.g. for virtual outputs).
+        The vertical refresh rate can be set to zero if it doesn't make
+        sense for this output (e.g. for virtual outputs).
 
-	The mode event will be followed by a done event (starting from
-	version 2).
+        The mode event will be followed by a done event (starting from
+        version 2).
 
-	Clients should not use the refresh rate to schedule frames. Instead,
-	they should use the wl_surface.frame event or the presentation-time
-	protocol.
+        Clients should not use the refresh rate to schedule frames. Instead,
+        they should use the wl_surface.frame event or the presentation-time
+        protocol.
 
-	Note: this information is not always meaningful for all outputs. Some
-	compositors, such as those exposing virtual outputs, might fake the
-	refresh rate or the size.
+        Note: this information is not always meaningful for all outputs. Some
+        compositors, such as those exposing virtual outputs, might fake the
+        refresh rate or the size.
       </description>
       <arg name="flags" type="uint" enum="mode" summary="bitfield of mode flags"/>
       <arg name="width" type="int" summary="width of the mode in hardware units"/>
@@ -2904,34 +3041,34 @@
 
     <event name="done" since="2">
       <description summary="sent all information about output">
-	This event is sent after all other properties have been
-	sent after binding to the output object and after any
-	other property changes done after that. This allows
-	changes to the output properties to be seen as
-	atomic, even if they happen via multiple events.
+        This event is sent after all other properties have been
+        sent after binding to the output object and after any
+        other property changes done after that. This allows
+        changes to the output properties to be seen as
+        atomic, even if they happen via multiple events.
       </description>
     </event>
 
     <event name="scale" since="2">
       <description summary="output scaling properties">
-	This event contains scaling geometry information
-	that is not in the geometry event. It may be sent after
-	binding the output object or if the output scale changes
-	later. The compositor will emit a non-zero, positive
-	value for scale. If it is not sent, the client should
-	assume a scale of 1.
+        This event contains scaling geometry information
+        that is not in the geometry event. It may be sent after
+        binding the output object or if the output scale changes
+        later. The compositor will emit a non-zero, positive
+        value for scale. If it is not sent, the client should
+        assume a scale of 1.
 
-	A scale larger than 1 means that the compositor will
-	automatically scale surface buffers by this amount
-	when rendering. This is used for very high resolution
-	displays where applications rendering at the native
-	resolution would be too small to be legible.
+        A scale larger than 1 means that the compositor will
+        automatically scale surface buffers by this amount
+        when rendering. This is used for very high resolution
+        displays where applications rendering at the native
+        resolution would be too small to be legible.
 
-	Clients should use wl_surface.preferred_buffer_scale
-	instead of this event to find the preferred buffer
-	scale to use for a surface.
+        Clients should use wl_surface.preferred_buffer_scale
+        instead of this event to find the preferred buffer
+        scale to use for a surface.
 
-	The scale event will be followed by a done event.
+        The scale event will be followed by a done event.
       </description>
       <arg name="factor" type="int" summary="scaling factor of output"/>
     </event>
@@ -2940,8 +3077,8 @@
 
     <request name="release" type="destructor" since="3">
       <description summary="release the output object">
-	Using this request a client can tell the server that it is not going to
-	use the output object anymore.
+        Using this request a client can tell the server that it is not going to
+        use the output object anymore.
       </description>
     </request>
 
@@ -2949,60 +3086,60 @@
 
     <event name="name" since="4">
       <description summary="name of this output">
-	Many compositors will assign user-friendly names to their outputs, show
-	them to the user, allow the user to refer to an output, etc. The client
-	may wish to know this name as well to offer the user similar behaviors.
+        Many compositors will assign user-friendly names to their outputs, show
+        them to the user, allow the user to refer to an output, etc. The client
+        may wish to know this name as well to offer the user similar behaviors.
 
-	The name is a UTF-8 string with no convention defined for its contents.
-	Each name is unique among all wl_output globals. The name is only
-	guaranteed to be unique for the compositor instance.
+        The name is a UTF-8 string with no convention defined for its contents.
+        Each name is unique among all wl_output globals. The name is only
+        guaranteed to be unique for the compositor instance.
 
-	The same output name is used for all clients for a given wl_output
-	global. Thus, the name can be shared across processes to refer to a
-	specific wl_output global.
+        The same output name is used for all clients for a given wl_output
+        global. Thus, the name can be shared across processes to refer to a
+        specific wl_output global.
 
-	The name is not guaranteed to be persistent across sessions, thus cannot
-	be used to reliably identify an output in e.g. configuration files.
+        The name is not guaranteed to be persistent across sessions, thus cannot
+        be used to reliably identify an output in e.g. configuration files.
 
-	Examples of names include 'HDMI-A-1', 'WL-1', 'X11-1', etc. However, do
-	not assume that the name is a reflection of an underlying DRM connector,
-	X11 connection, etc.
+        Examples of names include 'HDMI-A-1', 'WL-1', 'X11-1', etc. However, do
+        not assume that the name is a reflection of an underlying DRM connector,
+        X11 connection, etc.
 
-	The name event is sent after binding the output object. This event is
-	only sent once per output object, and the name does not change over the
-	lifetime of the wl_output global.
+        The name event is sent after binding the output object. This event is
+        only sent once per output object, and the name does not change over the
+        lifetime of the wl_output global.
 
-	Compositors may re-use the same output name if the wl_output global is
-	destroyed and re-created later. Compositors should avoid re-using the
-	same name if possible.
+        Compositors may re-use the same output name if the wl_output global is
+        destroyed and re-created later. Compositors should avoid re-using the
+        same name if possible.
 
-	The name event will be followed by a done event.
+        The name event will be followed by a done event.
       </description>
       <arg name="name" type="string" summary="output name"/>
     </event>
 
     <event name="description" since="4">
       <description summary="human-readable description of this output">
-	Many compositors can produce human-readable descriptions of their
-	outputs. The client may wish to know this description as well, e.g. for
-	output selection purposes.
+        Many compositors can produce human-readable descriptions of their
+        outputs. The client may wish to know this description as well, e.g. for
+        output selection purposes.
 
-	The description is a UTF-8 string with no convention defined for its
-	contents. The description is not guaranteed to be unique among all
-	wl_output globals. Examples might include 'Foocorp 11" Display' or
-	'Virtual X11 output via :1'.
+        The description is a UTF-8 string with no convention defined for its
+        contents. The description is not guaranteed to be unique among all
+        wl_output globals. Examples might include 'Foocorp 11" Display' or
+        'Virtual X11 output via :1'.
 
-	The description event is sent after binding the output object and
-	whenever the description changes. The description is optional, and may
-	not be sent at all.
+        The description event is sent after binding the output object and
+        whenever the description changes. The description is optional, and may
+        not be sent at all.
 
-	The description event will be followed by a done event.
+        The description event will be followed by a done event.
       </description>
       <arg name="description" type="string" summary="output description"/>
     </event>
   </interface>
 
-  <interface name="wl_region" version="1">
+  <interface name="wl_region" version="7">
     <description summary="region interface">
       A region object describes an area.
 
@@ -3012,13 +3149,13 @@
 
     <request name="destroy" type="destructor">
       <description summary="destroy region">
-	Destroy the region.  This will invalidate the object ID.
+        Destroy the region.  This will invalidate the object ID.
       </description>
     </request>
 
     <request name="add">
       <description summary="add rectangle to region">
-	Add the specified rectangle to the region.
+        Add the specified rectangle to the region.
       </description>
       <arg name="x" type="int" summary="region-local x coordinate"/>
       <arg name="y" type="int" summary="region-local y coordinate"/>
@@ -3028,7 +3165,7 @@
 
     <request name="subtract">
       <description summary="subtract rectangle from region">
-	Subtract the specified rectangle from the region.
+        Subtract the specified rectangle from the region.
       </description>
       <arg name="x" type="int" summary="region-local x coordinate"/>
       <arg name="y" type="int" summary="region-local y coordinate"/>
@@ -3062,47 +3199,47 @@
 
     <request name="destroy" type="destructor">
       <description summary="unbind from the subcompositor interface">
-	Informs the server that the client will not be using this
-	protocol object anymore. This does not affect any other
-	objects, wl_subsurface objects included.
+        Informs the server that the client will not be using this
+        protocol object anymore. This does not affect any other
+        objects, wl_subsurface objects included.
       </description>
     </request>
 
     <enum name="error">
       <entry name="bad_surface" value="0"
-	     summary="the to-be sub-surface is invalid"/>
+             summary="the to-be sub-surface is invalid"/>
       <entry name="bad_parent" value="1"
-	     summary="the to-be sub-surface parent is invalid"/>
+             summary="the to-be sub-surface parent is invalid"/>
     </enum>
 
     <request name="get_subsurface">
       <description summary="give a surface the role sub-surface">
-	Create a sub-surface interface for the given surface, and
-	associate it with the given parent surface. This turns a
-	plain wl_surface into a sub-surface.
+        Create a sub-surface interface for the given surface, and
+        associate it with the given parent surface. This turns a
+        plain wl_surface into a sub-surface.
 
-	The to-be sub-surface must not already have another role, and it
-	must not have an existing wl_subsurface object. Otherwise the
-	bad_surface protocol error is raised.
+        The to-be sub-surface must not already have another role, and it
+        must not have an existing wl_subsurface object. Otherwise the
+        bad_surface protocol error is raised.
 
-	Adding sub-surfaces to a parent is a double-buffered operation on the
-	parent (see wl_surface.commit). The effect of adding a sub-surface
-	becomes visible on the next time the state of the parent surface is
-	applied.
+        Adding sub-surfaces to a parent is a double-buffered operation on the
+        parent (see wl_surface.commit). The effect of adding a sub-surface
+        becomes visible on the next time the state of the parent surface is
+        applied.
 
-	The parent surface must not be one of the child surface's descendants,
-	and the parent must be different from the child surface, otherwise the
-	bad_parent protocol error is raised.
+        The parent surface must not be one of the child surface's descendants,
+        and the parent must be different from the child surface, otherwise the
+        bad_parent protocol error is raised.
 
-	This request modifies the behaviour of wl_surface.commit request on
-	the sub-surface, see the documentation on wl_subsurface interface.
+        This request modifies the behaviour of wl_surface.commit request on
+        the sub-surface, see the documentation on wl_subsurface interface.
       </description>
       <arg name="id" type="new_id" interface="wl_subsurface"
-	   summary="the new sub-surface object ID"/>
+           summary="the new sub-surface object ID"/>
       <arg name="surface" type="object" interface="wl_surface"
-	   summary="the surface to be turned into a sub-surface"/>
+           summary="the surface to be turned into a sub-surface"/>
       <arg name="parent" type="object" interface="wl_surface"
-	   summary="the parent surface"/>
+           summary="the parent surface"/>
     </request>
   </interface>
 
@@ -3120,23 +3257,9 @@
       hidden, or if a NULL wl_buffer is applied. These rules apply
       recursively through the tree of surfaces.
 
-      The behaviour of a wl_surface.commit request on a sub-surface
-      depends on the sub-surface's mode. The possible modes are
-      synchronized and desynchronized, see methods
-      wl_subsurface.set_sync and wl_subsurface.set_desync. Synchronized
-      mode caches the wl_surface state to be applied when the parent's
-      state gets applied, and desynchronized mode applies the pending
-      wl_surface state directly. A sub-surface is initially in the
-      synchronized mode.
-
-      Sub-surfaces also have another kind of state, which is managed by
-      wl_subsurface requests, as opposed to wl_surface requests. This
-      state includes the sub-surface position relative to the parent
-      surface (wl_subsurface.set_position), and the stacking order of
-      the parent and its sub-surfaces (wl_subsurface.place_above and
-      .place_below). This state is applied when the parent surface's
-      wl_surface state is applied, regardless of the sub-surface's mode.
-      As the exception, set_sync and set_desync are effective immediately.
+      A sub-surface can be in one of two modes. The possible modes are
+      synchronized and desynchronized, see methods wl_subsurface.set_sync and
+      wl_subsurface.set_desync.
 
       The main surface can be thought to be always in desynchronized mode,
       since it does not have a parent in the sub-surfaces sense.
@@ -3147,6 +3270,15 @@
       tree of surfaces. This means, that one can set a sub-surface into
       synchronized mode, and then assume that all its child and grand-child
       sub-surfaces are synchronized, too, without explicitly setting them.
+
+      If a surface behaves as in synchronized mode, it is effectively
+      synchronized, otherwise it is effectively desynchronized.
+
+      A sub-surface is initially in the synchronized mode.
+
+      The wl_subsurface interface has requests which modify double-buffered
+      state of the parent surface (wl_subsurface.set_position, .place_above and
+      .place_below).
 
       Destroying a sub-surface takes effect immediately. If you need to
       synchronize the removal of a sub-surface to the parent surface update,
@@ -3164,34 +3296,32 @@
 
     <request name="destroy" type="destructor">
       <description summary="remove sub-surface interface">
-	The sub-surface interface is removed from the wl_surface object
-	that was turned into a sub-surface with a
-	wl_subcompositor.get_subsurface request. The wl_surface's association
-	to the parent is deleted. The wl_surface is unmapped immediately.
+        The sub-surface interface is removed from the wl_surface object
+        that was turned into a sub-surface with a
+        wl_subcompositor.get_subsurface request. The wl_surface's association
+        to the parent is deleted. The wl_surface is unmapped immediately.
       </description>
     </request>
 
     <enum name="error">
       <entry name="bad_surface" value="0"
-	     summary="wl_surface is not a sibling or the parent"/>
+             summary="wl_surface is not a sibling or the parent"/>
     </enum>
 
     <request name="set_position">
       <description summary="reposition the sub-surface">
-	This schedules a sub-surface position change.
-	The sub-surface will be moved so that its origin (top left
-	corner pixel) will be at the location x, y of the parent surface
-	coordinate system. The coordinates are not restricted to the parent
-	surface area. Negative values are allowed.
+        This sets the position of the sub-surface, relative to the parent
+        surface.
 
-	The scheduled coordinates will take effect whenever the state of the
-	parent surface is applied.
+        The sub-surface will be moved so that its origin (top left
+        corner pixel) will be at the location x, y of the parent surface
+        coordinate system. The coordinates are not restricted to the parent
+        surface area. Negative values are allowed.
 
-	If more than one set_position request is invoked by the client before
-	the commit of the parent surface, the position of a new request always
-	replaces the scheduled position from any previous request.
+        The initial position is 0, 0.
 
-	The initial position is 0, 0.
+        Position is double-buffered state on the parent surface, see
+        wl_subsurface and wl_surface.commit for more information.
       </description>
       <arg name="x" type="int" summary="x coordinate in the parent surface"/>
       <arg name="y" type="int" summary="y coordinate in the parent surface"/>
@@ -3199,81 +3329,64 @@
 
     <request name="place_above">
       <description summary="restack the sub-surface">
-	This sub-surface is taken from the stack, and put back just
-	above the reference surface, changing the z-order of the sub-surfaces.
-	The reference surface must be one of the sibling surfaces, or the
-	parent surface. Using any other surface, including this sub-surface,
-	will cause a protocol error.
+        This sub-surface is taken from the stack, and put back just
+        above the reference surface, changing the z-order of the sub-surfaces.
+        The reference surface must be one of the sibling surfaces, or the
+        parent surface. Using any other surface, including this sub-surface,
+        will cause a protocol error.
 
-	The z-order is double-buffered. Requests are handled in order and
-	applied immediately to a pending state. The final pending state is
-	copied to the active state the next time the state of the parent
-	surface is applied.
+        A new sub-surface is initially added as the top-most in the stack
+        of its siblings and parent.
 
-	A new sub-surface is initially added as the top-most in the stack
-	of its siblings and parent.
+        Z-order is double-buffered state on the parent surface, see
+        wl_subsurface and wl_surface.commit for more information.
       </description>
       <arg name="sibling" type="object" interface="wl_surface"
-	   summary="the reference surface"/>
+           summary="the reference surface"/>
     </request>
 
     <request name="place_below">
       <description summary="restack the sub-surface">
-	The sub-surface is placed just below the reference surface.
-	See wl_subsurface.place_above.
+        The sub-surface is placed just below the reference surface.
+
+        See wl_subsurface.place_above.
       </description>
       <arg name="sibling" type="object" interface="wl_surface"
-	   summary="the reference surface"/>
+           summary="the reference surface"/>
     </request>
 
     <request name="set_sync">
       <description summary="set sub-surface to synchronized mode">
-	Change the commit behaviour of the sub-surface to synchronized
-	mode, also described as the parent dependent mode.
+        Change the commit behaviour of the sub-surface to synchronized
+        mode.
 
-	In synchronized mode, wl_surface.commit on a sub-surface will
-	accumulate the committed state in a cache, but the state will
-	not be applied and hence will not change the compositor output.
-	The cached state is applied to the sub-surface immediately after
-	the parent surface's state is applied. This ensures atomic
-	updates of the parent and all its synchronized sub-surfaces.
-	Applying the cached state will invalidate the cache, so further
-	parent surface commits do not (re-)apply old state.
-
-	See wl_subsurface for the recursive effect of this mode.
+        See wl_subsurface and wl_surface.commit for more information.
       </description>
     </request>
 
     <request name="set_desync">
       <description summary="set sub-surface to desynchronized mode">
-	Change the commit behaviour of the sub-surface to desynchronized
-	mode, also described as independent or freely running mode.
+        Change the commit behaviour of the sub-surface to desynchronized
+        mode.
 
-	In desynchronized mode, wl_surface.commit on a sub-surface will
-	apply the pending state directly, without caching, as happens
-	normally with a wl_surface. Calling wl_surface.commit on the
-	parent surface has no effect on the sub-surface's wl_surface
-	state. This mode allows a sub-surface to be updated on its own.
-
-	If cached state exists when wl_surface.commit is called in
-	desynchronized mode, the pending state is added to the cached
-	state, and applied as a whole. This invalidates the cache.
-
-	Note: even if a sub-surface is set to desynchronized, a parent
-	sub-surface may override it to behave as synchronized. For details,
-	see wl_subsurface.
-
-	If a surface's parent surface behaves as desynchronized, then
-	the cached state is applied on set_desync.
+        See wl_subsurface and wl_surface.commit for more information.
       </description>
     </request>
   </interface>
 
-  <interface name="wl_fixes" version="1">
+  <interface name="wl_fixes" version="2">
     <description summary="wayland protocol fixes">
       This global fixes problems with other core-protocol interfaces that
       cannot be fixed in these interfaces themselves.
     </description>
+
+    <enum name="error">
+      <description summary="wl_fixes error values">
+        These errors can be emitted in response to wl_fixes requests.
+      </description>
+      <entry name="invalid_ack_remove" value="0"
+             summary="unknown global or the global is not removed"/>
+    </enum>
 
     <request name="destroy" type="destructor">
       <description summary="destroys this object"/>
@@ -3281,18 +3394,48 @@
 
     <request name="destroy_registry">
       <description summary="destroy a wl_registry">
-	This request destroys a wl_registry object.
+        This request destroys a wl_registry object.
 
-	The client should no longer use the wl_registry after making this
-	request.
+        The client should no longer use the wl_registry after making this
+        request.
 
-	The compositor will emit a wl_display.delete_id event with the object ID
-	of the registry and will no longer emit any events on the registry. The
-	client should re-use the object ID once it receives the
-	wl_display.delete_id event.
+        The compositor will emit a wl_display.delete_id event with the object ID
+        of the registry and will no longer emit any events on the registry. The
+        client should re-use the object ID once it receives the
+        wl_display.delete_id event.
       </description>
       <arg name="registry" type="object" interface="wl_registry"
-	   summary="the registry to destroy"/>
+           summary="the registry to destroy"/>
+    </request>
+
+    <request name="ack_global_remove" since="2">
+      <description summary="acknowledge global removal">
+        Acknowledge the removal of the specified global.
+
+        If no global with the specified name exists or the global is not removed,
+        the wl_fixes.invalid_ack_remove protocol error will be posted.
+
+        Due to the Wayland protocol being asynchronous, the wl_global objects
+        cannot be destroyed immediately. For example, if a wl_global is removed
+        and a client attempts to bind that global around same time, it can
+        result in a protocol error due to an unknown global name in the bind
+        request.
+
+        In order to avoid crashing clients, the compositor should remove the
+        wl_global once it is guaranteed that no more bind requests will come.
+
+        The wl_fixes.ack_global_remove() request is used to signal to the
+        compositor that the client will not bind the given global anymore. After
+        all clients acknowledge the removal of the global, the compositor can
+        safely destroy it.
+
+        The client must call the wl_fixes.ack_global_remove() request in
+        response to a wl_registry.global_remove() event even if it did not bind
+        the corresponding global.
+      </description>
+      <arg name="registry" type="object" interface="wl_registry"
+           summary="the registry object"/>
+      <arg name="name" type="uint" summary="unique name of the global"/>
     </request>
   </interface>
 


### PR DESCRIPTION
The wl_fixes.ack_global_remove request signals the compositor that the client will not bind the removed global. It can be used by the compositor to decide when it is safe to actually destroy the corresponding global. If a global is destroyed too soon, some clients may get disconnected.

See also https://gitlab.freedesktop.org/wayland/wayland/-/merge_requests/533