### PR TITLE
macOS mouse scroll fix

### DIFF
--- a/src/video/cocoa/SDL_cocoamouse.m
+++ b/src/video/cocoa/SDL_cocoamouse.m
@@ -33,6 +33,8 @@
 #define DEBUG_COCOAMOUSE
 #endif
 
+//#define USE_GCMOUSE_SCROLL
+
 #ifdef DEBUG_COCOAMOUSE
 #define DLog(fmt, ...) printf("%s: " fmt "\n", SDL_FUNCTION, ##__VA_ARGS__)
 #else
@@ -348,6 +350,14 @@ static void Cocoa_OnGCMouseConnected(GCMouse *mouse)
             }
         };
 
+    #ifdef USE_GCMOUSE_SCROLL
+    /*
+    18/04/2026
+    There seems to be a bug in the CGMouse API, at least when using some mouse types.
+    An event is fired only for the first scroll in one direction. Repeated 1-step
+    scrolls in the same direction do not raise an event.
+    Observed on macOS 26.3.1 with 2 different USB mice.
+    */
     mouse.mouseInput.scroll.valueChangedHandler =
         ^(GCControllerDirectionPad *dpad, float xValue, float yValue) {
             DLog("GCMouse scroll: %f, %f", xValue, yValue);
@@ -364,7 +374,8 @@ static void Cocoa_OnGCMouseConnected(GCMouse *mouse)
                                cocoa_mouse_scroll_direction);
         };
     Cocoa_UpdateGCMouseScrollDirection();
-
+    #endif
+    
     // Use high-priority queue for low-latency input
     dispatch_queue_t queue = dispatch_queue_create("org.libsdl.input.mouse",
                                                    DISPATCH_QUEUE_SERIAL);
@@ -851,10 +862,12 @@ void Cocoa_HandleMouseEvent(SDL_VideoDevice *_this, NSEvent *event)
 
 void Cocoa_HandleMouseWheel(SDL_Window *window, NSEvent *event)
 {
+    #ifdef USE_GCMOUSE_SCROLL
     // GCMouse handles scroll events directly, skip NSEvent path to avoid duplicates
     if (Cocoa_HasGCMouse()) {
         return;
     }
+    #endif
 
     SDL_MouseID mouseID = SDL_DEFAULT_MOUSE_ID;
     SDL_MouseWheelDirection direction;

--- a/src/video/cocoa/SDL_cocoamouse.m
+++ b/src/video/cocoa/SDL_cocoamouse.m
@@ -264,6 +264,9 @@ static id cocoa_mouse_disconnect_observer = nil;
 // Atomic for thread-safe access during high-frequency mouse input
 static SDL_AtomicInt cocoa_gcmouse_relative_mode;
 static bool cocoa_has_gcmouse = false;
+
+
+#ifdef USE_GCMOUSE_SCROLL
 static SDL_MouseWheelDirection cocoa_mouse_scroll_direction = SDL_MOUSEWHEEL_NORMAL;
 
 static void Cocoa_UpdateGCMouseScrollDirection(void)
@@ -283,6 +286,7 @@ static void Cocoa_UpdateGCMouseScrollDirection(void)
         cocoa_mouse_scroll_direction = SDL_MOUSEWHEEL_NORMAL;
     }
 }
+#endif
 
 static bool Cocoa_SetGCMouseRelativeMode(bool enabled)
 {

--- a/src/video/cocoa/SDL_cocoamouse.m
+++ b/src/video/cocoa/SDL_cocoamouse.m
@@ -350,11 +350,10 @@ static void Cocoa_OnGCMouseConnected(GCMouse *mouse)
 
     mouse.mouseInput.scroll.valueChangedHandler =
         ^(GCControllerDirectionPad *dpad, float xValue, float yValue) {
+            DLog("GCMouse scroll: %f, %f", xValue, yValue);
             Uint64 timestamp = SDL_GetTicksNS();
-            // Raw scroll values: vertical in first axis, horizontal in second.
-            // Vertical values are inverted compared to SDL conventions.
-            float vertical = -xValue;
-            float horizontal = yValue;
+            float vertical = yValue;
+            float horizontal = xValue;
 
             if (cocoa_mouse_scroll_direction == SDL_MOUSEWHEEL_FLIPPED) {
                 vertical = -vertical;

--- a/src/video/cocoa/SDL_cocoamouse.m
+++ b/src/video/cocoa/SDL_cocoamouse.m
@@ -378,7 +378,7 @@ static void Cocoa_OnGCMouseConnected(GCMouse *mouse)
                                cocoa_mouse_scroll_direction);
         };
     Cocoa_UpdateGCMouseScrollDirection();
-    #endif
+    #endif // USE_GCMOUSE_SCROLL
     
     // Use high-priority queue for low-latency input
     dispatch_queue_t queue = dispatch_queue_create("org.libsdl.input.mouse",


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description

Recently, mouse handling on macOS has been upgraded to the GCMouse API, which is overall an improvement over AppKit events. However, 2 issues have been observed and reported in #15286. In short:
- Swapped horizontal/vertical axes
- No events on repeated 1-step scrolls in the same direction (apparently a CGMouse bug)

This PR fixes both:
- The horizontal/vertical axes and directions were fixed. Tested on an external mouse with both _Natural scrolling_ enabled and not.
- The scroll handling was reverted to use AppKit (this makes the previous change irrelevant, but could be re-enabled in the future if the CGMouse API bug gets fixed).

The mouse movement and button handling are still handled via CGMouse (if available) so they're not affected.