### PR TITLE
SDL_hidapi_zuiki.c: silence bogus -Warray-bounds warnings from gcc-4.9

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_zuiki.c
+++ b/src/joystick/hidapi/SDL_hidapi_zuiki.c
@@ -62,8 +62,8 @@ static float median_filter_update(MedianFilter_t* mf, float input) {
     if (mf->count < FILTER_SIZE) mf->count++;
     float temp[FILTER_SIZE];
     SDL_memcpy(temp, mf->buffer, sizeof(temp));
-    for (int i = 0; i < mf->count - 1; i++) {
-        for (int j = i + 1; j < mf->count; j++) {
+    for (uint8_t i = 0; i < mf->count - 1; i++) {
+        for (uint8_t j = i + 1; j < mf->count; j++) {
             if (temp[i] > temp[j]) {
                 float t = temp[i];
                 temp[i] = temp[j];


### PR DESCRIPTION
```
src/joystick/hidapi/SDL_hidapi_zuiki.c: In function 'HIDAPI_DriverZUIKI_UpdateDevice':
src/joystick/hidapi/SDL_hidapi_zuiki.c:67:31: warning: array subscript is above array bounds [-Warray-bounds]
             if (temp[i] > temp[j]) {
                               ^
src/joystick/hidapi/SDL_hidapi_zuiki.c:70:21: warning: array subscript is above array bounds [-Warray-bounds]
                 temp[j] = t;
                     ^
src/joystick/hidapi/SDL_hidapi_zuiki.c:67:31: warning: array subscript is above array bounds [-Warray-bounds]
             if (temp[i] > temp[j]) {
                               ^
src/joystick/hidapi/SDL_hidapi_zuiki.c:70:21: warning: array subscript is above array bounds [-Warray-bounds]
                 temp[j] = t;
                     ^
src/joystick/hidapi/SDL_hidapi_zuiki.c:67:31: warning: array subscript is above array bounds [-Warray-bounds]
             if (temp[i] > temp[j]) {
                               ^
src/joystick/hidapi/SDL_hidapi_zuiki.c:70:21: warning: array subscript is above array bounds [-Warray-bounds]
                 temp[j] = t;
                     ^
src/joystick/hidapi/SDL_hidapi_zuiki.c:67:31: warning: array subscript is above array bounds [-Warray-bounds]
             if (temp[i] > temp[j]) {
                               ^
src/joystick/hidapi/SDL_hidapi_zuiki.c:70:21: warning: array subscript is above array bounds [-Warray-bounds]
                 temp[j] = t;
                     ^
src/joystick/hidapi/SDL_hidapi_zuiki.c:67:31: warning: array subscript is above array bounds [-Warray-bounds]
             if (temp[i] > temp[j]) {
                               ^
src/joystick/hidapi/SDL_hidapi_zuiki.c:70:21: warning: array subscript is above array bounds [-Warray-bounds]
                 temp[j] = t;
                     ^
src/joystick/hidapi/SDL_hidapi_zuiki.c:67:31: warning: array subscript is above array bounds [-Warray-bounds]
             if (temp[i] > temp[j]) {
                               ^
src/joystick/hidapi/SDL_hidapi_zuiki.c:70:21: warning: array subscript is above array bounds [-Warray-bounds]
                 temp[j] = t;
                     ^
```

Happens both in main and in release-3.4.x branches.

The warnings don't seem to happen with the other gcc versions I tested,
namely 4.4, 7.5, 15.2.
