### PR TITLE
Improve constness with Clipboard APIs

### DIFF
--- a/include/SDL3/SDL_clipboard.h
+++ b/include/SDL3/SDL_clipboard.h
@@ -252,7 +252,7 @@ typedef void (SDLCALL *SDL_ClipboardCleanupCallback)(void *userdata);
  * \sa SDL_GetClipboardData
  * \sa SDL_HasClipboardData
  */
-extern SDL_DECLSPEC bool SDLCALL SDL_SetClipboardData(SDL_ClipboardDataCallback callback, SDL_ClipboardCleanupCallback cleanup, void *userdata, const char **mime_types, size_t num_mime_types);
+extern SDL_DECLSPEC bool SDLCALL SDL_SetClipboardData(SDL_ClipboardDataCallback callback, SDL_ClipboardCleanupCallback cleanup, void *userdata, const char *const *mime_types, size_t num_mime_types);
 
 /**
  * Clear the clipboard data.

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -830,7 +830,7 @@ SDL_DYNAPI_PROC(bool,SDL_SetAudioStreamInputChannelMap,(SDL_AudioStream *a, cons
 SDL_DYNAPI_PROC(bool,SDL_SetAudioStreamOutputChannelMap,(SDL_AudioStream *a, const int *b, int c),(a,b,c),return)
 SDL_DYNAPI_PROC(bool,SDL_SetAudioStreamPutCallback,(SDL_AudioStream *a, SDL_AudioStreamCallback b, void *c),(a,b,c),return)
 SDL_DYNAPI_PROC(bool,SDL_SetBooleanProperty,(SDL_PropertiesID a, const char *b, bool c),(a,b,c),return)
-SDL_DYNAPI_PROC(bool,SDL_SetClipboardData,(SDL_ClipboardDataCallback a, SDL_ClipboardCleanupCallback b, void *c, const char **d, size_t e),(a,b,c,d,e),return)
+SDL_DYNAPI_PROC(bool,SDL_SetClipboardData,(SDL_ClipboardDataCallback a, SDL_ClipboardCleanupCallback b, void *c, const char *const *d, size_t e),(a,b,c,d,e),return)
 SDL_DYNAPI_PROC(bool,SDL_SetClipboardText,(const char *a),(a),return)
 SDL_DYNAPI_PROC(bool,SDL_SetCurrentThreadPriority,(SDL_ThreadPriority a),(a),return)
 SDL_DYNAPI_PROC(bool,SDL_SetCursor,(SDL_Cursor *a),(a),return)

--- a/src/video/SDL_clipboard.c
+++ b/src/video/SDL_clipboard.c
@@ -62,7 +62,7 @@ void SDL_CancelClipboardData(Uint32 sequence)
     _this->clipboard_userdata = NULL;
 }
 
-bool SDL_SaveClipboardMimeTypes(const char **mime_types, size_t num_mime_types)
+bool SDL_SaveClipboardMimeTypes(const char *const *mime_types, size_t num_mime_types)
 {
     SDL_VideoDevice *_this = SDL_GetVideoDevice();
 
@@ -93,7 +93,7 @@ bool SDL_SaveClipboardMimeTypes(const char **mime_types, size_t num_mime_types)
     return true;
 }
 
-bool SDL_SetClipboardData(SDL_ClipboardDataCallback callback, SDL_ClipboardCleanupCallback cleanup, void *userdata, const char **mime_types, size_t num_mime_types)
+bool SDL_SetClipboardData(SDL_ClipboardDataCallback callback, SDL_ClipboardCleanupCallback cleanup, void *userdata, const char *const *mime_types, size_t num_mime_types)
 {
     SDL_VideoDevice *_this = SDL_GetVideoDevice();
 
@@ -265,7 +265,7 @@ bool SDL_HasClipboardData(const char *mime_type)
     }
 }
 
-char **SDL_CopyClipboardMimeTypes(const char **clipboard_mime_types, size_t num_mime_types, bool temporary)
+char **SDL_CopyClipboardMimeTypes(const char *const *clipboard_mime_types, size_t num_mime_types, bool temporary)
 {
     size_t allocSize = sizeof(char *);
     for (size_t i = 0; i < num_mime_types; i++) {
@@ -326,12 +326,12 @@ bool SDL_IsTextMimeType(const char *mime_type)
     return (SDL_strncmp(mime_type, "text", 4) == 0);
 }
 
-static const char **SDL_GetTextMimeTypes(SDL_VideoDevice *_this, size_t *num_mime_types)
+static const char *const *SDL_GetTextMimeTypes(SDL_VideoDevice *_this, size_t *num_mime_types)
 {
     if (_this->GetTextMimeTypes) {
         return _this->GetTextMimeTypes(_this, num_mime_types);
     } else {
-        static const char *text_mime_types[] = {
+        static const char *const text_mime_types[] = {
             "text/plain;charset=utf-8"
         };
 
@@ -355,7 +355,7 @@ bool SDL_SetClipboardText(const char *text)
 {
     SDL_VideoDevice *_this = SDL_GetVideoDevice();
     size_t num_mime_types;
-    const char **text_mime_types;
+    const char *const *text_mime_types;
 
     if (!_this) {
         return SDL_UninitializedVideo();
@@ -373,7 +373,7 @@ char *SDL_GetClipboardText(void)
 {
     SDL_VideoDevice *_this = SDL_GetVideoDevice();
     size_t i, num_mime_types;
-    const char **text_mime_types;
+    const char *const *text_mime_types;
     size_t length;
     char *text = NULL;
 
@@ -401,7 +401,7 @@ bool SDL_HasClipboardText(void)
 {
     SDL_VideoDevice *_this = SDL_GetVideoDevice();
     size_t i, num_mime_types;
-    const char **text_mime_types;
+    const char *const *text_mime_types;
 
     if (!_this) {
         return SDL_UninitializedVideo();

--- a/src/video/SDL_clipboard_c.h
+++ b/src/video/SDL_clipboard_c.h
@@ -39,8 +39,8 @@ extern bool SDL_HasInternalClipboardData(SDL_VideoDevice *_this, const char *mim
 // General purpose clipboard text callback
 const void * SDLCALL SDL_ClipboardTextCallback(void *userdata, const char *mime_type, size_t *size);
 
-bool SDL_SaveClipboardMimeTypes(const char **mime_types, size_t num_mime_types);
+bool SDL_SaveClipboardMimeTypes(const char *const *mime_types, size_t num_mime_types);
 void SDL_FreeClipboardMimeTypes(SDL_VideoDevice *_this);
-char **SDL_CopyClipboardMimeTypes(const char **clipboard_mime_types, size_t num_mime_types, bool temporary);
+char **SDL_CopyClipboardMimeTypes(const char *const *clipboard_mime_types, size_t num_mime_types, bool temporary);
 
 #endif // SDL_clipboard_c_h_

--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -376,7 +376,7 @@ struct SDL_VideoDevice
     void (*SetTextInputProperties)(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesID props);
 
     // Clipboard
-    const char **(*GetTextMimeTypes)(SDL_VideoDevice *_this, size_t *num_mime_types);
+    const char *const *(*GetTextMimeTypes)(SDL_VideoDevice *_this, size_t *num_mime_types);
     bool (*SetClipboardData)(SDL_VideoDevice *_this);
     void *(*GetClipboardData)(SDL_VideoDevice *_this, const char *mime_type, size_t *size);
     bool (*HasClipboardData)(SDL_VideoDevice *_this, const char *mime_type);

--- a/src/video/wayland/SDL_waylandclipboard.c
+++ b/src/video/wayland/SDL_waylandclipboard.c
@@ -96,7 +96,7 @@ bool Wayland_HasClipboardData(SDL_VideoDevice *_this, const char *mime_type)
     return result;
 }
 
-static const char *text_mime_types[] = {
+static const char *const text_mime_types[] = {
     TEXT_MIME,
     "text/plain",
     "TEXT",
@@ -104,7 +104,7 @@ static const char *text_mime_types[] = {
     "STRING"
 };
 
-const char **Wayland_GetTextMimeTypes(SDL_VideoDevice *_this, size_t *num_mime_types)
+const char *const *Wayland_GetTextMimeTypes(SDL_VideoDevice *_this, size_t *num_mime_types)
 {
     *num_mime_types = SDL_arraysize(text_mime_types);
     return text_mime_types;
@@ -185,7 +185,7 @@ bool Wayland_HasPrimarySelectionText(SDL_VideoDevice *_this)
             result = true;
         } else {
             size_t mime_count = 0;
-            const char **mime_types = Wayland_GetTextMimeTypes(_this, &mime_count);
+            const char *const *mime_types = Wayland_GetTextMimeTypes(_this, &mime_count);
             for (size_t i = 0; i < mime_count; i++) {
                 if (Wayland_primary_selection_offer_has_mime(primary_selection_device->selection_offer, mime_types[i])) {
                     result = true;

--- a/src/video/wayland/SDL_waylandclipboard.h
+++ b/src/video/wayland/SDL_waylandclipboard.h
@@ -23,7 +23,7 @@
 #ifndef SDL_waylandclipboard_h_
 #define SDL_waylandclipboard_h_
 
-extern const char **Wayland_GetTextMimeTypes(SDL_VideoDevice *_this, size_t *num_mime_types);
+extern const char *const *Wayland_GetTextMimeTypes(SDL_VideoDevice *_this, size_t *num_mime_types);
 extern bool Wayland_SetClipboardData(SDL_VideoDevice *_this);
 extern void *Wayland_GetClipboardData(SDL_VideoDevice *_this, const char *mime_type, size_t *length);
 extern bool Wayland_HasClipboardData(SDL_VideoDevice *_this, const char *mime_type);

--- a/src/video/wayland/SDL_waylanddatamanager.c
+++ b/src/video/wayland/SDL_waylanddatamanager.c
@@ -705,7 +705,7 @@ bool Wayland_data_device_set_selection(SDL_WaylandDataDevice *data_device,
 
 bool Wayland_primary_selection_device_set_selection(SDL_WaylandPrimarySelectionDevice *primary_selection_device,
                                                    SDL_WaylandPrimarySelectionSource *source,
-                                                   const char **mime_types,
+                                                   const char *const *mime_types,
                                                    size_t mime_count)
 {
     bool result = true;

--- a/src/video/wayland/SDL_waylanddatamanager.h
+++ b/src/video/wayland/SDL_waylanddatamanager.h
@@ -167,7 +167,7 @@ extern bool Wayland_data_device_set_selection(SDL_WaylandDataDevice *device,
                                               size_t mime_count);
 extern bool Wayland_primary_selection_device_set_selection(SDL_WaylandPrimarySelectionDevice *device,
                                                            SDL_WaylandPrimarySelectionSource *source,
-                                                           const char **mime_types,
+                                                           const char *const *mime_types,
                                                            size_t mime_count);
 extern void Wayland_data_device_set_serial(SDL_WaylandDataDevice *device,
                                            uint32_t serial);

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -2824,7 +2824,7 @@ static void data_device_handle_enter(void *data, struct wl_data_device *wl_data_
         }
 
         size_t mime_count = 0;
-        const char **text_mime_types = Wayland_GetTextMimeTypes(SDL_GetVideoDevice(), &mime_count);
+        const char *const *text_mime_types = Wayland_GetTextMimeTypes(SDL_GetVideoDevice(), &mime_count);
         for (size_t i = 0; i < mime_count; ++i) {
             if (Wayland_data_offer_has_mime(data_device->drag_offer, text_mime_types[i])) {
                 data_device->has_mime_text = true;

--- a/src/video/x11/SDL_x11clipboard.c
+++ b/src/video/x11/SDL_x11clipboard.c
@@ -29,7 +29,7 @@
 #include "../SDL_clipboard_c.h"
 #include "../../events/SDL_events_c.h"
 
-static const char *text_mime_types[] = {
+static const char *const text_mime_types[] = {
     "UTF8_STRING",
     "text/plain;charset=utf-8",
     "text/plain",
@@ -62,7 +62,7 @@ Window GetWindow(SDL_VideoDevice *_this)
 }
 
 static bool SetSelectionData(SDL_VideoDevice *_this, Atom selection, SDL_ClipboardDataCallback callback,
-                            void *userdata, const char **mime_types, size_t mime_count, Uint32 sequence)
+                            void *userdata, const char *const *mime_types, size_t mime_count, Uint32 sequence)
 {
     SDL_VideoData *videodata = _this->internal;
     Display *display = videodata->display;
@@ -258,7 +258,7 @@ static void *GetSelectionData(SDL_VideoDevice *_this, Atom selection_type,
     return data;
 }
 
-const char **X11_GetTextMimeTypes(SDL_VideoDevice *_this, size_t *num_mime_types)
+const char *const *X11_GetTextMimeTypes(SDL_VideoDevice *_this, size_t *num_mime_types)
 {
     *num_mime_types = SDL_arraysize(text_mime_types);
     return text_mime_types;

--- a/src/video/x11/SDL_x11clipboard.h
+++ b/src/video/x11/SDL_x11clipboard.h
@@ -28,12 +28,12 @@
 typedef struct X11_ClipboardData {
     SDL_ClipboardDataCallback callback;
     void *userdata;
-    const char **mime_types;
+    const char *const *mime_types;
     size_t mime_count;
     Uint32 sequence;
 } SDLX11_ClipboardData;
 
-extern const char **X11_GetTextMimeTypes(SDL_VideoDevice *_this, size_t *num_mime_types);
+extern const char *const *X11_GetTextMimeTypes(SDL_VideoDevice *_this, size_t *num_mime_types);
 extern bool X11_SetClipboardData(SDL_VideoDevice *_this);
 extern void *X11_GetClipboardData(SDL_VideoDevice *_this, const char *mime_type, size_t *length);
 extern bool X11_HasClipboardData(SDL_VideoDevice *_this, const char *mime_type);


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description

Using `const char *const` for arrays of pointers ensures that the array itself is const, not just the data being pointed to, allowing it to be included in a read-only data segment.

The public `SDL_SetClipboardData` has been changed, however it shouldn't (in theory) affect compatibility with existing applications.