### PR TITLE
dialog: Use case-insensitive filter matching on portal dialogs

### DIFF
--- a/src/dialog/unix/SDL_portaldialog.c
+++ b/src/dialog/unix/SDL_portaldialog.c
@@ -86,9 +86,24 @@ static void DBus_AppendFilter(SDL_DBusContext *dbus, DBusMessageIter *parent, co
     dbus->message_iter_append_basic(&filter_entry, DBUS_TYPE_STRING, &filter.name);
     dbus->message_iter_open_container(&filter_entry, DBUS_TYPE_ARRAY, "(us)", &filter_array);
 
-    patterns = SDL_strdup(filter.pattern);
+    /* Copy the filter string, converting to a case-insensitive version.
+     * For example, for case-insensitive matching of '*.png', the pattern '*.[pP][nN][gG]' is used.
+     */
+    const size_t len = SDL_strlen(filter.pattern) + 1;
+    patterns = SDL_malloc(len * 4); // Single characters may be expanded to 4 characters.
     if (!patterns) {
         goto cleanup;
+    }
+    for (size_t i = 0, p = 0; i < len; ++i) {
+        if ((filter.pattern[i] >= 'a' && filter.pattern[i] <= 'z') ||
+            (filter.pattern[i] >= 'A' && filter.pattern[i] <= 'Z')) {
+            patterns[p++] = '[';
+            patterns[p++] = SDL_tolower(filter.pattern[i]);
+            patterns[p++] = SDL_toupper(filter.pattern[i]);
+            patterns[p++] = ']';
+        } else {
+            patterns[p++] = filter.pattern[i];
+        }
     }
 
     pattern = SDL_strtok_r(patterns, ";", &state);


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

On most dialog portal implementations, file selection filter pattern matching is case-sensitive. For case-insensitive matching of a pattern such as '*.png', the pattern *.[pP][nN][gG]' must be used.

https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.FileChooser.html

I would imagine that something similar should be possible for Zenity, however, after converting the filter strings to that pattern in convert_ext_list(), Zenity just hangs when started. @Semphriss any ideas?

This at least fixes it in the portal dialogs, which is what anything remotely modern will be using anyway.

Fixes #15398