### PR TITLE
video: Prefer better pixel formats in SDL_GetClosestFullscreenDisplayMode

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -1427,6 +1427,23 @@ bool SDL_GetClosestFullscreenDisplayMode(SDL_DisplayID displayID, int w, int h, 
                  * refresh rate target */
                 continue;
             }
+
+            int closest_bpp = SDL_BITSPERPIXEL(closest->format);
+            int current_bpp = SDL_BITSPERPIXEL(mode->format);
+
+            if (closest_bpp > current_bpp) {
+                // The mode we already found has better color depth
+                continue;
+
+            } else if (closest_bpp == current_bpp) {
+                bool closest_is_indexed = SDL_ISPIXELFORMAT_INDEXED(closest->format);
+                bool current_is_indexed = SDL_ISPIXELFORMAT_INDEXED(mode->format);
+
+                if (current_is_indexed && (!closest_is_indexed)) {
+                    // The mode we already found is non indexed, prefer it over the current indexed mode
+                    continue;
+                }
+            }
         }
 
         closest = mode;


### PR DESCRIPTION

- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I have added logic to the mode picking in SDL_GetClosestFullscreenDisplayMode so that it now:
- Prefers modes with pixel formats that offer higher bits per pixel
- Prefers modes with non indexed pixel formats over modes with indexed pixel formats

Before my changes the function had no preference for any pixel format. If two identical modes existed, one with a 8 bit indexed format and one with a true color non indexed format, it would simply pick the one it finds last.
I think that is incorrect behavior for most people, who would prefer formats with higher color depth and non indexed ones.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/libsdl-org/SDL/issues/15396
Possibly fixes a part of the above issue