### PR TITLE
(video) fix SDL_GetClosestFullscreenDisplayMode preferring latter modes

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -1416,14 +1416,14 @@ bool SDL_GetClosestFullscreenDisplayMode(SDL_DisplayID displayID, int w, int h, 
         if (closest) {
             float current_aspect_ratio = (float)mode->w / mode->h;
             float closest_aspect_ratio = (float)closest->w / closest->h;
-            if (SDL_fabsf(aspect_ratio - closest_aspect_ratio) < SDL_fabsf(aspect_ratio - current_aspect_ratio)) {
-                // The mode we already found has a better aspect ratio match
+            if (SDL_fabsf(aspect_ratio - closest_aspect_ratio) <= SDL_fabsf(aspect_ratio - current_aspect_ratio)) {
+                // The mode we already found has a similar or better aspect ratio match
                 continue;
             }
 
             if (mode->w == closest->w && mode->h == closest->h &&
-                SDL_fabsf(closest->refresh_rate - refresh_rate) < SDL_fabsf(mode->refresh_rate - refresh_rate)) {
-                /* We already found a mode and the new mode is further from our
+                SDL_fabsf(closest->refresh_rate - refresh_rate) <= SDL_fabsf(mode->refresh_rate - refresh_rate)) {
+                /* We already found a mode and the new mode's refresh rate is the same or is further away from our
                  * refresh rate target */
                 continue;
             }


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed a bug in SDL_GetClosestFullscreenDisplayMode that made it pick a latter mode over an earlier mode if they both had an equal refresh rate or aspect ratio match. 
The intended behavior (as outlined in https://github.com/libsdl-org/SDL/issues/15396#issuecomment-4271092989) is to pick the mode we found first when both modes are equal in refresh rate and aspect ratio match.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/libsdl-org/SDL/issues/15396
Partially fixes the above issue