### PR TITLE
wayland: Enable text input even when the text input protocol is not a…

### DIFF
--- a/src/video/wayland/SDL_waylandkeyboard.c
+++ b/src/video/wayland/SDL_waylandkeyboard.c
@@ -183,11 +183,12 @@ bool Wayland_StartTextInput(SDL_VideoDevice *_this, SDL_Window *window, SDL_Prop
                 Wayland_SeatUpdateTextInput(seat);
             }
         }
-
-        return true;
     }
 
-    return SDL_SetError("wayland: cannot enable text input; compositor lacks support for the required zwp_text_input_v3 protocol");
+    /* Always return true, even if the text input protocol isn't supported, as basic
+     * text can still be obtained from individual keys and composition system.
+     */
+    return true;
 }
 
 bool Wayland_StopTextInput(SDL_VideoDevice *_this, SDL_Window *window)


### PR DESCRIPTION
…vailable.

Even without the text input protocol, basic text can still be obtained from individual keys and the composition system.

Fixes #15372 