### PR TITLE
Fix potential leak in camera example

### DIFF
--- a/examples/camera/01-read-and-draw/read-and-draw.c
+++ b/examples/camera/01-read-and-draw/read-and-draw.c
@@ -44,6 +44,7 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
         return SDL_APP_FAILURE;
     } else if (devcount == 0) {
         SDL_Log("Couldn't find any camera devices! Please connect a camera and try again.");
+        SDL_free(devices);
         return SDL_APP_FAILURE;
     }
 


### PR DESCRIPTION
Happens when no camera devices are connected.

```
./camera-read-and-draw

Couldn't find any camera devices! Please connect a camera and try again.

=================================================================
==797479==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 4 byte(s) in 1 object(s) allocated from:
    #0 0x7f4d1d520cb5 in malloc (/usr/lib/libasan.so.8+0x120cb5) (BuildId: 0b96d08695bbce2da9d4770c29ad2e72fb536f47)
    #1 0x7f4d1a97dfe5 in real_malloc SDL3/src/stdlib/SDL_malloc.c:6452
    #2 0x7f4d1a97e497 in SDL_malloc_REAL SDL3/src/stdlib/SDL_malloc.c:6577
    #3 0x7f4d1a500dc0 in SDL_GetCameras_REAL SDL3/src/camera/SDL_camera.c:747
    #4 0x7f4d1a5206b6 in SDL_GetCameras SDL3/src/dynapi/SDL_dynapi_procs.h:295
    #5 0x55dded9ec559 in SDL_AppInit SDL3/examples/camera/01-read-and-draw/read-and-draw.c:41
    #6 0x7f4d1a6316e5 in SDL_InitMainCallbacks SDL3/src/main/SDL_main_callbacks.c:104
    #7 0x7f4d1b440ae2 in SDL_EnterAppMainCallbacks_REAL SDL3/src/main/generic/SDL_sysmain_callbacks.c:56
    #8 0x7f4d1a51fbe3 in SDL_EnterAppMainCallbacks SDL3/src/dynapi/SDL_dynapi_procs.h:207
    #9 0x55dded9ec387 in SDL_main SDL3/include/SDL3/SDL_main_impl.h:59
    #10 0x7f4d1a631a47 in SDL_CallMainFunction SDL3/src/main/SDL_main_callbacks.c:164
    #11 0x7f4d1a631b24 in SDL_RunApp_REAL SDL3/src/main/SDL_runapp.c:37
    #12 0x7f4d1a5168ae in SDL_RunApp_DEFAULT SDL3/src/dynapi/SDL_dynapi_procs.h:804
    #13 0x7f4d1a524c58 in SDL_RunApp SDL3/src/dynapi/SDL_dynapi_procs.h:804
    #14 0x55dded9ec3b2 in main SDL3/include/SDL3/SDL_main_impl.h:137
    #15 0x7f4d184366c0  (/usr/lib/libc.so.6+0x276c0) (BuildId: 7a8d41a2df4fde040b4c6ac2832311ab645a1e41)
    #16 0x7f4d184367f8 in __libc_start_main (/usr/lib/libc.so.6+0x277f8) (BuildId: 7a8d41a2df4fde040b4c6ac2832311ab645a1e41)
    #17 0x55dded9ec274 in _start (SDL3/builds/examples/camera-read-and-draw+0x3274) (BuildId: 760993fb3196e14208ee479f1b8d6dbee1b40aa8)

SUMMARY: AddressSanitizer: 4 byte(s) leaked in 1 allocation(s).
```