### PR TITLE
x11: Look for text/uri-list in the list of MIME types more thoroughly

### DIFF
--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -122,15 +122,19 @@ static void X11_ReadProperty(SDL_x11Prop *p, Display *disp, Window w, Atom prop)
    if available, else return None */
 static Atom X11_PickTarget(Display *disp, Atom list[], int list_count)
 {
+    const Atom text_uri_request = X11_XInternAtom(disp, "text/uri-list", False);
     Atom request = None;
-    char *name;
-    int i;
-    for (i = 0; i < list_count && request == None; i++) {
-        name = X11_XGetAtomName(disp, list[i]);
+    Atom preferred = None;
+
+    for (int i = 0; i < list_count && request != text_uri_request; i++) {
+        char *name = X11_XGetAtomName(disp, list[i]);
         // Preferred MIME targets
         if ((SDL_strcmp("text/uri-list", name) == 0) ||
             (SDL_strcmp("text/plain;charset=utf-8", name) == 0) ||
             (SDL_strcmp("UTF8_STRING", name) == 0)) {
+            if (preferred == None) {
+                preferred = list[i];
+            }
             request = list[i];
         }
         // Fallback MIME targets
@@ -141,6 +145,11 @@ static Atom X11_PickTarget(Display *disp, Atom list[], int list_count)
             }
         }
         X11_XFree(name);
+    }
+
+    // The type 'text/uri-list' is preferred over all others.
+    if (preferred != None && request != text_uri_request) {
+        request = preferred;
     }
     return request;
 }


### PR DESCRIPTION
A uri-list of files is the preferred format, so don't bail if a preferred text format is encountered first.

Fixes #15047
