### PR TITLE
Expose Steam Controller touchpads in Gamepad API

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -1496,7 +1496,7 @@ static bool HIDAPI_DriverSteam_UpdateDevice(SDL_HIDAPI_Device *device)
                 static float oldLeftY = 0;
                 float jitter=256.0f / (1 << 16);
                 float leftX = ctx->m_state.sLeftPadX /(float)(1 << 16)+ 0.5f;
-                float leftY = (~ctx->m_state.sLeftPadY) /(float)(1 << 16)+ 0.5f;
+                float leftY =(~ctx->m_state.sLeftPadY)/(float)(1 << 16)+ 0.5f;
                 float fake_pressure = fingerDown ? 0.5f : 0.0f;
                 if (leftPadClicked) {
                     fake_pressure += 0.5f;

--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -1516,7 +1516,7 @@ static bool HIDAPI_DriverSteam_UpdateDevice(SDL_HIDAPI_Device *device)
             static float oldRightY = 0;
             float jitter = 256.0f / (1 << 16);
             float rightX = ctx->m_state.sRightPadX / 0x1.0p16f + 0.5f;
-            float rightY = (~ctx->m_state.sRightPadY)/ 0x1.0p16f + 0.5f;
+            float rightY = (~ctx->m_state.sRightPadY) / 0x1.0p16f + 0.5f;
             float fake_pressure = fingerDown ? 0.5f : 0.0f;
             if (rightPadClicked) {
                 fake_pressure += 0.5f;

--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -1268,9 +1268,9 @@ static bool HIDAPI_DriverSteam_OpenJoystick(SDL_HIDAPI_Device *device, SDL_Joyst
 
     SDL_PrivateJoystickAddSensor(joystick, SDL_SENSOR_GYRO, update_rate_in_hz);
     SDL_PrivateJoystickAddSensor(joystick, SDL_SENSOR_ACCEL, update_rate_in_hz);
-
-    SDL_PrivateJoystickAddTouchpad(joystick, 1);
-    SDL_PrivateJoystickAddTouchpad(joystick, 1);
+    int num_fingers=1;
+    SDL_PrivateJoystickAddTouchpad(joystick, num_fingers);
+    SDL_PrivateJoystickAddTouchpad(joystick, num_fingers);
 
     SDL_AddHintCallback(SDL_HINT_JOYSTICK_HIDAPI_STEAM_HOME_LED,
                         SDL_HomeLEDHintChanged, ctx);
@@ -1355,16 +1355,18 @@ static bool ControllerConnected(SDL_HIDAPI_Device *device, SDL_Joystick **joysti
 
 static float filter(float newvalue, float oldvalue, float jitter)
 {
-  jitter= jitter>=0 ? jitter: -jitter;
-  if (newvalue > oldvalue-jitter*0.5f && newvalue <oldvalue+ jitter*0.5f)
+    jitter = jitter >= 0 ? jitter : -jitter;
+    if (newvalue > (oldvalue - jitter * 0.5f) && newvalue < (oldvalue + jitter * 0.5f)){
       return  oldvalue;
-  if (newvalue > oldvalue- jitter && newvalue <oldvalue+ jitter)
-      return oldvalue*0.75f+newvalue*0.25f;
-  if (newvalue > oldvalue-jitter*2.0f && newvalue <oldvalue+jitter*2.0f)
-      return (oldvalue+newvalue)*0.5f;
-
-  return newvalue;
- }
+    }
+    if (newvalue > (oldvalue - jitter) && newvalue < (oldvalue + jitter)){
+      return oldvalue * 0.75f + newvalue * 0.25f;
+    }
+    if (newvalue > (oldvalue - jitter * 2.0f) && newvalue < (oldvalue + jitter * 2.0f)){
+      return (oldvalue + newvalue) * 0.5f;
+    }
+    return newvalue;
+}
 
 
 
@@ -1490,40 +1492,42 @@ static bool HIDAPI_DriverSteam_UpdateDevice(SDL_HIDAPI_Device *device)
             SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHTY, ~ctx->m_state.sRightPadY);
 
 {
-            int padindex=0;
-            int fingerindex=0;
-            bool fingerDown=(ctx->m_state.ulButtons & STEAM_LEFTPAD_FINGERDOWN_MASK) ? 1 : 0;
-            bool leftPadClicked=(ctx->m_state.ulButtons & STEAM_BUTTON_LEFTPAD_CLICKED_MASK) ? 1 : 0;
-            static float oldLeftX=0;
-            static float oldLeftY=0;
-            float jitter=256.0f/(1<<16);
-            float leftX=ctx->m_state.sLeftPadX / 0x1.0p16f + 0.5f;
-            float leftY=(~ctx->m_state.sLeftPadY) / 0x1.0p16f + 0.5f;
-            float fake_pressure=fingerDown ? 0.5f : 0.0f;
-            if (leftPadClicked)
-                fake_pressure+=0.5f;
+            int padindex = 0;
+            int fingerindex = 0;
+            bool fingerDown = (ctx->m_state.ulButtons & STEAM_LEFTPAD_FINGERDOWN_MASK) ? 1 : 0;
+            bool leftPadClicked = (ctx->m_state.ulButtons & STEAM_BUTTON_LEFTPAD_CLICKED_MASK) ? 1 : 0;
+            static float oldLeftX = 0;
+            static float oldLeftY = 0;
+            float jitter=256.0f / (1 << 16);
+            float leftX = ctx->m_state.sLeftPadX / 0x1.0p16f + 0.5f;
+            float leftY = (~ctx->m_state.sLeftPadY) / 0x1.0p16f + 0.5f;
+            float fake_pressure = fingerDown ? 0.5f : 0.0f;
+            if (leftPadClicked){
+                fake_pressure += 0.5f;
+            }
             if (fingerDown){
-                oldLeftX=filter(leftX, oldLeftX, jitter);
-                oldLeftY=filter(leftY, oldLeftY, jitter);
+                oldLeftX = filter(leftX, oldLeftX, jitter);
+                oldLeftY = filter(leftY, oldLeftY, jitter);
             }
             SDL_SendJoystickTouchpad(timestamp, joystick, padindex, fingerindex,fingerDown,oldLeftX,oldLeftY,fake_pressure);
 }
 {
-            int padindex=1;
-            int fingerindex=0;
-            bool fingerDown=(ctx->m_state.ulButtons & STEAM_RIGHTPAD_FINGERDOWN_MASK) ? 1 : 0;
-            bool rightPadClicked=(ctx->m_state.ulButtons & STEAM_BUTTON_RIGHTPAD_CLICKED_MASK) ? 1 : 0;
-            static float oldRightX=0;
-            static float oldRightY=0;
-            float jitter=256.0f/(1<<16);
-            float rightX=ctx->m_state.sRightPadX / 0x1.0p16f + 0.5f;
-            float rightY=(~ctx->m_state.sRightPadY)/ 0x1.0p16f + 0.5f;
-            float fake_pressure=fingerDown ? 0.5f : 0.0f;
-            if (rightPadClicked)
-                fake_pressure+=0.5f;
+            int padindex = 1;
+            int fingerindex = 0;
+            bool fingerDown = (ctx->m_state.ulButtons & STEAM_RIGHTPAD_FINGERDOWN_MASK) ? 1 : 0;
+            bool rightPadClicked = (ctx->m_state.ulButtons & STEAM_BUTTON_RIGHTPAD_CLICKED_MASK) ? 1 : 0;
+            static float oldRightX = 0;
+            static float oldRightY = 0;
+            float jitter = 256.0f / (1 << 16);
+            float rightX = ctx->m_state.sRightPadX / 0x1.0p16f + 0.5f;
+            float rightY = (~ctx->m_state.sRightPadY)/ 0x1.0p16f + 0.5f;
+            float fake_pressure = fingerDown ? 0.5f : 0.0f;
+            if (rightPadClicked){
+                fake_pressure += 0.5f;
+            }
             if (fingerDown){
-                oldRightX=filter(rightX, oldRightX, jitter);
-                oldRightY=filter(rightY, oldRightY, jitter);
+                oldRightX = filter(rightX, oldRightX, jitter);
+                oldRightY = filter(rightY, oldRightY, jitter);
             }
             SDL_SendJoystickTouchpad(timestamp, joystick, padindex, fingerindex,fingerDown,oldRightX,oldRightY,fake_pressure);
 }

--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -1268,7 +1268,7 @@ static bool HIDAPI_DriverSteam_OpenJoystick(SDL_HIDAPI_Device *device, SDL_Joyst
 
     SDL_PrivateJoystickAddSensor(joystick, SDL_SENSOR_GYRO, update_rate_in_hz);
     SDL_PrivateJoystickAddSensor(joystick, SDL_SENSOR_ACCEL, update_rate_in_hz);
-    int num_fingers=1;
+    int num_fingers = 1;
     SDL_PrivateJoystickAddTouchpad(joystick, num_fingers);
     SDL_PrivateJoystickAddTouchpad(joystick, num_fingers);
 

--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -1011,6 +1011,13 @@ typedef struct
     Uint64 sensor_timestamp;
     Uint64 pairing_time;
 
+    bool left_touch_down;
+    float left_touch_x;
+    float left_touch_y;
+    bool right_touch_down;
+    float right_touch_x;
+    float right_touch_y;
+
     SteamControllerPacketAssembler m_assembler;
     SteamControllerStateInternal_t m_state;
     SteamControllerStateInternal_t m_last_state;
@@ -1268,9 +1275,9 @@ static bool HIDAPI_DriverSteam_OpenJoystick(SDL_HIDAPI_Device *device, SDL_Joyst
 
     SDL_PrivateJoystickAddSensor(joystick, SDL_SENSOR_GYRO, update_rate_in_hz);
     SDL_PrivateJoystickAddSensor(joystick, SDL_SENSOR_ACCEL, update_rate_in_hz);
-    int num_fingers = 1;
-    SDL_PrivateJoystickAddTouchpad(joystick, num_fingers);
-    SDL_PrivateJoystickAddTouchpad(joystick, num_fingers);
+
+    SDL_PrivateJoystickAddTouchpad(joystick, 1);
+    SDL_PrivateJoystickAddTouchpad(joystick, 1);
 
     SDL_AddHintCallback(SDL_HINT_JOYSTICK_HIDAPI_STEAM_HOME_LED,
                         SDL_HomeLEDHintChanged, ctx);
@@ -1351,9 +1358,9 @@ static bool ControllerConnected(SDL_HIDAPI_Device *device, SDL_Joystick **joysti
     return true;
 }
 
-static float Filter(float newValue, float oldValue, float jitter)
+static float FilterTouch(float newValue, float oldValue)
 {
-    jitter = jitter >= 0 ? jitter : -jitter;
+    const float jitter = 256.0f / (1 << 16);
     if (newValue > (oldValue - jitter * 0.5f) && newValue < (oldValue + jitter * 0.5f)) {
         return oldValue;
     }
@@ -1487,45 +1494,44 @@ static bool HIDAPI_DriverSteam_UpdateDevice(SDL_HIDAPI_Device *device)
             SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHTX, ctx->m_state.sRightPadX);
             SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHTY, ~ctx->m_state.sRightPadY);
 
+            // Note that the left pad is normally mapped to D-Pad, so you should ignore that input if you use the touchpad instead.
             {
-                int padIndex = 0;
-                int fingerIndex = 0;
-                bool fingerDown = (ctx->m_state.ulButtons & STEAM_LEFTPAD_FINGERDOWN_MASK) ? 1 : 0;
-                bool leftPadClicked = (ctx->m_state.ulButtons & STEAM_BUTTON_LEFTPAD_CLICKED_MASK) ? 1 : 0;
-                static float oldLeftX = 0;
-                static float oldLeftY = 0;
-                float jitter=256.0f / (1 << 16);
-                float leftX = ctx->m_state.sLeftPadX /(float)(1 << 16)+ 0.5f;
-                float leftY =(~ctx->m_state.sLeftPadY)/(float)(1 << 16)+ 0.5f;
-                float fakePressure = fingerDown ? 0.5f : 0.0f;
-                if (leftPadClicked) {
-                    fakePressure += 0.5f;
+                const bool down = (ctx->m_state.ulButtons & STEAM_LEFTPAD_FINGERDOWN_MASK) ? true : false;
+                if (down || ctx->left_touch_down) {
+                    const bool clicked = (ctx->m_state.ulButtons & STEAM_BUTTON_LEFTPAD_CLICKED_MASK) ? true : false;
+                    const float leftX = (float)ctx->m_state.sLeftPadX / (1 << 16) + 0.5f;
+                    const float leftY = -(float)ctx->m_state.sLeftPadY / (1 << 16) + 0.5f;
+                    float pressure = down ? 0.5f : 0.0f;
+                    if (clicked) {
+                        pressure += 0.5f;
+                    }
+                    if (down) {
+                        ctx->left_touch_x = FilterTouch(leftX, ctx->left_touch_x);
+                        ctx->left_touch_y = FilterTouch(leftY, ctx->left_touch_y);
+                    }
+                    SDL_SendJoystickTouchpad(timestamp, joystick, 0, 0, down, ctx->left_touch_x, ctx->left_touch_y, pressure);
+                    ctx->left_touch_down = down;
                 }
-                if (fingerDown) {
-                    oldLeftX = Filter(leftX, oldLeftX, jitter);
-                    oldLeftY = Filter(leftY, oldLeftY, jitter);
-                }
-                SDL_SendJoystickTouchpad(timestamp, joystick, padIndex, fingerIndex,fingerDown,oldLeftX,oldLeftY,fakePressure);
             }
+
+            // Note that the right pad is normally mapped to right thumbstick, so you should ignore that input if you use the touchpad instead.
             {
-                int padIndex = 1;
-                int fingerIndex = 0;
-                bool fingerDown = (ctx->m_state.ulButtons & STEAM_RIGHTPAD_FINGERDOWN_MASK) ? 1 : 0;
-                bool rightPadClicked = (ctx->m_state.ulButtons & STEAM_BUTTON_RIGHTPAD_CLICKED_MASK) ? 1 : 0;
-                static float oldRightX = 0;
-                static float oldRightY = 0;
-                float jitter = 256.0f / (1 << 16);
-                float rightX = ctx->m_state.sRightPadX /(float)(1 << 16)+ 0.5f;
-                float rightY = (~ctx->m_state.sRightPadY) /(float)(1 << 16)+ 0.5f;
-                float fakePressure = fingerDown ? 0.5f : 0.0f;
-                if (rightPadClicked) {
-                    fakePressure += 0.5f;
+                const bool down = (ctx->m_state.ulButtons & STEAM_RIGHTPAD_FINGERDOWN_MASK) ? true : false;
+                if (down || ctx->right_touch_down) {
+                    const bool clicked = (ctx->m_state.ulButtons & STEAM_BUTTON_RIGHTPAD_CLICKED_MASK) ? true : false;
+                    const float rightX = (float)ctx->m_state.sRightPadX / (1 << 16) + 0.5f;
+                    const float rightY = -(float)ctx->m_state.sRightPadY / (1 << 16) + 0.5f;
+                    float pressure = down ? 0.5f : 0.0f;
+                    if (clicked) {
+                        pressure += 0.5f;
+                    }
+                    if (down) {
+                        ctx->right_touch_x = FilterTouch(rightX, ctx->right_touch_x);
+                        ctx->right_touch_y = FilterTouch(rightY, ctx->right_touch_y);
+                    }
+                    SDL_SendJoystickTouchpad(timestamp, joystick, 1, 0, down, ctx->right_touch_x, ctx->right_touch_y, pressure);
+                    ctx->right_touch_down = down;
                 }
-                if (fingerDown) {
-                    oldRightX = Filter(rightX, oldRightX, jitter);
-                    oldRightY = Filter(rightY, oldRightY, jitter);
-                }
-                SDL_SendJoystickTouchpad(timestamp, joystick, padIndex, fingerIndex,fingerDown,oldRightX,oldRightY,fakePressure);
             }
 
             if (ctx->report_sensors) {

--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -1351,19 +1351,19 @@ static bool ControllerConnected(SDL_HIDAPI_Device *device, SDL_Joystick **joysti
     return true;
 }
 
-static float filter(float newvalue, float oldvalue, float jitter)
+static float filter(float newValue, float oldValue, float jitter)
 {
     jitter = jitter >= 0 ? jitter : -jitter;
-    if (newvalue > (oldvalue - jitter * 0.5f) && newvalue < (oldvalue + jitter * 0.5f)) {
-        return oldvalue;
+    if (newValue > (oldValue - jitter * 0.5f) && newValue < (oldValue + jitter * 0.5f)) {
+        return oldValue;
     }
-    if (newvalue > (oldvalue - jitter) && newvalue < (oldvalue + jitter)) {
-        return oldvalue * 0.75f + newvalue * 0.25f;
+    if (newValue > (oldValue - jitter) && newValue < (oldValue + jitter)) {
+        return oldValue * 0.75f + newValue * 0.25f;
     }
-    if (newvalue > (oldvalue - jitter * 2.0f) && newvalue < (oldvalue + jitter * 2.0f)) {
-        return (oldvalue + newvalue) * 0.5f;
+    if (newValue > (oldValue - jitter * 2.0f) && newValue < (oldValue + jitter * 2.0f)) {
+        return (oldValue + newValue) * 0.5f;
     }
-    return newvalue;
+    return newValue;
 }
 
 static void ControllerDisconnected(SDL_HIDAPI_Device *device, SDL_Joystick **joystick)
@@ -1488,8 +1488,8 @@ static bool HIDAPI_DriverSteam_UpdateDevice(SDL_HIDAPI_Device *device)
             SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHTY, ~ctx->m_state.sRightPadY);
 
             {
-                int padindex = 0;
-                int fingerindex = 0;
+                int padIndex = 0;
+                int fingerIndex = 0;
                 bool fingerDown = (ctx->m_state.ulButtons & STEAM_LEFTPAD_FINGERDOWN_MASK) ? 1 : 0;
                 bool leftPadClicked = (ctx->m_state.ulButtons & STEAM_BUTTON_LEFTPAD_CLICKED_MASK) ? 1 : 0;
                 static float oldLeftX = 0;
@@ -1497,19 +1497,19 @@ static bool HIDAPI_DriverSteam_UpdateDevice(SDL_HIDAPI_Device *device)
                 float jitter=256.0f / (1 << 16);
                 float leftX = ctx->m_state.sLeftPadX /(float)(1 << 16)+ 0.5f;
                 float leftY =(~ctx->m_state.sLeftPadY)/(float)(1 << 16)+ 0.5f;
-                float fake_pressure = fingerDown ? 0.5f : 0.0f;
+                float fakePressure = fingerDown ? 0.5f : 0.0f;
                 if (leftPadClicked) {
-                    fake_pressure += 0.5f;
+                    fakePressure += 0.5f;
                 }
                 if (fingerDown) {
                     oldLeftX = filter(leftX, oldLeftX, jitter);
                     oldLeftY = filter(leftY, oldLeftY, jitter);
                 }
-                SDL_SendJoystickTouchpad(timestamp, joystick, padindex, fingerindex,fingerDown,oldLeftX,oldLeftY,fake_pressure);
+                SDL_SendJoystickTouchpad(timestamp, joystick, padIndex, fingerIndex,fingerDown,oldLeftX,oldLeftY,fakePressure);
             }
             {
-                int padindex = 1;
-                int fingerindex = 0;
+                int padIndex = 1;
+                int fingerIndex = 0;
                 bool fingerDown = (ctx->m_state.ulButtons & STEAM_RIGHTPAD_FINGERDOWN_MASK) ? 1 : 0;
                 bool rightPadClicked = (ctx->m_state.ulButtons & STEAM_BUTTON_RIGHTPAD_CLICKED_MASK) ? 1 : 0;
                 static float oldRightX = 0;
@@ -1517,15 +1517,15 @@ static bool HIDAPI_DriverSteam_UpdateDevice(SDL_HIDAPI_Device *device)
                 float jitter = 256.0f / (1 << 16);
                 float rightX = ctx->m_state.sRightPadX /(float)(1 << 16)+ 0.5f;
                 float rightY = (~ctx->m_state.sRightPadY) /(float)(1 << 16)+ 0.5f;
-                float fake_pressure = fingerDown ? 0.5f : 0.0f;
+                float fakePressure = fingerDown ? 0.5f : 0.0f;
                 if (rightPadClicked) {
-                    fake_pressure += 0.5f;
+                    fakePressure += 0.5f;
                 }
                 if (fingerDown) {
                     oldRightX = filter(rightX, oldRightX, jitter);
                     oldRightY = filter(rightY, oldRightY, jitter);
                 }
-                SDL_SendJoystickTouchpad(timestamp, joystick, padindex, fingerindex,fingerDown,oldRightX,oldRightY,fake_pressure);
+                SDL_SendJoystickTouchpad(timestamp, joystick, padIndex, fingerIndex,fingerDown,oldRightX,oldRightY,fakePressure);
             }
 
             if (ctx->report_sensors) {

--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -1498,10 +1498,10 @@ static bool HIDAPI_DriverSteam_UpdateDevice(SDL_HIDAPI_Device *device)
             float leftX = ctx->m_state.sLeftPadX / 0x1.0p16f + 0.5f;
             float leftY = (~ctx->m_state.sLeftPadY) / 0x1.0p16f + 0.5f;
             float fake_pressure = fingerDown ? 0.5f : 0.0f;
-            if (leftPadClicked){
+            if (leftPadClicked) {
                 fake_pressure += 0.5f;
             }
-            if (fingerDown){
+            if (fingerDown) {
                 oldLeftX = filter(leftX, oldLeftX, jitter);
                 oldLeftY = filter(leftY, oldLeftY, jitter);
             }

--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -1275,7 +1275,6 @@ static bool HIDAPI_DriverSteam_OpenJoystick(SDL_HIDAPI_Device *device, SDL_Joyst
     SDL_AddHintCallback(SDL_HINT_JOYSTICK_HIDAPI_STEAM_HOME_LED,
                         SDL_HomeLEDHintChanged, ctx);
 
-
     return true;
 }
 

--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -1355,13 +1355,13 @@ static float filter(float newvalue, float oldvalue, float jitter)
 {
     jitter = jitter >= 0 ? jitter : -jitter;
     if (newvalue > (oldvalue - jitter * 0.5f) && newvalue < (oldvalue + jitter * 0.5f)){
-      return  oldvalue;
+        return  oldvalue;
     }
     if (newvalue > (oldvalue - jitter) && newvalue < (oldvalue + jitter)){
-      return oldvalue * 0.75f + newvalue * 0.25f;
+        return oldvalue * 0.75f + newvalue * 0.25f;
     }
     if (newvalue > (oldvalue - jitter * 2.0f) && newvalue < (oldvalue + jitter * 2.0f)){
-      return (oldvalue + newvalue) * 0.5f;
+        return (oldvalue + newvalue) * 0.5f;
     }
     return newvalue;
 }

--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -1495,8 +1495,8 @@ static bool HIDAPI_DriverSteam_UpdateDevice(SDL_HIDAPI_Device *device)
                 static float oldLeftX = 0;
                 static float oldLeftY = 0;
                 float jitter=256.0f / (1 << 16);
-                float leftX = ctx->m_state.sLeftPadX /(float)(1 << 16) + 0.5f;
-                float leftY = (~ctx->m_state.sLeftPadY) /(float)(1 << 16) + 0.5f;
+                float leftX = ctx->m_state.sLeftPadX /(float)(1 << 16)+ 0.5f;
+                float leftY = (~ctx->m_state.sLeftPadY) /(float)(1 << 16)+ 0.5f;
                 float fake_pressure = fingerDown ? 0.5f : 0.0f;
                 if (leftPadClicked) {
                     fake_pressure += 0.5f;

--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -1355,7 +1355,7 @@ static float filter(float newvalue, float oldvalue, float jitter)
 {
     jitter = jitter >= 0 ? jitter : -jitter;
     if (newvalue > (oldvalue - jitter * 0.5f) && newvalue < (oldvalue + jitter * 0.5f)){
-        return  oldvalue;
+        return oldvalue;
     }
     if (newvalue > (oldvalue - jitter) && newvalue < (oldvalue + jitter)){
         return oldvalue * 0.75f + newvalue * 0.25f;

--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -925,6 +925,7 @@ static bool UpdateBLESteamControllerState(const uint8_t *pData, int nDataSize, S
 static bool UpdateSteamControllerState(const uint8_t *pData, int nDataSize, SteamControllerStateInternal_t *pState)
 {
     ValveInReport_t *pInReport = (ValveInReport_t *)pData;
+    //the cast above is likely not safe due to struct padding rules being platform dependent
 
     if (pInReport->header.unReportVersion != k_ValveInReportMsgVersion) {
         if ((pData[0] & 0x0F) == k_EBLEReportState) {
@@ -1269,8 +1270,12 @@ static bool HIDAPI_DriverSteam_OpenJoystick(SDL_HIDAPI_Device *device, SDL_Joyst
     SDL_PrivateJoystickAddSensor(joystick, SDL_SENSOR_GYRO, update_rate_in_hz);
     SDL_PrivateJoystickAddSensor(joystick, SDL_SENSOR_ACCEL, update_rate_in_hz);
 
+    SDL_PrivateJoystickAddTouchpad(joystick, 1);
+    SDL_PrivateJoystickAddTouchpad(joystick, 1);
+
     SDL_AddHintCallback(SDL_HINT_JOYSTICK_HIDAPI_STEAM_HOME_LED,
                         SDL_HomeLEDHintChanged, ctx);
+
 
     return true;
 }
@@ -1468,6 +1473,21 @@ static bool HIDAPI_DriverSteam_UpdateDevice(SDL_HIDAPI_Device *device)
             SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_LEFTY, ~ctx->m_state.sLeftStickY);
             SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHTX, ctx->m_state.sRightPadX);
             SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHTY, ~ctx->m_state.sRightPadY);
+
+
+            //todo: check if -ctx->m_state.sLeftPadY or ~ctx->m_state.sLeftPadY gives better centering
+            SDL_SendJoystickTouchpad(timestamp, joystick, /*pad idx*/0, /*finger idx*/0,
+                     !!(ctx->m_state.ulButtons & STEAM_LEFTPAD_FINGERDOWN_MASK),//fingerdown yes/no
+                     ctx->m_state.sLeftPadX                    / 65536.0f + 0.5f,
+                     (-(int32_t)ctx->m_state.sLeftPadY)        / 65536.0f + 0.5f,
+                     (float)!!(ctx->m_state.ulButtons & STEAM_LEFTPAD_FINGERDOWN_MASK));//fake pressure
+
+            SDL_SendJoystickTouchpad(timestamp, joystick, /*pad idx*/1, /*finger idx*/0,
+                     !!(ctx->m_state.ulButtons & STEAM_RIGHTPAD_FINGERDOWN_MASK),//fingerdown yes/no
+                     ctx->m_state.sRightPadX                    / 65536.0f + 0.5f,
+                     (-(int32_t)ctx->m_state.sRightPadY)        / 65536.0f + 0.5f,
+                     (float)!!(ctx->m_state.ulButtons & STEAM_RIGHTPAD_FINGERDOWN_MASK));//fake pressure
+
 
             if (ctx->report_sensors) {
                 float values[3];

--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -1351,7 +1351,7 @@ static bool ControllerConnected(SDL_HIDAPI_Device *device, SDL_Joystick **joysti
     return true;
 }
 
-static float filter(float newValue, float oldValue, float jitter)
+static float Filter(float newValue, float oldValue, float jitter)
 {
     jitter = jitter >= 0 ? jitter : -jitter;
     if (newValue > (oldValue - jitter * 0.5f) && newValue < (oldValue + jitter * 0.5f)) {
@@ -1502,8 +1502,8 @@ static bool HIDAPI_DriverSteam_UpdateDevice(SDL_HIDAPI_Device *device)
                     fakePressure += 0.5f;
                 }
                 if (fingerDown) {
-                    oldLeftX = filter(leftX, oldLeftX, jitter);
-                    oldLeftY = filter(leftY, oldLeftY, jitter);
+                    oldLeftX = Filter(leftX, oldLeftX, jitter);
+                    oldLeftY = Filter(leftY, oldLeftY, jitter);
                 }
                 SDL_SendJoystickTouchpad(timestamp, joystick, padIndex, fingerIndex,fingerDown,oldLeftX,oldLeftY,fakePressure);
             }
@@ -1522,8 +1522,8 @@ static bool HIDAPI_DriverSteam_UpdateDevice(SDL_HIDAPI_Device *device)
                     fakePressure += 0.5f;
                 }
                 if (fingerDown) {
-                    oldRightX = filter(rightX, oldRightX, jitter);
-                    oldRightY = filter(rightY, oldRightY, jitter);
+                    oldRightX = Filter(rightX, oldRightX, jitter);
+                    oldRightY = Filter(rightY, oldRightY, jitter);
                 }
                 SDL_SendJoystickTouchpad(timestamp, joystick, padIndex, fingerIndex,fingerDown,oldRightX,oldRightY,fakePressure);
             }

--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -1351,7 +1351,6 @@ static bool ControllerConnected(SDL_HIDAPI_Device *device, SDL_Joystick **joysti
     return true;
 }
 
-
 static float filter(float newvalue, float oldvalue, float jitter)
 {
     jitter = jitter >= 0 ? jitter : -jitter;
@@ -1366,8 +1365,6 @@ static float filter(float newvalue, float oldvalue, float jitter)
     }
     return newvalue;
 }
-
-
 
 static void ControllerDisconnected(SDL_HIDAPI_Device *device, SDL_Joystick **joystick)
 {

--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -925,7 +925,6 @@ static bool UpdateBLESteamControllerState(const uint8_t *pData, int nDataSize, S
 static bool UpdateSteamControllerState(const uint8_t *pData, int nDataSize, SteamControllerStateInternal_t *pState)
 {
     ValveInReport_t *pInReport = (ValveInReport_t *)pData;
-    //the cast above is likely not safe due to struct padding rules being platform dependent
 
     if (pInReport->header.unReportVersion != k_ValveInReportMsgVersion) {
         if ((pData[0] & 0x0F) == k_EBLEReportState) {
@@ -1353,6 +1352,22 @@ static bool ControllerConnected(SDL_HIDAPI_Device *device, SDL_Joystick **joysti
     return true;
 }
 
+
+static float filter(float newvalue, float oldvalue, float jitter)
+{
+  jitter= jitter>=0 ? jitter: -jitter;
+  if (newvalue > oldvalue-jitter*0.5f && newvalue <oldvalue+ jitter*0.5f)
+      return  oldvalue;
+  if (newvalue > oldvalue- jitter && newvalue <oldvalue+ jitter)
+      return oldvalue*0.75f+newvalue*0.25f;
+  if (newvalue > oldvalue-jitter*2.0f && newvalue <oldvalue+jitter*2.0f)
+      return (oldvalue+newvalue)*0.5f;
+
+  return newvalue;
+ }
+
+
+
 static void ControllerDisconnected(SDL_HIDAPI_Device *device, SDL_Joystick **joystick)
 {
     SDL_DriverSteam_Context *ctx = (SDL_DriverSteam_Context *)device->context;
@@ -1474,20 +1489,42 @@ static bool HIDAPI_DriverSteam_UpdateDevice(SDL_HIDAPI_Device *device)
             SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHTX, ctx->m_state.sRightPadX);
             SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHTY, ~ctx->m_state.sRightPadY);
 
+{
+            int padindex=0;
+            int fingerindex=0;
+            bool fingerDown=(ctx->m_state.ulButtons & STEAM_LEFTPAD_FINGERDOWN_MASK) ? 1 : 0;
 
-            //todo: check if -ctx->m_state.sLeftPadY or ~ctx->m_state.sLeftPadY gives better centering
-            SDL_SendJoystickTouchpad(timestamp, joystick, /*pad idx*/0, /*finger idx*/0,
-                     !!(ctx->m_state.ulButtons & STEAM_LEFTPAD_FINGERDOWN_MASK),//fingerdown yes/no
-                     ctx->m_state.sLeftPadX                    / 65536.0f + 0.5f,
-                     (-(int32_t)ctx->m_state.sLeftPadY)        / 65536.0f + 0.5f,
-                     (float)!!(ctx->m_state.ulButtons & STEAM_LEFTPAD_FINGERDOWN_MASK));//fake pressure
+            bool leftPadClicked=(ctx->m_state.ulButtons & STEAM_BUTTON_LEFTPAD_CLICKED_MASK) ? 1 : 0;
+            static float oldLeftX=0;
+            static float oldLeftY=0;
+            float jitter=256.0f/(1<<16);
+            float leftX=ctx->m_state.sLeftPadX / 0x1.0p16f + 0.5f;
+            float leftY=(~ctx->m_state.sLeftPadY) / 0x1.0p16f + 0.5f;
+            oldLeftX=filter(leftX, oldLeftX, jitter);
+            oldLeftY=filter(leftY, oldLeftY, jitter);
+            float fake_pressure=fingerDown ? 0.5f : 0.0f;
+            if (leftPadClicked)
+                fake_pressure+=0.5f;
 
-            SDL_SendJoystickTouchpad(timestamp, joystick, /*pad idx*/1, /*finger idx*/0,
-                     !!(ctx->m_state.ulButtons & STEAM_RIGHTPAD_FINGERDOWN_MASK),//fingerdown yes/no
-                     ctx->m_state.sRightPadX                    / 65536.0f + 0.5f,
-                     (-(int32_t)ctx->m_state.sRightPadY)        / 65536.0f + 0.5f,
-                     (float)!!(ctx->m_state.ulButtons & STEAM_RIGHTPAD_FINGERDOWN_MASK));//fake pressure
-
+            SDL_SendJoystickTouchpad(timestamp, joystick, padindex, fingerindex,fingerDown,oldLeftX,oldLeftY,fake_pressure);
+}
+{
+            int padindex=1;
+            int fingerindex=0;
+            bool fingerDown=(ctx->m_state.ulButtons & STEAM_RIGHTPAD_FINGERDOWN_MASK) ? 1 : 0;
+            bool rightPadClicked=(ctx->m_state.ulButtons & STEAM_BUTTON_RIGHTPAD_CLICKED_MASK) ? 1 : 0;
+            static float oldRightX=0;
+            static float oldRightY=0;
+            float jitter=256.0f/(1<<16);
+            float rightX=ctx->m_state.sRightPadX / 0x1.0p16f + 0.5f;
+            float rightY=(~ctx->m_state.sRightPadY)/ 0x1.0p16f + 0.5f;
+            float fake_pressure=fingerDown ? 0.5f : 0.0f;
+            if (rightPadClicked)
+                fake_pressure+=0.5f;
+            oldRightX=filter(rightX, oldRightX, jitter);
+            oldRightY=filter(rightY, oldRightY, jitter);
+            SDL_SendJoystickTouchpad(timestamp, joystick, padindex, fingerindex,fingerDown,oldRightX,oldRightY,fake_pressure);
+}
 
             if (ctx->report_sensors) {
                 float values[3];

--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -1500,12 +1500,13 @@ static bool HIDAPI_DriverSteam_UpdateDevice(SDL_HIDAPI_Device *device)
             float jitter=256.0f/(1<<16);
             float leftX=ctx->m_state.sLeftPadX / 0x1.0p16f + 0.5f;
             float leftY=(~ctx->m_state.sLeftPadY) / 0x1.0p16f + 0.5f;
-            oldLeftX=filter(leftX, oldLeftX, jitter);
-            oldLeftY=filter(leftY, oldLeftY, jitter);
             float fake_pressure=fingerDown ? 0.5f : 0.0f;
             if (leftPadClicked)
                 fake_pressure+=0.5f;
-
+            if (fingerDown){
+                oldLeftX=filter(leftX, oldLeftX, jitter);
+                oldLeftY=filter(leftY, oldLeftY, jitter);
+            }
             SDL_SendJoystickTouchpad(timestamp, joystick, padindex, fingerindex,fingerDown,oldLeftX,oldLeftY,fake_pressure);
 }
 {
@@ -1521,8 +1522,10 @@ static bool HIDAPI_DriverSteam_UpdateDevice(SDL_HIDAPI_Device *device)
             float fake_pressure=fingerDown ? 0.5f : 0.0f;
             if (rightPadClicked)
                 fake_pressure+=0.5f;
-            oldRightX=filter(rightX, oldRightX, jitter);
-            oldRightY=filter(rightY, oldRightY, jitter);
+            if (fingerDown){
+                oldRightX=filter(rightX, oldRightX, jitter);
+                oldRightY=filter(rightY, oldRightY, jitter);
+            }
             SDL_SendJoystickTouchpad(timestamp, joystick, padindex, fingerindex,fingerDown,oldRightX,oldRightY,fake_pressure);
 }
 

--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -1354,13 +1354,13 @@ static bool ControllerConnected(SDL_HIDAPI_Device *device, SDL_Joystick **joysti
 static float filter(float newvalue, float oldvalue, float jitter)
 {
     jitter = jitter >= 0 ? jitter : -jitter;
-    if (newvalue > (oldvalue - jitter * 0.5f) && newvalue < (oldvalue + jitter * 0.5f)){
+    if (newvalue > (oldvalue - jitter * 0.5f) && newvalue < (oldvalue + jitter * 0.5f)) {
         return oldvalue;
     }
-    if (newvalue > (oldvalue - jitter) && newvalue < (oldvalue + jitter)){
+    if (newvalue > (oldvalue - jitter) && newvalue < (oldvalue + jitter)) {
         return oldvalue * 0.75f + newvalue * 0.25f;
     }
-    if (newvalue > (oldvalue - jitter * 2.0f) && newvalue < (oldvalue + jitter * 2.0f)){
+    if (newvalue > (oldvalue - jitter * 2.0f) && newvalue < (oldvalue + jitter * 2.0f)) {
         return (oldvalue + newvalue) * 0.5f;
     }
     return newvalue;
@@ -1518,10 +1518,10 @@ static bool HIDAPI_DriverSteam_UpdateDevice(SDL_HIDAPI_Device *device)
             float rightX = ctx->m_state.sRightPadX / 0x1.0p16f + 0.5f;
             float rightY = (~ctx->m_state.sRightPadY)/ 0x1.0p16f + 0.5f;
             float fake_pressure = fingerDown ? 0.5f : 0.0f;
-            if (rightPadClicked){
+            if (rightPadClicked) {
                 fake_pressure += 0.5f;
             }
-            if (fingerDown){
+            if (fingerDown) {
                 oldRightX = filter(rightX, oldRightX, jitter);
                 oldRightY = filter(rightY, oldRightY, jitter);
             }

--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -1487,46 +1487,46 @@ static bool HIDAPI_DriverSteam_UpdateDevice(SDL_HIDAPI_Device *device)
             SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHTX, ctx->m_state.sRightPadX);
             SDL_SendJoystickAxis(timestamp, joystick, SDL_GAMEPAD_AXIS_RIGHTY, ~ctx->m_state.sRightPadY);
 
-{
-            int padindex = 0;
-            int fingerindex = 0;
-            bool fingerDown = (ctx->m_state.ulButtons & STEAM_LEFTPAD_FINGERDOWN_MASK) ? 1 : 0;
-            bool leftPadClicked = (ctx->m_state.ulButtons & STEAM_BUTTON_LEFTPAD_CLICKED_MASK) ? 1 : 0;
-            static float oldLeftX = 0;
-            static float oldLeftY = 0;
-            float jitter=256.0f / (1 << 16);
-            float leftX = ctx->m_state.sLeftPadX / 0x1.0p16f + 0.5f;
-            float leftY = (~ctx->m_state.sLeftPadY) / 0x1.0p16f + 0.5f;
-            float fake_pressure = fingerDown ? 0.5f : 0.0f;
-            if (leftPadClicked) {
-                fake_pressure += 0.5f;
+            {
+                int padindex = 0;
+                int fingerindex = 0;
+                bool fingerDown = (ctx->m_state.ulButtons & STEAM_LEFTPAD_FINGERDOWN_MASK) ? 1 : 0;
+                bool leftPadClicked = (ctx->m_state.ulButtons & STEAM_BUTTON_LEFTPAD_CLICKED_MASK) ? 1 : 0;
+                static float oldLeftX = 0;
+                static float oldLeftY = 0;
+                float jitter=256.0f / (1 << 16);
+                float leftX = ctx->m_state.sLeftPadX /(float)(1 << 16) + 0.5f;
+                float leftY = (~ctx->m_state.sLeftPadY) /(float)(1 << 16) + 0.5f;
+                float fake_pressure = fingerDown ? 0.5f : 0.0f;
+                if (leftPadClicked) {
+                    fake_pressure += 0.5f;
+                }
+                if (fingerDown) {
+                    oldLeftX = filter(leftX, oldLeftX, jitter);
+                    oldLeftY = filter(leftY, oldLeftY, jitter);
+                }
+                SDL_SendJoystickTouchpad(timestamp, joystick, padindex, fingerindex,fingerDown,oldLeftX,oldLeftY,fake_pressure);
             }
-            if (fingerDown) {
-                oldLeftX = filter(leftX, oldLeftX, jitter);
-                oldLeftY = filter(leftY, oldLeftY, jitter);
+            {
+                int padindex = 1;
+                int fingerindex = 0;
+                bool fingerDown = (ctx->m_state.ulButtons & STEAM_RIGHTPAD_FINGERDOWN_MASK) ? 1 : 0;
+                bool rightPadClicked = (ctx->m_state.ulButtons & STEAM_BUTTON_RIGHTPAD_CLICKED_MASK) ? 1 : 0;
+                static float oldRightX = 0;
+                static float oldRightY = 0;
+                float jitter = 256.0f / (1 << 16);
+                float rightX = ctx->m_state.sRightPadX /(float)(1 << 16)+ 0.5f;
+                float rightY = (~ctx->m_state.sRightPadY) /(float)(1 << 16)+ 0.5f;
+                float fake_pressure = fingerDown ? 0.5f : 0.0f;
+                if (rightPadClicked) {
+                    fake_pressure += 0.5f;
+                }
+                if (fingerDown) {
+                    oldRightX = filter(rightX, oldRightX, jitter);
+                    oldRightY = filter(rightY, oldRightY, jitter);
+                }
+                SDL_SendJoystickTouchpad(timestamp, joystick, padindex, fingerindex,fingerDown,oldRightX,oldRightY,fake_pressure);
             }
-            SDL_SendJoystickTouchpad(timestamp, joystick, padindex, fingerindex,fingerDown,oldLeftX,oldLeftY,fake_pressure);
-}
-{
-            int padindex = 1;
-            int fingerindex = 0;
-            bool fingerDown = (ctx->m_state.ulButtons & STEAM_RIGHTPAD_FINGERDOWN_MASK) ? 1 : 0;
-            bool rightPadClicked = (ctx->m_state.ulButtons & STEAM_BUTTON_RIGHTPAD_CLICKED_MASK) ? 1 : 0;
-            static float oldRightX = 0;
-            static float oldRightY = 0;
-            float jitter = 256.0f / (1 << 16);
-            float rightX = ctx->m_state.sRightPadX / 0x1.0p16f + 0.5f;
-            float rightY = (~ctx->m_state.sRightPadY) / 0x1.0p16f + 0.5f;
-            float fake_pressure = fingerDown ? 0.5f : 0.0f;
-            if (rightPadClicked) {
-                fake_pressure += 0.5f;
-            }
-            if (fingerDown) {
-                oldRightX = filter(rightX, oldRightX, jitter);
-                oldRightY = filter(rightY, oldRightY, jitter);
-            }
-            SDL_SendJoystickTouchpad(timestamp, joystick, padindex, fingerindex,fingerDown,oldRightX,oldRightY,fake_pressure);
-}
 
             if (ctx->report_sensors) {
                 float values[3];

--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -1493,7 +1493,6 @@ static bool HIDAPI_DriverSteam_UpdateDevice(SDL_HIDAPI_Device *device)
             int padindex=0;
             int fingerindex=0;
             bool fingerDown=(ctx->m_state.ulButtons & STEAM_LEFTPAD_FINGERDOWN_MASK) ? 1 : 0;
-
             bool leftPadClicked=(ctx->m_state.ulButtons & STEAM_BUTTON_LEFTPAD_CLICKED_MASK) ? 1 : 0;
             static float oldLeftX=0;
             static float oldLeftY=0;


### PR DESCRIPTION
## Description
Adds the touchpads to the joystick object associated with the steam controller, and updates them when possible.

## Existing Issue(s)
Fixes https://github.com/libsdl-org/SDL/issues/15359

Should be checked by someone with more experience with the hardware who knows whether the pads are properly centered at (0,0) to decide whether it should be ~ or  - for reporting the y-coordinate. The kernel driver does this differently from SDL, so there are two different implementations out there. Overflow is not a problem here.

The cast I added a comment to should probably be changed in the future, but that might be better as its own issue to discuss it. I do not believe it is safe to keep it as is because struct padding is platform dependent.

I copied the syntax for converting from int to sdl's float format from the steam deck code, though I'm not sure this is optimal. Probably depends on whether sdl can be used on soft-float devices. It should be reasonably trivial to keep it mostly as int or fixed point except for the last step when converting to float, even provided that you want the same rounding behavior.
