### PR TITLE
atomic: Fix missing full memory barrier on GCC/Clang (SDL2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2812,6 +2812,7 @@ elseif(PS2)
     gskit
     dmakit
     ps2_drivers
+    atomic
   )
 
 elseif(OS2)

--- a/src/atomic/SDL_atomic.c
+++ b/src/atomic/SDL_atomic.c
@@ -35,11 +35,17 @@
 #include <atomic.h>
 #endif
 
-/* The __atomic_load_n() intrinsic showed up in different times for different compilers. */
-#if defined(__GNUC__) && (__GNUC__ >= 5)
+/* The __atomic intrinsics showed up in different times for different compilers. */
+#if (defined(__GNUC__) && (__GNUC__ >= 5)) || (defined(__clang__) && defined(HAVE_GCC_ATOMICS))
 #define HAVE_ATOMIC_LOAD_N 1
-#elif _SDL_HAS_BUILTIN(__atomic_load_n) || (defined(__clang__) && defined(HAVE_GCC_ATOMICS))
+#define HAVE_ATOMIC_EXCHANGE_N 1
+#else
+#if _SDL_HAS_BUILTIN(__atomic_load_n)
 #define HAVE_ATOMIC_LOAD_N 1
+#endif
+#if _SDL_HAS_BUILTIN(__atomic_exchange_n)
+#define HAVE_ATOMIC_EXCHANGE_N 1
+#endif
 #endif
 
 /* *INDENT-OFF* */ /* clang-format off */
@@ -182,7 +188,15 @@ int SDL_AtomicSet(SDL_atomic_t *a, int v)
     return _InterlockedExchange((long *)&a->value, v);
 #elif defined(HAVE_WATCOM_ATOMICS)
     return _SDL_xchg_watcom(&a->value, v);
+#elif defined(HAVE_ATOMIC_EXCHANGE_N)
+    return __atomic_exchange_n(&a->value, v, __ATOMIC_SEQ_CST);
 #elif defined(HAVE_GCC_ATOMICS)
+    /* __sync_lock_test_and_set() is designed for locking rather than a
+       generic atomic exchange, so it only provides an acquire barrier
+       and may not store the exact value on all architectures. We prefer
+       __atomic_exchange_n() instead on all modern compilers.
+    */
+    __sync_synchronize();
     return __sync_lock_test_and_set(&a->value, v);
 #elif defined(__SOLARIS__)
     return (int)atomic_swap_uint((volatile uint_t *)&a->value, v);
@@ -201,7 +215,15 @@ void *SDL_AtomicSetPtr(void **a, void *v)
     return _InterlockedExchangePointer(a, v);
 #elif defined(HAVE_WATCOM_ATOMICS)
     return (void *)_SDL_xchg_watcom((int *)a, (long)v);
+#elif defined(HAVE_ATOMIC_EXCHANGE_N)
+    return __atomic_exchange_n(a, v, __ATOMIC_SEQ_CST);
 #elif defined(HAVE_GCC_ATOMICS)
+    /* __sync_lock_test_and_set() is designed for locking rather than a
+       generic atomic exchange, so it only provides an acquire barrier
+       and may not store the exact value on all architectures. We prefer
+       __atomic_exchange_n() instead on all modern compilers.
+    */
+    __sync_synchronize();
     return __sync_lock_test_and_set(a, v);
 #elif defined(__SOLARIS__)
     return atomic_swap_ptr(a, v);


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
`__sync_lock_test_and_set()` is designed for creating locks, not as a general atomic exchange function. As a result, it only provides an acquire memory barrier and isn't guaranteed to actually store the provided value (though it does on architectures we care about).

`__atomic_exchange_n()` is supported on GCC/Clang for the last ~10 years, so let's use that instead if available. We will keep the `__sync_lock_test_and_set()` fallback around for ancient platforms, but add a full memory barrier to match the documented behavior.

## Existing Issue(s)
Closes #15409 
