### PR TITLE
Fix DirectSound buffer creation failure with >200kHz

### DIFF
--- a/src/audio/directsound/SDL_directsound.c
+++ b/src/audio/directsound/SDL_directsound.c
@@ -545,6 +545,7 @@ static bool DSOUND_OpenDevice(SDL_AudioDevice *device)
             tried_format = true;
 
             device->spec.format = test_format;
+            device->spec.freq = SDL_min(200000, device->spec.freq); // DirectSound has an arbitrary limit of 200,000Hz.
 
             // Update the fragment size as size in bytes
             SDL_UpdatedAudioDeviceFormat(device);


### PR DESCRIPTION
Caps the sample rate at 200kHz so that SDL's mixer will downsample any streams which are higher than that.

My Mega Drive emulator outputs at 223721Hz (the sample rate of the PSG chip), and `SDL_OpenAudioDeviceStream` fails due to DirectSound's `CreateSoundBuffer` returning an 'invalid parameter' error code. Lowering the sample rate makes the error go away.

Reported to me by @B3HKO in this issue:
https://github.com/Clownacy/clownmdemu-frontend/issues/60

The 200kHz limit is documented here:
https://learn.microsoft.com/en-us/previous-versions/windows/desktop/ee419022(v=vs.85)

DirectSound's Wikipedia article mentions that problems may occur with sample rates above 192kHz, but no source is provided, so I am unsure whether to take it seriously.