### PR TITLE
vulkan: undo extra yv12 chroma plane flip

### DIFF
--- a/src/render/vulkan/SDL_render_vulkan.c
+++ b/src/render/vulkan/SDL_render_vulkan.c
@@ -2980,11 +2980,7 @@ static bool VULKAN_UpdateTexture(SDL_Renderer *renderer, SDL_Texture *texture,
         const Uint8 *plane1 = plane0 + rect->h * Ypitch;
         const Uint8 *plane2 = plane1 + ((rect->h + 1) / 2) * UVpitch;
 
-        if (texture->format == SDL_PIXELFORMAT_YV12) {
-            return VULKAN_UpdateTextureYUV(renderer, texture, rect, plane0, Ypitch, plane2, UVpitch, plane1, UVpitch);
-        } else {
-            return VULKAN_UpdateTextureYUV(renderer, texture, rect, plane0, Ypitch, plane1, UVpitch, plane2, UVpitch);
-        }
+        return VULKAN_UpdateTextureYUV(renderer, texture, rect, plane0, Ypitch, plane1, UVpitch, plane2, UVpitch);
     }
 #endif
     if (!VULKAN_UpdateTextureInternal(rendererData, textureData->mainImage.image, textureData->mainImage.format, 0, rect->x, rect->y, rect->w, rect->h, srcPixels, srcPitch, &textureData->mainImage.imageLayout)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
While doing some manual code review, looking for #13878, I noticed that YV12 had their chroma planes flipped twice, undoing the flip.


## Description
~`VULKAN_UpdateTexture()` passes the planes to `VULKAN_UpdateTextureYUV()` already flipped. So I remove the second flip.~
`VULKAN_UpdateTextureYUV()` is used in multiple places, so I removed the flip from `VULKAN_UpdateTexture()`.

Due to #13878 I cant test this for correctness.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
Did not see any.