### PR TITLE
SDL_PrivateJoystickForceRecentering(): fix infinite loop

### DIFF
--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -2492,7 +2492,7 @@ bool SDL_IsJoystickBeingAdded(void)
 
 void SDL_PrivateJoystickForceRecentering(SDL_Joystick *joystick)
 {
-    Uint8 i, j;
+    int i, j;
     Uint64 timestamp = SDL_GetTicksNS();
 
     SDL_AssertJoysticksLocked();


### PR DESCRIPTION
`SDL_PrivateJoystickForceRecentering` uses a u8 for the loop variables, which can lead to the function never returning. 

For background, I had a user with a game controller that appeared to have 256 buttons, so he wouldn't be able to close my app because of the following call chain

SDL_Quit --> SDL_QuitJoysticks --> SDL_PrivateJoystickRemoved --> SDL_PrivateJoystickForceRecentering

and in there, this loop would never exit due to `i` wrapping from 255 to 0, so it never got to 256

```c
for (i = 0; i < joystick->nbuttons; i++) {
    SDL_SendJoystickButton(timestamp, joystick, i, false);
}
```

I don't imagine many controllers have 256 or more buttons. His controller doesn't actually have that many either -- the 256 buttons are from a "ghost controller" that is related to, as far as I know, problems with Steam -- but that's kind of beside the point. This is a very simple solution to the problem.

In case you're curious, here's a dump of the controller(s) in question. Only the first one is real, and interestingly, the other two seem to share a GUID

```
joystick 0
  name: Controller (Razer Wolverine V3 Pro for Xbox)
  guid: 03006f85321500004c0a000000007200
  attached: 1
  button_count: 11
  hat_count: 1
joystick 1
  name: Controller (Razer Wolverine V3 Pro)
  guid: 0300ab87321500004c0a000000000000
  attached: 1
  button_count: 1
  hat_count: 0
joystick 2
  name: Controller (Razer Wolverine V3 Pro)
  guid: 0300ab87321500004c0a000000000000
  attached: 1
  button_count: 256
```