### PR TITLE
bugs: Initial attempt at auto-bugreporting.

### DIFF
--- a/src/SDL_utils.c
+++ b/src/SDL_utils.c
@@ -583,9 +583,80 @@ char *SDL_CreateDeviceName(Uint16 vendor, Uint16 product, const char *vendor_nam
     return name;
 }
 
+static char *initialized_backends = NULL;
 
 void SDL_DebugLogBackend(const char *subsystem, const char *backend)
 {
     SDL_LogDebug(SDL_LOG_CATEGORY_SYSTEM, "SDL chose %s backend '%s'", subsystem, backend);
+    char *newstr = NULL;
+    if (SDL_asprintf(&newstr, "%s%s%s=%s", initialized_backends ? initialized_backends : "", initialized_backends ? ", " : "", subsystem, backend) > 0) {
+        SDL_free(initialized_backends);
+        initialized_backends = newstr;
+    }
+    // !!! FIXME: free this string on SDL_Quit.
 }
+
+
+#define BUGREPORT_URL_BASE "https://github.com/libsdl-org/SDL/issues/new/?body="
+
+static char *URLEncode(const char *base, const char *url)
+{
+    const size_t slen = SDL_strlen(base) + (SDL_strlen(url) * 3) + 1;
+    char *retval = SDL_malloc(slen);
+    if (retval) {
+        char *ptr = retval + SDL_strlcpy(retval, base, slen);
+        while (*url) {
+            const char ch = *(url++);
+            // RFC 3986 section 2.3 Unreserved Characters (don't percent-encode these).
+            if ( ((ch >= 'a') && (ch <= 'z')) || ((ch >= 'A') && (ch <= 'Z')) || ((ch >= '0') && (ch <= '9')) || (ch == '-') || (ch == '.') || (ch == '_') || (ch == '~') ) {
+                *(ptr++) = ch;
+            } else if (ch == ' ') {
+                *(ptr++) = '+';
+            } else {  // encode everything else (multiple bytes in a UTF-8 codepoint will encode byte-by-byte).
+                ptr += SDL_snprintf(ptr, 4, "%%%02X", (unsigned int) ch);
+            }
+            SDL_assert(((size_t)(ptr - retval)) < slen);
+        }
+        *ptr = '\0';
+    }
+    return retval;
+}
+
+bool SDL_LaunchBugReportURL(void)
+{
+    const int version = SDL_GetVersion();
+    char *body = NULL;
+    const int rc = SDL_asprintf(&body,
+        "Some info about my system:\n"
+        "- SDL version: %d.%d.%d\n"
+        "- SDL revision: %s\n"
+        "- App id: %s\n"
+        "- App version: %s\n"
+        "- App url: %s\n"
+        "- platform: %s\n"
+        //!!! FIXME: processor type, HasSSE, etc. "cpuinfo: %s\n"
+        "- backends: %s\n"
+        "----\n\n"
+        "(Please report your SDL bug here!)",
+            SDL_VERSIONNUM_MAJOR(version), SDL_VERSIONNUM_MINOR(version), SDL_VERSIONNUM_MICRO(version),
+            SDL_GetRevision(),
+            SDL_GetAppMetadataProperty(SDL_PROP_APP_METADATA_IDENTIFIER_STRING),
+            SDL_GetAppMetadataProperty(SDL_PROP_APP_METADATA_VERSION_STRING),
+            SDL_GetAppMetadataProperty(SDL_PROP_APP_METADATA_URL_STRING),
+            SDL_GetPlatform(),  // !!! FIXME: this is just SDL's hardcoded thing, a better platform string ("Windows 11" verses "windows") would be good.
+            // !!! FIXME: CPU info.
+            initialized_backends ? initialized_backends : "(none)"
+    );
+
+    if (rc < 0) {
+        return false;
+    }
+    char *url = URLEncode(BUGREPORT_URL_BASE, body);
+    SDL_free(body);
+    SDL_Log("Launching bug report URL! Go here if this doesn't work: %s", url);
+    const bool retval = SDL_OpenURL(url);
+    SDL_free(url);
+    return retval;
+}
+
 

--- a/src/SDL_utils_c.h
+++ b/src/SDL_utils_c.h
@@ -93,6 +93,10 @@ extern char *SDL_CreateDeviceName(Uint16 vendor, Uint16 product, const char *ven
 // Log what backend a subsystem chose, if a hint was set to do so. Useful for debugging.
 extern void SDL_DebugLogBackend(const char *subsystem, const char *backend);
 
+// Launch a web browser to our bug tracker with some end-user info automatically added to the bug report.
+bool SDL_LaunchBugReportURL(void);
+
+
 #ifdef SDL_PLATFORM_EMSCRIPTEN
 // even though we reference the C runtime's free() in other places, it appears
 // to be inlined more aggressively in Emscripten 4, so we need a reference to

--- a/src/events/SDL_keyboard.c
+++ b/src/events/SDL_keyboard.c
@@ -627,6 +627,24 @@ static bool SDL_SendKeyboardKeyInternal(Uint64 timestamp, Uint32 flags, SDL_Keyb
         }
     }
 
+    static bool check_for_bugreport_cheatcode = true;
+    if (check_for_bugreport_cheatcode && (SDL_GetTicks() > 10000)) {
+        check_for_bugreport_cheatcode = false;  // stop checking for this after 10 seconds of uptime.
+    }
+    if (down && check_for_bugreport_cheatcode) {
+        static const char *bugreport_cheatcode = "sdlbug";
+        static int cheatcode_index = 0;
+        if (((SDL_Keycode) bugreport_cheatcode[cheatcode_index]) != keycode) {
+            cheatcode_index = 0;
+        } else {
+            cheatcode_index++;
+            if (bugreport_cheatcode[cheatcode_index] == '\0') {
+                check_for_bugreport_cheatcode = false;  // don't check again after we've launched.
+                SDL_LaunchBugReportURL();
+            }
+        }
+    }
+
     // Post the event, if desired
     if (SDL_EventEnabled(type)) {
         SDL_Event event;


### PR DESCRIPTION
I made this smart-aleck comment in https://github.com/libsdl-org/SDL/issues/15244#issuecomment-4107291847 ...

> Hell, can we add a thing where it just launches a pre-filled bug report if you start any SDL program while holding down a weird key combo? :)

And thought, okay, why not?

This PR makes it so if a user types "sdlbug" into any SDL app within the first 10 seconds of its run, it'll launch a web browser to the issue tracker with some data we're likely going to ask for, prefilled. The idea is the bug template could just tell people to do that instead of telling them to enter all that info (possibly incorrectly) by hand.

In practice, it opens a link like [this](https://github.com/libsdl-org/SDL/issues/new/?body=Some+info+about+my+system%3A%0A-+SDL+version%3A+3.5.0%0A-+SDL+revision%3A+SDL-3.5.0-release-3.4.0-445-g55fa5e033%0A-+App+id%3A+org.libsdl.testaudio%0A-+App+version%3A+3.5.0%0A-+App+url%3A+%28null%29%0A-+platform%3A+Linux%0A-+backends%3A+video%3Dx11%2C+gpu%3Dvulkan%2C+render%3Dgpu%2C+audio%3Dpipewire%0A----%0A%0A%28Please+report+your+SDL+bug+here%21%29).

This PR needs work (more useful info should be posted, there's a small memory leak, etc), but also this might be absolutely the stupidest idea I've ever had, so I'll wait for feedback to see if it's worth spending more time on it.