### PR TITLE
iOS: Fix SDL_EVENT_DROP_FILE lost on cold start from URL open

### DIFF
--- a/src/video/uikit/SDL_uikitappdelegate.m
+++ b/src/video/uikit/SDL_uikitappdelegate.m
@@ -352,6 +352,7 @@ API_AVAILABLE(ios(13.0))
 @implementation SDLUIKitSceneDelegate
 {
     UIWindow *launchWindow;
+    NSMutableArray<NSURL *> *launchURLs;
 }
 
 + (NSString *)getSceneDelegateClassName
@@ -411,15 +412,16 @@ API_AVAILABLE(ios(13.0))
     // Set working directory to resource path
     [[NSFileManager defaultManager] changeCurrentDirectoryPath:[bundle resourcePath]];
 
-    // Handle any connection options (like opening URLs)
+    launchURLs = [[NSMutableArray alloc] init];
+
     for (NSUserActivity *activity in connectionOptions.userActivities) {
         if (activity.webpageURL) {
-            [self handleURL:activity.webpageURL];
+            [launchURLs addObject:activity.webpageURL];
         }
     }
 
     for (UIOpenURLContext *urlContext in connectionOptions.URLContexts) {
-        [self handleURL:urlContext.URL];
+        [launchURLs addObject:urlContext.URL];
     }
 
     SDL_SetMainReady();
@@ -488,6 +490,7 @@ API_AVAILABLE(ios(13.0))
 - (void)postFinishLaunch
 {
     [self performSelector:@selector(hideLaunchScreen) withObject:nil afterDelay:0.0];
+    [self performSelector:@selector(processLaunchURLs) withObject:nil afterDelay:0.0];
 
     SDL_SetiOSEventPump(true);
     exit_status = SDL_CallMainFunction(forward_argc, forward_argv, forward_main);
@@ -497,6 +500,14 @@ API_AVAILABLE(ios(13.0))
         launchWindow.hidden = YES;
         launchWindow = nil;
     }
+}
+
+- (void)processLaunchURLs
+{
+    for (NSURL *url in launchURLs) {
+        [self handleURL:url];
+    }
+    launchURLs = nil;
 }
 
 - (UISceneConfiguration *)application:(UIApplication *)application configurationForConnectingSceneSession:(UISceneSession *)connectingSceneSession options:(UISceneConnectionOptions *)options API_AVAILABLE(ios(13.0))


### PR DESCRIPTION
## Description

The Visual Pinball iOS app uses SDL main callbacks and a SwiftUI front end. 

We use `SDL_EVENT_DROP_FILE` because SwiftUI's `onopenurl` does not work when added to the `SDL_uikitviewcontroller` via a `UIHostingController`.

When the app is launched from a cold start, the event system isn't initialized, so the event gets dropped.

This PR fixes this by queueing up launch urls and then firing in `postFinishLaunch`.

## Existing Issue(s)

https://github.com/issues/created?issue=libsdl-org%7CSDL%7C15093
