### PR TITLE
PS2: fix joystick init

### DIFF
--- a/src/joystick/ps2/SDL_sysjoystick.c
+++ b/src/joystick/ps2/SDL_sysjoystick.c
@@ -52,8 +52,8 @@ struct JoyInfo
     int8_t opened;
 } __attribute__((aligned(64)));
 
-static uint8_t enabled_pads = 0;
-static struct JoyInfo joyInfo[MAX_CONTROLLERS];
+static uint8_t enabled_pads = 1;
+static struct JoyInfo joyInfo[MAX_CONTROLLERS + 1];
 
 static inline int16_t convert_u8_to_s16(uint8_t val)
 {


### PR DESCRIPTION
There is an issue with connecting gamepads in PS2.
In this PR https://github.com/libsdl-org/SDL/pull/8601/changes
PS2_JoystickGetDeviceInstanceID was set to return device_index + 1;
we have in PS2 joystick array.
static uint8_t enabled_pads = 0;
static struct JoyInfo joyInfo[MAX_CONTROLLERS];

description from PS2_JoystickInit()
```
            /* 2 main controller ports acts the same with and without multitap
            Port 0,0 -> Connector 1 - the same as Port 0
            Port 1,0 -> Connector 2 - the same as Port 1
            Port 0,1 -> Connector 3
            Port 1,1 -> Connector 4
            Port 0,2 -> Connector 5
            Port 1,2 -> Connector 6
            Port 0,3 -> Connector 7
            Port 1,3 -> Connector 8
            */
```
where the joyInfo[0]->port = 0 is joystick connected to first ps2 port.
joyInfo[1]->port = 1 connected to second.

When I'm trying to check if gamepad is available and connect due to the fix from PR it will try to use port 1 (not 0) which freeze the application in PS2_WaitPadReady function.

Code I'm using to open the first available gamepad is

```
int count = 0; 
SDL_JoystickID *pads = SDL_GetGamepads(&count);
SDL_Gamepad *gamepad = NULL;
if (pads) {
  for (int i = 0; i < count; ++i) {
	  if (SDL_IsGamepad(pads[i])) {
		  gamepad = SDL_OpenGamepad(pads[i]);
		  if (gamepad) {
			break;
		  }
	  }
  }
  // Free the array returned by SDL_GetGamepads
  SDL_free(pads);
}
```

my solution is to adjust a enabled_pads variable and joyInfo array.

This issue is not present in SDL2.