### PR TITLE
Cleanup __atomic_load_n() detection

### DIFF
--- a/src/atomic/SDL_atomic.c
+++ b/src/atomic/SDL_atomic.c
@@ -37,11 +37,7 @@
 #if defined(__GNUC__) && (__GNUC__ >= 5)
 #define HAVE_ATOMIC_LOAD_N 1
 #elif SDL_HAS_BUILTIN(__atomic_load_n) || (defined(__clang__) && defined(HAVE_GCC_ATOMICS))
-/* !!! FIXME: this advertises as available in the NDK but uses an external symbol we don't have.
-   It might be in a later NDK or we might need an extra library? --ryan. */
-#ifndef SDL_PLATFORM_ANDROID
 #define HAVE_ATOMIC_LOAD_N 1
-#endif
 #endif
 
 /*

--- a/src/atomic/SDL_atomic.c
+++ b/src/atomic/SDL_atomic.c
@@ -34,16 +34,12 @@
 #endif
 
 // The __atomic_load_n() intrinsic showed up in different times for different compilers.
-#ifdef __clang__
-#if __has_builtin(__atomic_load_n) || defined(HAVE_GCC_ATOMICS)
+#if defined(__GNUC__) && (__GNUC__ >= 5)
+#define HAVE_ATOMIC_LOAD_N 1
+#elif SDL_HAS_BUILTIN(__atomic_load_n) || (defined(__clang__) && defined(HAVE_GCC_ATOMICS))
 /* !!! FIXME: this advertises as available in the NDK but uses an external symbol we don't have.
    It might be in a later NDK or we might need an extra library? --ryan. */
 #ifndef SDL_PLATFORM_ANDROID
-#define HAVE_ATOMIC_LOAD_N 1
-#endif
-#endif
-#elif defined(__GNUC__)
-#if (__GNUC__ >= 5)
 #define HAVE_ATOMIC_LOAD_N 1
 #endif
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Cleans up the detection logic for `__atomic_load_n()` by using `SDL_HAS_BUILTIN()` instead of `__has_builtin()` and removes the very old guard preventing use of `__atomic_load_n()` on Android.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
