### PR TITLE
Fix EGL KMSDRM crash with the Nvidia proprietary driver

### DIFF
--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
@@ -1693,17 +1693,6 @@ static void KMSDRM_DestroySurfaces(SDL_VideoDevice *_this, SDL_Window *window)
     }
 
     /***************************/
-    // Destroy the EGL surface
-    /***************************/
-
-    SDL_EGL_MakeCurrent(_this, EGL_NO_SURFACE, EGL_NO_CONTEXT);
-
-    if (windata->egl_surface != EGL_NO_SURFACE) {
-        SDL_EGL_DestroySurface(_this, windata->egl_surface);
-        windata->egl_surface = EGL_NO_SURFACE;
-    }
-
-    /***************************/
     // Destroy the GBM buffers
     /***************************/
 
@@ -1717,6 +1706,17 @@ static void KMSDRM_DestroySurfaces(SDL_VideoDevice *_this, SDL_Window *window)
     if (windata->next_bo) {
         KMSDRM_gbm_surface_release_buffer(windata->gs, windata->next_bo);
         windata->next_bo = NULL;
+    }
+
+    /***************************/
+    // Destroy the EGL surface
+    /***************************/
+
+    SDL_EGL_MakeCurrent(_this, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+
+    if (windata->egl_surface != EGL_NO_SURFACE) {
+        SDL_EGL_DestroySurface(_this, windata->egl_surface);
+        windata->egl_surface = EGL_NO_SURFACE;
     }
 
     /***************************/


### PR DESCRIPTION
## Description
Running `testgles2` using the KMSDRM video driver with the Nvidia proprietary driver segfaults on startup (atomic) or shutdown (legacy). The problem is that `eglDestroySurface()` actually nukes the underlying `GbmSurface` object that is accessed to release the GBM buffers.

This is how we make it to [FreeSurface()](https://github.com/NVIDIA/egl-gbm/blob/a73cbcec5e3911ea6b075df63f6f4e559392926c/src/gbm-surface.c#L399-L428) which wipes out the `GbmSurface`
```
#0  FreeSurface (obj=0x5555556e8cb0) at ../egl-gbm-1.1.3/src/gbm-surface.c:401
#1  0x00007ffff4d9b2de in eGbmDestroyHandle (handle=0x5555556e8cb0) at ../egl-gbm-1.1.3/src/gbm-handle.c:122
#2  eGbmDestroySurfaceHook (dpy=<optimized out>, eglSurf=0x5555556e8cb0) at ../egl-gbm-1.1.3/src/gbm-surface.c:575
#3  0x00007ffff73d448b in ?? () from /usr/lib/libEGL_nvidia.so.0
#4  0x00007ffff736f48a in ?? () from /usr/lib/libEGL_nvidia.so.0
#5  0x00007ffff7bd8b46 in SDL_EGL_DestroySurface (_this=0x55555557e870, egl_surface=0x5555556e8cb0) at /home/cgutman/SDL/src/video/SDL_egl.c:1403
#6  0x00007ffff7cec93f in KMSDRM_DestroySurfaces (_this=0x55555557e870, window=0x5555555dbcc0) at /home/cgutman/SDL/src/video/kmsdrm/SDL_kmsdrmvideo.c:1702
#7  0x00007ffff7cecc8f in KMSDRM_CreateSurfaces (_this=0x55555557e870, window=0x5555555dbcc0) at /home/cgutman/SDL/src/video/kmsdrm/SDL_kmsdrmvideo.c:1781
#8  0x00007ffff7ce8598 in KMSDRM_GLES_SwapWindowFenced (_this=0x55555557e870, window=0x5555555dbcc0) at /home/cgutman/SDL/src/video/kmsdrm/SDL_kmsdrmopengles.c:237
#9  0x00007ffff7ce8f61 in KMSDRM_GLES_SwapWindow (_this=0x55555557e870, window=0x5555555dbcc0) at /home/cgutman/SDL/src/video/kmsdrm/SDL_kmsdrmopengles.c:518
#10 0x00007ffff7c16758 in SDL_GL_SwapWindow_REAL (window=0x5555555dbcc0) at /home/cgutman/SDL/src/video/SDL_video.c:5598
#11 0x00007ffff7a785f1 in SDL_GL_SwapWindow (a=0x5555555dbcc0) at /home/cgutman/SDL/src/dynapi/SDL_dynapi_procs.h:238
#12 0x000055555555c18b in render_window (index=0) at /home/cgutman/SDL/test/testgles2.c:560
#13 0x000055555555c5e5 in loop () at /home/cgutman/SDL/test/testgles2.c:653
#14 0x000055555555d9c2 in main (argc=1, argv=0x7fffffffe758) at /home/cgutman/SDL/test/testgles2.c:931
```

and finally the UAF happens when [accessing the GbmSurface again](https://github.com/NVIDIA/egl-gbm/blob/a73cbcec5e3911ea6b075df63f6f4e559392926c/src/gbm-surface.c#L361) in `gbm_surface_release_buffer()`:
```
#0  eGbmSurfaceReleaseBuffer (s=0x5555556ed438, bo=0x5555558b0bd0) at ../egl-gbm-1.1.3/src/gbm-surface.c:390
#1  0x00007ffff7cec9b5 in KMSDRM_DestroySurfaces (_this=0x55555557e870, window=0x55555558a630) at /home/cgutman/SDL/src/video/kmsdrm/SDL_kmsdrmvideo.c:1716
#2  0x00007ffff7cecc8f in KMSDRM_CreateSurfaces (_this=0x55555557e870, window=0x55555558a630) at /home/cgutman/SDL/src/video/kmsdrm/SDL_kmsdrmvideo.c:1781
#3  0x00007ffff7ce8598 in KMSDRM_GLES_SwapWindowFenced (_this=0x55555557e870, window=0x55555558a630) at /home/cgutman/SDL/src/video/kmsdrm/SDL_kmsdrmopengles.c:237
#4  0x00007ffff7ce8f61 in KMSDRM_GLES_SwapWindow (_this=0x55555557e870, window=0x55555558a630) at /home/cgutman/SDL/src/video/kmsdrm/SDL_kmsdrmopengles.c:518
#5  0x00007ffff7c16758 in SDL_GL_SwapWindow_REAL (window=0x55555558a630) at /home/cgutman/SDL/src/video/SDL_video.c:5598
#6  0x00007ffff7a785f1 in SDL_GL_SwapWindow (a=0x55555558a630) at /home/cgutman/SDL/src/dynapi/SDL_dynapi_procs.h:238
#7  0x000055555555c18b in render_window (index=0) at /home/cgutman/SDL/test/testgles2.c:560
#8  0x000055555555c5e5 in loop () at /home/cgutman/SDL/test/testgles2.c:653
#9  0x000055555555d9c2 in main (argc=1, argv=0x7fffffffe758) at /home/cgutman/SDL/test/testgles2.c:931
```

I couldn't find anything definitive that said you needed to release GBM buffers before destroying the EGL surface, but cleaning up in that order fixes the UAF.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
