### PR TITLE
joystick: Add VIRPIL Controls flight stick and throttle device IDs.

### DIFF
--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -477,6 +477,8 @@ static Uint32 initial_flightstick_devices[] = {
     MAKE_VIDPID(0x231d, 0x0126), // Gunfighter Mk.III 'Space Combat Edition' (right)
     MAKE_VIDPID(0x231d, 0x0127), // Gunfighter Mk.III 'Space Combat Edition' (left)
     MAKE_VIDPID(0x362c, 0x0001), // Yawman Arrow
+    MAKE_VIDPID(0x3344, 0x4391), // VIRPIL Controls R-VPC Stick MT-50CM3
+    MAKE_VIDPID(0x3344, 0x8390), // VIRPIL Controls L-VPC Stick MT-50CM3
 };
 static SDL_vidpid_list flightstick_devices = {
     SDL_HINT_JOYSTICK_FLIGHTSTICK_DEVICES, 0, 0, NULL,
@@ -523,6 +525,7 @@ static Uint32 initial_throttle_devices[] = {
     MAKE_VIDPID(0x044f, 0x0404), // HOTAS Warthog Throttle
     MAKE_VIDPID(0x0738, 0xa221), // Saitek Pro Flight X-56 Rhino Throttle
     MAKE_VIDPID(0x10f5, 0x7085), // Turtle Beach VelocityOne Throttle
+    MAKE_VIDPID(0x3344, 0x0196), // VIRPIL Controls VPC VMAX Prime Throttle
 };
 static SDL_vidpid_list throttle_devices = {
     SDL_HINT_JOYSTICK_THROTTLE_DEVICES, 0, 0, NULL,

--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -476,9 +476,9 @@ static Uint32 initial_flightstick_devices[] = {
     MAKE_VIDPID(0x10f5, 0x7084), // Turtle Beach VelocityOne
     MAKE_VIDPID(0x231d, 0x0126), // Gunfighter Mk.III 'Space Combat Edition' (right)
     MAKE_VIDPID(0x231d, 0x0127), // Gunfighter Mk.III 'Space Combat Edition' (left)
-    MAKE_VIDPID(0x362c, 0x0001), // Yawman Arrow
     MAKE_VIDPID(0x3344, 0x4391), // VIRPIL Controls R-VPC Stick MT-50CM3
     MAKE_VIDPID(0x3344, 0x8390), // VIRPIL Controls L-VPC Stick MT-50CM3
+    MAKE_VIDPID(0x362c, 0x0001), // Yawman Arrow
 };
 static SDL_vidpid_list flightstick_devices = {
     SDL_HINT_JOYSTICK_FLIGHTSTICK_DEVICES, 0, 0, NULL,


### PR DESCRIPTION
VIRPIL Controls (VID 0x3344) flight sticks are misclassified as gamepads by SDL's axis-count heuristic because they report exactly 6 axes, matching SDL_GAMEPAD_AXIS_COUNT. Adding them to the appropriate device lists ensures correct classification.

Tested on Linux (Fedora 43, kernel 6.19) with:
- R-VPC Stick MT-50CM3 (PID 0x4391) -> SDL_JOYSTICK_TYPE_FLIGHT_STICK
- L-VPC Stick MT-50CM3 (PID 0x8390) -> SDL_JOYSTICK_TYPE_FLIGHT_STICK
- VPC VMAX Prime Throttle (PID 0x0196) -> SDL_JOYSTICK_TYPE_THROTTLE

- [ ] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
VIRPIL Controls (VID 0x3344) produces professional HOTAS flight 
simulation hardware. Their flight sticks report exactly 6 axes 
(X, Y, Z, Rx, Ry, Rz), which matches SDL_GAMEPAD_AXIS_COUNT and 
triggers SDL's gamepad auto-detection heuristic, causing them to be 
misclassified as gamepads.

The HID descriptor correctly declares these devices as joysticks 
(Usage Page 0x01, Usage 0x04). The Linux kernel correctly classifies 
them as ID_INPUT_JOYSTICK=1. The misclassification occurs only at the 
SDL layer.

Adding the affected PIDs to initial_flightstick_devices and 
initial_throttle_devices ensures correct classification without 
affecting device visibility.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
No existing issue. This PR introduces the fix and documents the 
root cause for the first time.

## Notes
This fix was developed collaboratively with an AI assistant (Claude 
by Anthropic) which helped diagnose the root cause by analyzing the 
SDL source code and USB HID descriptor data. The hardware testing, 
verification, and final decisions were performed by the author on 
physical VIRPIL hardware connected to a Linux system (Fedora 43, 
kernel 6.19).