### PR TITLE
[Feature] dynapi: Change SDL dynapi library without restarting the app

### DIFF
--- a/src/dynapi/SDL_dynapi.c
+++ b/src/dynapi/SDL_dynapi.c
@@ -248,15 +248,24 @@ static SDL_DYNAPI_jump_table jump_table = {
 #undef SDL_DYNAPI_PROC_NO_VARARGS
 SDL_DYNAPI_VARARGS(static, _DEFAULT, SDL_InitDynamicAPI())
 
+static void SDL_UnloadDynamicAPI(void);
+
 // Public API functions to jump into the jump table.
 #define SDL_DYNAPI_PROC(rc, fn, params, args, ret) \
     rc SDLCALL fn params                           \
     {                                              \
         ret jump_table.fn args;                    \
     }
+#define SDL_DYNAPI_PROC_SDL_Quit(rc, fn, params, args, ret) \
+    rc SDLCALL fn params                                    \
+    {                                                       \
+        jump_table.fn args;                                 \
+        SDL_UnloadDynamicAPI();                             \
+    }
 #define SDL_DYNAPI_PROC_NO_VARARGS 1
 #include "SDL_dynapi_procs.h"
 #undef SDL_DYNAPI_PROC
+#undef SDL_DYNAPI_PROC_SDL_Quit
 #undef SDL_DYNAPI_PROC_NO_VARARGS
 SDL_DYNAPI_VARARGS(, , )
 

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -722,7 +722,11 @@ SDL_DYNAPI_PROC(void,SDL_PushGPUFragmentUniformData,(SDL_GPUCommandBuffer *a, Ui
 SDL_DYNAPI_PROC(void,SDL_PushGPUVertexUniformData,(SDL_GPUCommandBuffer *a, Uint32 b, const void *c, Uint32 d),(a,b,c,d),)
 SDL_DYNAPI_PROC(bool,SDL_PutAudioStreamData,(SDL_AudioStream *a, const void *b, int c),(a,b,c),return)
 SDL_DYNAPI_PROC(bool,SDL_QueryGPUFence,(SDL_GPUDevice *a, SDL_GPUFence *b),(a,b),return)
+#ifdef SDL_DYNAPI_PROC_SDL_Quit
+SDL_DYNAPI_PROC_SDL_Quit(void,SDL_Quit,(void),(),)
+#else
 SDL_DYNAPI_PROC(void,SDL_Quit,(void),(),)
+#endif
 SDL_DYNAPI_PROC(void,SDL_QuitSubSystem,(SDL_InitFlags a),(a),)
 SDL_DYNAPI_PROC(bool,SDL_RaiseWindow,(SDL_Window *a),(a),return)
 SDL_DYNAPI_PROC(size_t,SDL_ReadIO,(SDL_IOStream *a, void *b, size_t c),(a,b,c),return)


### PR DESCRIPTION
It would be nice, if a different SDL version could be loaded without restarting the app by changing  `SDL3_DYNAMIC_API` and just reinitializing SDL.

What the commits do:
- At the end of the SDL_Quit() public API function, the dynapi jump table is reset and the SDL library unloaded.
- This has the effect that the next call to an SDL function can reload another SDL library.

Risk: Thread safety. No other thread, which calls SDL functions, should be running.

Tested by applying following patch to the 3.4.x branch (7b7322b2221ff551f8a11fb0d7a37fff3f29584c) and trying to load the newest main revision:
<details><summary>3.4.x test patch (same changes but for 3.4.x)</summary>
<p>

3.4.x `git diff`:
```diff
diff --git a/src/dynapi/SDL_dynapi.c b/src/dynapi/SDL_dynapi.c
index 495a8e5..5c954b6 100644
--- a/src/dynapi/SDL_dynapi.c
+++ b/src/dynapi/SDL_dynapi.c
@@ -247,15 +247,24 @@ static SDL_DYNAPI_jump_table jump_table = {
 #undef SDL_DYNAPI_PROC_NO_VARARGS
 SDL_DYNAPI_VARARGS(static, _DEFAULT, SDL_InitDynamicAPI())
 
+static void SDL_UnloadDynamicAPI(void);
+
 // Public API functions to jump into the jump table.
 #define SDL_DYNAPI_PROC(rc, fn, params, args, ret) \
     rc SDLCALL fn params                           \
     {                                              \
         ret jump_table.fn args;                    \
     }
+#define SDL_DYNAPI_PROC_SDL_Quit(rc, fn, params, args, ret) \
+    rc SDLCALL fn params                                    \
+    {                                                       \
+        jump_table.fn args;                                 \
+        SDL_UnloadDynamicAPI();                             \
+    }
 #define SDL_DYNAPI_PROC_NO_VARARGS 1
 #include "SDL_dynapi_procs.h"
 #undef SDL_DYNAPI_PROC
+#undef SDL_DYNAPI_PROC_SDL_Quit
 #undef SDL_DYNAPI_PROC_NO_VARARGS
 SDL_DYNAPI_VARARGS(, , )
 
@@ -448,16 +457,26 @@ Sint32 SDL_DYNAPI_entry(Uint32 apiver, void *table, Uint32 tablesize)
 #endif
 
 // Obviously we can't use SDL_LoadObject() to load SDL.  :)
-// Also obviously, we never close the loaded library.
+// Also obviously, we never close the loaded library, once we accept it.
 #if defined(WIN32) || defined(_WIN32) || defined(SDL_PLATFORM_CYGWIN)
+static HMODULE sdlapi_lib = NULL;  // The handle to the other SDL library, loaded with SDL_DYNAMIC_API_ENVVAR
+
+static SDL_INLINE void unload_sdlapi_library(void)
+{
+    if (sdlapi_lib) {
+        FreeLibrary(sdlapi_lib);
+        sdlapi_lib = NULL;
+    }
+}
+
 static SDL_INLINE void *get_sdlapi_entry(const char *fname, const char *sym)
 {
-    HMODULE lib = LoadLibraryA(fname);
+    sdlapi_lib = LoadLibraryA(fname);
     void *result = NULL;
-    if (lib) {
-        result = (void *) GetProcAddress(lib, sym);
+    if (sdlapi_lib) {
+        result = (void *) GetProcAddress(sdlapi_lib, sym);
         if (!result) {
-            FreeLibrary(lib);
+            unload_sdlapi_library();
         }
     }
     return result;
@@ -465,14 +484,24 @@ static SDL_INLINE void *get_sdlapi_entry(const char *fname, const char *sym)
 
 #elif defined(SDL_PLATFORM_UNIX) || defined(SDL_PLATFORM_APPLE) || defined(SDL_PLATFORM_HAIKU)
 #include <dlfcn.h>
+static void *sdlapi_lib = NULL;  // The handle to the other SDL library, loaded with SDL_DYNAMIC_API_ENVVAR
+
+static SDL_INLINE void unload_sdlapi_library(void)
+{
+    if (sdlapi_lib) {
+        dlclose(sdlapi_lib);
+        sdlapi_lib = NULL;
+    }
+}
+
 static SDL_INLINE void *get_sdlapi_entry(const char *fname, const char *sym)
 {
-    void *lib = dlopen(fname, RTLD_NOW | RTLD_LOCAL);
+    sdlapi_lib = dlopen(fname, RTLD_NOW | RTLD_LOCAL);
     void *result = NULL;
-    if (lib) {
-        result = dlsym(lib, sym);
+    if (sdlapi_lib) {
+        result = dlsym(sdlapi_lib, sym);
         if (!result) {
-            dlclose(lib);
+            unload_sdlapi_library();
         }
     }
     return result;
@@ -568,6 +597,9 @@ static void SDL_InitDynamicAPILocked(void)
     // we intentionally never close the newly-loaded lib, of course.
 }
 
+static bool already_initialized = false;
+static SDL_SpinLock lock = 0;
+
 static void SDL_InitDynamicAPI(void)
 {
     /* So the theory is that every function in the jump table defaults to
@@ -581,9 +613,7 @@ static void SDL_InitDynamicAPI(void)
      *  SDL_CreateThread() would also call this function before building the
      *  new thread).
      */
-    static bool already_initialized = false;
 
-    static SDL_SpinLock lock = 0;
     SDL_LockSpinlock_REAL(&lock);
 
     if (!already_initialized) {
@@ -594,6 +624,28 @@ static void SDL_InitDynamicAPI(void)
     SDL_UnlockSpinlock_REAL(&lock);
 }
 
+static void SDL_UnloadDynamicAPILocked(void)
+{
+    // reset jump table
+#define SDL_DYNAPI_PROC(rc, fn, params, args, ret) jump_table.fn = fn##_DEFAULT;
+#include "SDL_dynapi_procs.h"
+#undef SDL_DYNAPI_PROC
+    
+    unload_sdlapi_library();
+}
+
+static void SDL_UnloadDynamicAPI(void)
+{
+    SDL_LockSpinlock_REAL(&lock);
+
+    if (already_initialized) {
+        SDL_UnloadDynamicAPILocked();
+        already_initialized = false;
+    }
+
+    SDL_UnlockSpinlock_REAL(&lock);
+}
+
 #else // SDL_DYNAMIC_API
 
 #include <SDL3/SDL.h>
diff --git a/src/dynapi/SDL_dynapi_procs.h b/src/dynapi/SDL_dynapi_procs.h
index 9f28b68..fb8d516 100644
--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -722,7 +722,11 @@ SDL_DYNAPI_PROC(void,SDL_PushGPUFragmentUniformData,(SDL_GPUCommandBuffer *a, Ui
 SDL_DYNAPI_PROC(void,SDL_PushGPUVertexUniformData,(SDL_GPUCommandBuffer *a, Uint32 b, const void *c, Uint32 d),(a,b,c,d),)
 SDL_DYNAPI_PROC(bool,SDL_PutAudioStreamData,(SDL_AudioStream *a, const void *b, int c),(a,b,c),return)
 SDL_DYNAPI_PROC(bool,SDL_QueryGPUFence,(SDL_GPUDevice *a, SDL_GPUFence *b),(a,b),return)
+#ifdef SDL_DYNAPI_PROC_SDL_Quit
+SDL_DYNAPI_PROC_SDL_Quit(void,SDL_Quit,(void),(),)
+#else
 SDL_DYNAPI_PROC(void,SDL_Quit,(void),(),)
+#endif
 SDL_DYNAPI_PROC(void,SDL_QuitSubSystem,(SDL_InitFlags a),(a),)
 SDL_DYNAPI_PROC(bool,SDL_RaiseWindow,(SDL_Window *a),(a),return)
 SDL_DYNAPI_PROC(size_t,SDL_ReadIO,(SDL_IOStream *a, void *b, size_t c),(a,b,c),return)

```

</p>
</details> 

-----

## Test code:

In the code the `SDL3_DYNAMIC_API` environment variable is changed to `"libSDL3.so.0.5.0"` after the SDL library already loaded.
Then SDL restarts(SDL_Quit/SD_Init) and it is checked if the version from the environment variable was loaded.

`main.c`:
```c
#include <SDL3/SDL.h>

#include <stdio.h>
#include <unistd.h>

void print_sdl_version(void)
{
    int version = SDL_GetVersion();
    
    printf("SDL version: %d.%d.%d\n", 
        SDL_VERSIONNUM_MAJOR(version),
        SDL_VERSIONNUM_MINOR(version),
        SDL_VERSIONNUM_MICRO(version)
    );
}

int main(void)
{
    SDL_Init(0);
    printf("SDL3_DYNAMIC_API = \"%s\"\n", SDL_getenv_unsafe("SDL3_DYNAMIC_API"));
    print_sdl_version();
    SDL_setenv_unsafe("SDL3_DYNAMIC_API", "libSDL3.so.0.5.0", 1); // "libSDL3.so.0.5.0" is the SDL lib name on Linux
    SDL_Quit();
    
    SDL_Init(0);
    printf("SDL3_DYNAMIC_API = \"%s\"\n", SDL_getenv_unsafe("SDL3_DYNAMIC_API"));
    print_sdl_version();
    SDL_Quit();
    
    return 0;
}
```

### Before change
- build `main.c` and link it against the unpatched SDL 3.4.x lib
- Run it: `LD_LIBRARY_PATH="/path/to/SDL-3.4.x/lib/dir" ./a.out`:
Output:
```
SDL3_DYNAMIC_API: "(null)"
SDL version: 3.4.3
SDL3_DYNAMIC_API: "libSDL3.so.0.5.0"
SDL version: 3.4.3
```
SDL versions did not change.

### After change:
- build `main.c` and link it against the patched SDL 3.4.x lib
- Run it: `LD_LIBRARY_PATH="/path/to/SDL-3.4.x/lib/dir" ./a.out`:
Output:
```
SDL3_DYNAMIC_API: "(null)"
SDL version: 3.4.3
SDL3_DYNAMIC_API: "libSDL3.so.0.5.0"
SDL version: 3.5.0
```
SDL version changed.