### PR TITLE
SDL_systhread.c: Do not block SIGCHLD during thread creation as it might break SDL_CreateProcess logic.

### DIFF
--- a/src/thread/pthread/SDL_systhread.c
+++ b/src/thread/pthread/SDL_systhread.c
@@ -60,7 +60,7 @@
 #ifdef HAVE_SIGNAL_H
 // List of signals to mask in the subthreads
 static const int sig_list[] = {
-    SIGHUP, SIGINT, SIGQUIT, SIGPIPE, SIGALRM, SIGTERM, SIGCHLD, SIGWINCH,
+    SIGHUP, SIGINT, SIGQUIT, SIGPIPE, SIGALRM, SIGTERM, SIGWINCH,
     SIGVTALRM, SIGPROF, 0
 };
 #endif


### PR DESCRIPTION
When CMake build is executed through `SDL_CreateProcess` call from the thread created using `SDL_CreateThread` (execution from the main thread works fine), it would get stuck and never exit after executing all the build commands. `SDL_CreateThread` blocks `SIGCHLD` signal while `SDL_CreateProcessWithProperties` docs say that `SIGCHLD` should not be ignored or handled because this would prevent SDL from properly tracking the lifetime of the underlying process. I guess, `SIGCHLD` block breaks lifetime tracking not only in SDL, but in CMake as well. I removed `SIGCHLD` from blocked list and the issue has disappeared for me.

## Description

As described in #15210, I encountered the above error with CMake while refactoring hot reload on my pet project. I also provided minimal reproduction example in that issue in [second comment](https://github.com/libsdl-org/SDL/issues/15210#issuecomment-4061691561). This issue seemed to be ignored, therefore I decided to check signal handling in `SDL_CreateThread` myself and discovered that `SIGCHLD` is blocked. I removed it from blocked list and that fixed the behavior on minimal reproduction example. It also didn't break anything in my pet project where I'm using `SDL_CreateProcess` to run CMake, kritarunner and patchelf.

Therefore, I decided that `SIGCHLD` might be blocked by mistake and it is worth to open pull request about it to at least start the discussion.

## Existing Issue(s)

#15210
