### PR TITLE
SDL_EnumerateDirectory(""): Don't append path separator if path is empty

### DIFF
--- a/src/filesystem/posix/SDL_sysfsops.c
+++ b/src/filesystem/posix/SDL_sysfsops.c
@@ -74,7 +74,7 @@ bool SDL_SYS_EnumerateDirectory(const char *path, SDL_EnumerateDirectoryCallback
 #endif
 
     char *pathwithsep = NULL;
-    int pathwithseplen = SDL_asprintf(&pathwithsep, "%s/", apath ? apath : path);
+    int pathwithseplen = SDL_asprintf(&pathwithsep, "%s%s", apath ? apath : path, (apath ? *apath : *path) ? "/" : "");
     const size_t extralen = apath ? (SDL_strlen(apath) - SDL_strlen(path)) : 0;
     SDL_free(apath);
     if ((pathwithseplen == -1) || (!pathwithsep)) {


### PR DESCRIPTION
Calling `SDL_EnumerateDirectory("")` enumerates the root directory `"/"`.

Example code:
```c
#include <SDL3/SDL.h>

#define SDL_MAIN_USE_CALLBACKS 1
#include <SDL3/SDL_main.h>

const char *path = "";

SDL_EnumerationResult enum_dir_callback(void *userdata, const char *dirname, const char *fname)
{
    SDL_Log("dirname = \"%s\", fname = \"%s\"", dirname, fname);
    
    return SDL_ENUM_CONTINUE;
}


SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
{
    if(!SDL_Init(0)) {
        SDL_Log("ERROR: SDL_Init(): %s", SDL_GetError());
    }
    
    SDL_Log("SDL_EnumerateDirectory(\"%s\")", path);
    if(!SDL_EnumerateDirectory(path, enum_dir_callback, NULL)) {
        SDL_Log("ERROR: %s", SDL_GetError());
    }
    
    SDL_Log("");
    
    SDL_Log("SDL_GlobDirectory(\"%s\")", path);
    int glob_count =  0;
    char **globs = SDL_GlobDirectory(path, "*", 0, &glob_count);
    if (!globs) {
        SDL_Log("ERROR: %s", SDL_GetError());
    } else {
        SDL_Log("glob_count: %d", glob_count);
        for (int i = 0; i < glob_count; ++i) {
            SDL_Log("%s", globs[i]);
        }
        SDL_free(globs);
    }
    
    return SDL_APP_SUCCESS;
}

SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
{
    return SDL_APP_SUCCESS;
}

SDL_AppResult SDL_AppIterate(void *appstate)
{
    return SDL_APP_SUCCESS;
}

void SDL_AppQuit(void *appstate, SDL_AppResult result)
{
}

```
Output:
```
SDL_EnumerateDirectory("")
dirname = "/", fname = "tmp"
dirname = "/", fname = "var"
dirname = "/", fname = "efi"
dirname = "/", fname = "root"
dirname = "/", fname = "bin"
dirname = "/", fname = "dev"
dirname = "/", fname = "lost+found"
dirname = "/", fname = "media"
dirname = "/", fname = "mnt"
dirname = "/", fname = "run"
dirname = "/", fname = "lib64"
dirname = "/", fname = "proc"
dirname = "/", fname = "sbin"
dirname = "/", fname = "opt"
dirname = "/", fname = "lib"
dirname = "/", fname = "srv"
dirname = "/", fname = "etc"
dirname = "/", fname = "home"
dirname = "/", fname = "sys"
dirname = "/", fname = "boot"
dirname = "/", fname = "usr"

SDL_GlobDirectory("")
glob_count: 0
```

This is due to an appended path separator on an empty string here:
https://github.com/libsdl-org/SDL/blob/ccf688c9215a08bbba4b09c528ff82f9d67589c9/src/filesystem/posix/SDL_sysfsops.c#L76-L82

This PR only appends the path separator if the path is not empty.
Outpt after change:
```
SDL_EnumerateDirectory("")
ERROR: Can't open directory: No such file or directory

SDL_GlobDirectory("")
ERROR: Can't open directory: No such file or directory
```

The changed code is not the prettiest, but a pretty fix would take more refactoring.
Ideas for a pretty fix are welcome.