### PR TITLE
Android restore fullscreen after resume

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -1344,6 +1344,12 @@ int SDL_GetWindowDisplayMode(SDL_Window *window, SDL_DisplayMode *mode)
 
     display = SDL_GetDisplayForWindow(window);
 
+#ifdef __ANDROID__
+    /* Android does not support native resolution changes (SDL_WINDOW_FULLSCREEN) */
+    if((window->flags & FULLSCREEN_MASK) != 0) {
+        fullscreen_mode = display->desktop_mode;
+    }
+#else
     /* if in desktop size mode, just return the size of the desktop */
     if ((window->flags & SDL_WINDOW_FULLSCREEN_DESKTOP) == SDL_WINDOW_FULLSCREEN_DESKTOP) {
         fullscreen_mode = display->desktop_mode;
@@ -1353,6 +1359,7 @@ int SDL_GetWindowDisplayMode(SDL_Window *window, SDL_DisplayMode *mode)
         SDL_zerop(mode);
         return SDL_SetError("Couldn't find display mode match");
     }
+#endif
 
     *mode = fullscreen_mode;
 


### PR DESCRIPTION
## Description
Just a small fix to reapply the full screen mode after resuming if full screen flags are set.

Always had issues when android would send an window hide event to the sdl java activity which would then exit full screen mode and won't restore it after resuming.
