### PR TITLE
SDL_dynapi.c: Unload other SDL library if initializing the jumptable fails

### DIFF
--- a/src/dynapi/SDL_dynapi.c
+++ b/src/dynapi/SDL_dynapi.c
@@ -448,17 +448,27 @@ Sint32 SDL_DYNAPI_entry(Uint32 apiver, void *table, Uint32 tablesize)
 }
 #endif
 
+// The handle to the other SDL library, loaded with SDL_DYNAMIC_API_ENVVAR
+#if defined(WIN32) || defined(_WIN32) || defined(SDL_PLATFORM_CYGWIN)
+static HMODULE lib = NULL;
+#elif defined(SDL_PLATFORM_UNIX) || defined(SDL_PLATFORM_APPLE) || defined(SDL_PLATFORM_HAIKU)
+static void *lib = NULL;
+#else
+#error Please define your platform.
+#endif
+
 // Obviously we can't use SDL_LoadObject() to load SDL.  :)
 // Also obviously, we never close the loaded library.
 #if defined(WIN32) || defined(_WIN32) || defined(SDL_PLATFORM_CYGWIN)
 static SDL_INLINE void *get_sdlapi_entry(const char *fname, const char *sym)
 {
-    HMODULE lib = LoadLibraryA(fname);
+    lib = LoadLibraryA(fname);
     void *result = NULL;
     if (lib) {
         result = (void *) GetProcAddress(lib, sym);
         if (!result) {
             FreeLibrary(lib);
+            lib = NULL;
         }
     }
     return result;
@@ -468,19 +478,17 @@ static SDL_INLINE void *get_sdlapi_entry(const char *fname, const char *sym)
 #include <dlfcn.h>
 static SDL_INLINE void *get_sdlapi_entry(const char *fname, const char *sym)
 {
-    void *lib = dlopen(fname, RTLD_NOW | RTLD_LOCAL);
+    lib = dlopen(fname, RTLD_NOW | RTLD_LOCAL);
     void *result = NULL;
     if (lib) {
         result = dlsym(lib, sym);
         if (!result) {
             dlclose(lib);
+            lib = NULL;
         }
     }
     return result;
 }
-
-#else
-#error Please define your platform.
 #endif
 
 static void dynapi_warn(const char *msg)
@@ -548,6 +556,16 @@ static void SDL_InitDynamicAPILocked(void)
     if (entry) {
         if (entry(SDL_DYNAPI_VERSION, &jump_table, sizeof(jump_table)) < 0) {
             dynapi_warn("Couldn't override SDL library. Using a newer SDL build might help. Please fix or remove the " SDL_DYNAMIC_API_ENVVAR " environment variable. Using the default SDL.");
+
+            // unload the other SDL library
+#if defined(WIN32) || defined(_WIN32) || defined(SDL_PLATFORM_CYGWIN)
+            FreeLibrary(lib);
+            lib = NULL;
+#elif defined(SDL_PLATFORM_UNIX) || defined(SDL_PLATFORM_APPLE) || defined(SDL_PLATFORM_HAIKU)
+            dlclose(lib);
+            lib = NULL;
+#endif
+
             // Just fill in the function pointers from this library, later.
         } else {
             use_internal = false; // We overrode SDL! Don't use the internal version!


### PR DESCRIPTION
When trying to load SDL via `SDL3_DYNAMIC_API` and this version is older(smaller jumptable or dynapi versions don't match) than the SDL version, the application was linked with at launch, the following message is printed:
```
SDL Dynamic API Failure!
Couldn't override SDL library. Using a newer SDL build might help. Please fix or remove the SDL3_DYNAMIC_API environment variable. Using the default SDL.
```
In this case the launch-SDL initializes itself.

But the other SDL library(the older one) doesn't get unloaded and still takes up a bit of memory (~600-800 KB (Debug type)).

This commit unloads the old library when this happens.

Example:
Link an app with the latest revision of SDL, and don't set `SDL3_DYNAMIC_API`, memory consumption is ~800 KB:
```bash
./a.out
```
Link an app with the latest revision of SDL, but load an older SDL via `SDL3_DYNAMIC_API`
The above error message is printed because it could not load the old SDL. The latest SDL lib revision is initialized.
, memory consumption is ~1.6 MB, because the old lib stays open:
```bash
SDL3_DYNAMIC_API="libSDL3.so.0.4.2" ./a.out
```

main.c:
```c
#include <SDL3/SDL.h>

#include <stdio.h>
#include <unistd.h>

int main(void)
{
    sleep(10); // delay to check memory consumption (before SDL jumptable is initialized, not important)
    
    int ver = SDL_GetVersion();
    
    printf("SDL version: %d.%d.%d\n", 
        SDL_VERSIONNUM_MAJOR(ver),
        SDL_VERSIONNUM_MINOR(ver),
        SDL_VERSIONNUM_MICRO(ver)
    );
    
    sleep(10); // delay to check memory consumption (after SDL jumptable is initialized, important !!)
    
    return 0;
}
```

-----

A different (but close-by) issue?/topic:
`SDL3_DYNAMIC_API` can have multiple entries for SDL libraries(separated by a comma),which will be tried one after the other.
The loop continues if it couldn't find a lib entry, couldn't open it, or it doesn't have the `SDL_DYNAPI_entry` symbol.
But if the jumptable fails to initialize, the loop stops and no later entries are tried.
Is this good enough or would it be better if the loop continues in this case and tries later entries too?