### PR TITLE
xinput2: correct horizontal touchpad scrolling direction

### DIFF
--- a/src/video/x11/SDL_x11xinput2.c
+++ b/src/video/x11/SDL_x11xinput2.c
@@ -180,7 +180,7 @@ static void xinput2_parse_scrollable_valuators(const XIDeviceEvent *xev)
                             const double y = info->scroll_type == XIScrollTypeVertical ? delta : 0;
 
                             SDL_Mouse *mouse = SDL_GetMouse();
-                            SDL_SendMouseWheel(xev->time, mouse->focus, (SDL_MouseID)xev->sourceid, (float)x, (float)y, SDL_MOUSEWHEEL_NORMAL);
+                            SDL_SendMouseWheel(xev->time, mouse->focus, (SDL_MouseID)xev->sourceid, (float)-x, (float)y, SDL_MOUSEWHEEL_NORMAL);
                         }
                         info->prev_value = current_val;
                         info->prev_value_valid = true;


### PR DESCRIPTION
## Description
Discovered during https://github.com/david-vanderson/dvui testing that horizontal touchpad scrolling direction was reversed in SDL3 (SDL2 is okay) when using xinput2.

Reproduced in the testmouse test.  Currently when my two fingers move left on the touchpad the green line moves to the right.

## Existing Issue(s)
None that I could find.
