### PR TITLE
Fix GCMouse scroll axis mapping on macOS

### DIFF
--- a/src/video/cocoa/SDL_cocoamouse.m
+++ b/src/video/cocoa/SDL_cocoamouse.m
@@ -351,10 +351,10 @@ static void Cocoa_OnGCMouseConnected(GCMouse *mouse)
     mouse.mouseInput.scroll.valueChangedHandler =
         ^(GCControllerDirectionPad *dpad, float xValue, float yValue) {
             Uint64 timestamp = SDL_GetTicksNS();
-            // Raw scroll values: vertical in first axis, horizontal in second.
+            // xValue corresponds to xAxis (horizontal), yValue to yAxis (vertical).
             // Vertical values are inverted compared to SDL conventions.
-            float vertical = -xValue;
-            float horizontal = yValue;
+            float vertical = -yValue;
+            float horizontal = xValue;
 
             if (cocoa_mouse_scroll_direction == SDL_MOUSEWHEEL_FLIPPED) {
                 vertical = -vertical;


### PR DESCRIPTION
The scroll valueChangedHandler was treating xValue as vertical and yValue as horizontal, copied from the iOS GCMouse implementation. On macOS, the GCControllerDirectionPad axes follow their documented semantics: xAxis (left/right) is horizontal and yAxis (up/down) is vertical.

Swap the axis assignment so xValue maps to horizontal scroll and yValue maps to vertical scroll.

Tested on macOS 26.3.1, using both the internal trackpad of my MacBook Pro M1 Pro and a wireless USB mouse, and ultimately fixes scrolling for me in Dear ImGui.