### PR TITLE
Fixes cursor scaling on Wayland

### DIFF
--- a/src/video/wayland/SDL_waylandmouse.c
+++ b/src/video/wayland/SDL_waylandmouse.c
@@ -1132,6 +1132,7 @@ static void Wayland_CursorStateSetCursor(SDL_WaylandCursorState *state, const Wa
                 state->viewport = wp_viewporter_get_viewport(viddata->viewporter, state->surface);
             }
 
+            wl_surface_set_buffer_scale(state->surface, SDL_ceil(state->scale));
             wp_viewport_set_source(state->viewport, wl_fixed_from_int(-1), wl_fixed_from_int(-1), wl_fixed_from_int(-1), wl_fixed_from_int(-1));
             wp_viewport_set_destination(state->viewport, dst_width, dst_height);
         } else if (state->viewport) {


### PR DESCRIPTION
resolves #15416

- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description

On my Wayland setup, SDL was previously picking the correct cursors, but then rendering them at larger-than-actual resolution this resulted in blurry and incorreclty cropped cursors.

This is my resolution. It resolves the issue on my test setup, but I'm not familiar with these APIs so it's definitely possible there's a better way to fix this. My call to `ceil` in particular is a little suspicious--maybe there's some other integer parameter I'm supposed to be passing into buffer scale, or some other way to prevent Wayland from scaling the image up?

## Existing Issue(s)

#15416