### PR TITLE
(emscripten) Add null checks for gamepad in vendor/product/xinput helpers

### DIFF
--- a/src/joystick/emscripten/SDL_sysjoystick.c
+++ b/src/joystick/emscripten/SDL_sysjoystick.c
@@ -39,7 +39,9 @@ static int SDL_GetEmscriptenJoystickVendor(int device_index)
 {
     return MAIN_THREAD_EM_ASM_INT({
         let gamepad = navigator['getGamepads']()[$0];
-        if (!gamepad) return 0;
+        if (!gamepad) {
+            return 0;
+        }
 
         // Chrome, Edge, Opera: Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 09cc)
         let vendor_str = 'Vendor: ';
@@ -62,7 +64,9 @@ static int SDL_GetEmscriptenJoystickProduct(int device_index)
 {
     return MAIN_THREAD_EM_ASM_INT({
         let gamepad = navigator['getGamepads']()[$0];
-        if (!gamepad) return 0;
+        if (!gamepad) {
+            return 0;
+        }
 
         // Chrome, Edge, Opera: Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 09cc)
         let product_str = 'Product: ';
@@ -85,7 +89,9 @@ static int SDL_IsEmscriptenJoystickXInput(int device_index)
 {
     return MAIN_THREAD_EM_ASM_INT({
         let gamepad = navigator['getGamepads']()[$0];
-        if (!gamepad) return 0;
+        if (!gamepad) {
+            return 0;
+        }
 
         // Chrome, Edge, Opera: Xbox 360 Controller (XInput STANDARD GAMEPAD)
         // Firefox: xinput


### PR DESCRIPTION
navigator.getGamepads() can return null for a slot if the gamepad disconnects between the gamepadconnected event and the proxied MAIN_THREAD_EM_ASM_INT call. This causes a TypeError when accessing gamepad.id. Add null guards matching the pattern already used in EMSCRIPTEN_JoystickOpen and EMSCRIPTEN_JoystickRumble.