### PR TITLE
thread: SDL_CreateThread() shouldn't return before the new thread is set up.

### DIFF
--- a/src/thread/SDL_thread.c
+++ b/src/thread/SDL_thread.c
@@ -333,6 +333,8 @@ void SDL_RunThread(SDL_Thread *thread)
     // Get the thread id
     thread->threadid = SDL_GetCurrentThreadID();
 
+    SDL_SignalSemaphore(thread->ready_sem);  // the thread is officially ready to run!
+
     // Run the function
     *statusloc = userfunc(userdata);
 
@@ -389,6 +391,13 @@ SDL_Thread *SDL_CreateThreadWithPropertiesRuntime(SDL_PropertiesID props,
         }
     }
 
+    thread->ready_sem = SDL_CreateSemaphore(0);
+    if (!thread->ready_sem) {
+        SDL_free(thread->name);
+        SDL_free(thread);
+        return NULL;
+    }
+
     thread->userfunc = fn;
     thread->userdata = userdata;
     thread->stacksize = stacksize;
@@ -399,10 +408,15 @@ SDL_Thread *SDL_CreateThreadWithPropertiesRuntime(SDL_PropertiesID props,
     if (!SDL_SYS_CreateThread(thread, pfnBeginThread, pfnEndThread)) {
         // Oops, failed.  Gotta free everything
         SDL_SetObjectValid(thread, SDL_OBJECT_TYPE_THREAD, false);
+        SDL_DestroySemaphore(thread->ready_sem);
         SDL_free(thread->name);
         SDL_free(thread);
         thread = NULL;
     }
+
+    SDL_WaitSemaphore(thread->ready_sem);
+    SDL_DestroySemaphore(thread->ready_sem);
+    thread->ready_sem = NULL;
 
     // Everything is running now
     return thread;

--- a/src/thread/SDL_thread_c.h
+++ b/src/thread/SDL_thread_c.h
@@ -54,6 +54,7 @@ struct SDL_Thread
     SDL_error errbuf;
     char *name;
     size_t stacksize; // 0 for default, >0 for user-specified stack size.
+    SDL_Semaphore *ready_sem;  // signals when the thread is set up and about to start running.
     int(SDLCALL *userfunc)(void *);
     void *userdata;
     void *data;


### PR DESCRIPTION

This uses a brief-lived semaphore to make sure SDL's thread init code has run before letting SDL_CreateThread actually return. The new thread will signal it right before calling the app's thread entry point, SDL_CreateThread will then destroy the semaphore and return.

Two notes on this patch:

- Technically this is a (very minor) inefficiency, since most things that use threads probably don't immediately care about the thread ID or passing the thread name to the OS, and you can't just let everything rip while the initial thread waits for this setup to happen. But most apps don't care about the thread ID (vs the `SDL_Thread*`), and presumably the OS doesn't care about the thread name much until a debugger hits a breakpoint. If this really is a serious issue--and I don't think it is--I'd argue adding a "i promise to not care about the thread ID" property would be the right thing to do here and keep things correct for the normal use case.
- On single-threaded systems like Emscripten, this probably counted on SDL_SYS_CreateThread setting a "threads not available on this platform" error string, and it might get a slightly-confusing "semaphores not supported" error message now. I haven't tested.
 
Fixes #15290.
