### PR TITLE
Prevent DWM debug spam on Windows 10

### DIFF
--- a/src/video/windows/SDL_windowswindow.c
+++ b/src/video/windows/SDL_windowswindow.c
@@ -1227,7 +1227,7 @@ static void WIN_UpdateCornerRoundingForHWND(SDL_VideoDevice *_this, HWND hwnd, D
 {
 #if !defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES)
     SDL_VideoData *videodata = _this->internal;
-    if (videodata->DwmSetWindowAttribute) {
+    if (videodata->DwmSetWindowAttribute && WIN_IsWindows11OrGreater()) {
         videodata->DwmSetWindowAttribute(hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, &cornerPref, sizeof(cornerPref));
     }
 #endif
@@ -1237,7 +1237,7 @@ static void WIN_UpdateBorderColorForHWND(SDL_VideoDevice *_this, HWND hwnd, COLO
 {
 #if !defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES)
     SDL_VideoData *videodata = _this->internal;
-    if (videodata->DwmSetWindowAttribute) {
+    if (videodata->DwmSetWindowAttribute && WIN_IsWindows11OrGreater()) {
         videodata->DwmSetWindowAttribute(hwnd, DWMWA_BORDER_COLOR, &colorRef, sizeof(colorRef));
     }
 #endif


### PR DESCRIPTION
When calling `SDL_SetWindowFullscreen` on Windows 10 the debug console gets spammed with internal DWM warnings:
```
clientcore\windows\dwm\dwmapi\attribute.cpp(185)\DWMAPI.DLL!00007FFF83253827: (caller: 00007FFF3288196E) ReturnHr(1) tid(d14) 80070057 The parameter is incorrect.
clientcore\windows\dwm\dwmapi\attribute.cpp(185)\DWMAPI.DLL!00007FFF83253827: (caller: 00007FFF328819CE) ReturnHr(2) tid(d14) 80070057 The parameter is incorrect.
```
This happens because the DWM attributes `DWMWA_WINDOW_CORNER_PREFERENCE` and `DWMWA_BORDER_COLOR` were introduced in Windows 11.