### PR TITLE
Use DSBFREQUENCY_MAX instead of magic number for DirectSound max sample rate.

### DIFF
--- a/src/audio/directsound/SDL_directsound.c
+++ b/src/audio/directsound/SDL_directsound.c
@@ -545,7 +545,7 @@ static bool DSOUND_OpenDevice(SDL_AudioDevice *device)
             tried_format = true;
 
             device->spec.format = test_format;
-            device->spec.freq = SDL_min(200000, device->spec.freq); // DirectSound has an arbitrary limit of 200,000Hz.
+            device->spec.freq = SDL_min(DSBFREQUENCY_MAX, device->spec.freq);
 
             // Update the fragment size as size in bytes
             SDL_UpdatedAudioDeviceFormat(device);


### PR DESCRIPTION
Corrects the maximum sample rate for the DirectSound driver to use DSBFREQUENCY_MAX instead of a hardcoded constant.

The maximum frequency in DirectSound was changed from DirectSound 8.0 to 9.0 ([documented here](https://learn.microsoft.com/en-us/previous-versions/windows/desktop/ee419022(v=vs.85))) from 100khz to 200khz. In the dsound header, DSBFREQUENCY_MAX is defined as following:
```cpp
#if DIRECTSOUND_VERSION >= 0x0900
#define DSBFREQUENCY_MAX            200000
#else
#define DSBFREQUENCY_MAX            100000
#endif
```

While 200,000khz works on the current version of DirectSound provided by Windows, SDL3 currently targets DirectSound 8.0, as defined here:
https://github.com/libsdl-org/SDL/blob/6efe0e19a7c9f41988615a84341038de34af674e/src/core/windows/SDL_directx.h#L94

This addresses a concern of mine from PR #15265 here:
https://github.com/libsdl-org/SDL/pull/15265#issuecomment-4130607226