### PR TITLE
render: Skip UV check when software-rendering untextured quads

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -5163,7 +5163,7 @@ static bool SDLCALL SDL_SW_RenderGeometryRaw(SDL_Renderer *renderer,
         }
 
         // Check if UVs within range
-        if (is_quad) {
+        if (is_quad && uv) {
             const float *uv0_ = (const float *)((const char *)uv + A * color_stride);
             const float *uv1_ = (const float *)((const char *)uv + B * color_stride);
             const float *uv2_ = (const float *)((const char *)uv + C * color_stride);


### PR DESCRIPTION
Fixes a crash when calling SDL_RenderGeometryRaw() with both `texture` and `uv` set to `NULL`, and with geometry that is laid out in a way that passes the quad checks.

To reproduce the crash, edit `examples/renderer/10-geometry/geometry.c` like this and then run with `SDL_RENDER_DRIVER=software`:

```diff
-    const int indices[] = { 0, 1, 2, 1, 2, 3 };
-    SDL_RenderGeometry(renderer, texture, vertices, 4, indices, SDL_arraysize(indices));
+    const int indices[] = { 0, 1, 3, 0, 2, 3 };
+    const float *xy = &vertices->position.x;
+    int xy_stride = sizeof(SDL_Vertex);
+    const SDL_FColor *color = &vertices->color;
+    int color_stride = sizeof(SDL_Vertex);
+    int size_indices = 4;
+    SDL_RenderGeometryRaw(renderer, NULL, xy, xy_stride, color, color_stride, NULL, 0, 4, indices, SDL_arraysize(indices), size_indices);
```