### PR TITLE
GPU Vulkan: handle VK_ERROR_SURFACE_LOST_KHR in acquire path

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -10214,6 +10214,13 @@ static bool VULKAN_INTERNAL_AcquireSwapchainTexture(
             break;  // we got the next image!
         }
 
+        // Surface lost — flag for surface + swapchain recreation on next call
+        if (acquireResult == VK_ERROR_SURFACE_LOST_KHR) {
+            windowData->needsSurfaceRecreate = true;
+            windowData->needsSwapchainRecreate = true;
+            return true;
+        }
+
         // If acquisition is invalid, let's try to recreate
         Uint32 recreateSwapchainResult = VULKAN_INTERNAL_RecreateSwapchain(renderer, windowData);
         if (!recreateSwapchainResult) {


### PR DESCRIPTION
## Summary

Handle `VK_ERROR_SURFACE_LOST_KHR` in the `VULKAN_AcquireSwapchainTexture` acquire loop.

On Android, backgrounding and foregrounding an app causes the Vulkan surface to be destroyed. `vkAcquireNextImageKHR` returns `VK_ERROR_SURFACE_LOST_KHR`, but the acquire `while(true)` loop only calls `RecreateSwapchain`, which doesn't recreate the surface — resulting in an infinite retry loop and a black screen.

The present path (line ~10894) already correctly handles this by setting both `needsSurfaceRecreate` and `needsSwapchainRecreate`. This PR applies the same fix to the acquire path.

## Fix

```c
if (acquireResult == VK_ERROR_SURFACE_LOST_KHR) {
    windowData->needsSurfaceRecreate = true;
    windowData->needsSwapchainRecreate = true;
    return true;
}
```

## Testing

- **Device:** Moto G54 5G, Android 14 (API 34)
- **SDL:** 3.4.2 and current main
- Confirmed working — app fully recovers rendering after multiple background/foreground cycles

Fixes #15322