### PR TITLE
SDL2: Limit DirectSound maximum sample rate

### DIFF
--- a/src/audio/directsound/SDL_directsound.c
+++ b/src/audio/directsound/SDL_directsound.c
@@ -526,6 +526,7 @@ static int DSOUND_OpenDevice(_THIS, const char *devname)
             tried_format = SDL_TRUE;
 
             this->spec.format = test_format;
+            this->spec.freq = SDL_min(DSBFREQUENCY_MAX, this->spec.freq);
 
             /* Update the fragment size as size in bytes */
             SDL_CalculateAudioSpec(&this->spec);
@@ -580,7 +581,7 @@ static int DSOUND_OpenDevice(_THIS, const char *devname)
                 }
 
                 wfmt.Format.wBitsPerSample = SDL_AUDIO_BITSIZE(this->spec.format);
-                wfmt.Format.nChannels = this->spec.channels;
+                wfmt.Format.nChannels = (WORD)this->spec.channels;
                 wfmt.Format.nSamplesPerSec = this->spec.freq;
                 wfmt.Format.nBlockAlign = wfmt.Format.nChannels * (wfmt.Format.wBitsPerSample / 8);
                 wfmt.Format.nAvgBytesPerSec = wfmt.Format.nSamplesPerSec * wfmt.Format.nBlockAlign;


### PR DESCRIPTION
Limits the maximum sample rate for DirectSound audio to DSBFREQUENCY_MAX, as otherwise the sound buffer will fail to be created ([documented here](https://learn.microsoft.com/en-us/previous-versions/windows/desktop/mt708937(v=vs.85)), [reported here](https://github.com/Clownacy/clownmdemu-frontend/issues/60)).

The exact maximum frequency depends on the version of DirectSound being targeted, which is currently defined as DirectSound 8.0 in SDL2:
https://github.com/libsdl-org/SDL/blob/3debb9e2bb583c54755afc8ce66799c441981575/src/core/windows/SDL_directx.h#L94

This PR is the same as #15266 and #15265 from the SDL3 branch.
