### PR TITLE
video: Handle error when binding EGL API in context creation

### DIFF
--- a/src/video/SDL_egl.c
+++ b/src/video/SDL_egl.c
@@ -1115,7 +1115,10 @@ SDL_GLContext SDL_EGL_CreateContext(SDL_VideoDevice *_this, EGLSurface egl_surfa
     } else {
         _this->egl_data->apitype = EGL_OPENGL_API;
     }
-    _this->egl_data->eglBindAPI(_this->egl_data->apitype);
+    if (!_this->egl_data->eglBindAPI(_this->egl_data->apitype)) {
+        SDL_SetError("Could not bind EGL API");
+        return NULL;
+    }
 
     egl_context = _this->egl_data->eglCreateContext(_this->egl_data->egl_display,
                                                     _this->egl_data->egl_config,


### PR DESCRIPTION
eglBindAPI(EGL_OPENGL_API) can fail on GLES-only drivers (e.g. libmali)
that do not support desktop OpenGL.  Without checking the return value,
SDL proceeds to create what it thinks is a desktop GL context (but is
actually GLES), then crashes when calling desktop GL functions on it.

Check the return value and fail early so the renderer fallback logic can
try the next backend (opengles2).
