### PR TITLE
Added rumble to Gamecube Adapter PC_Mode

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_gamecube.c
+++ b/src/joystick/hidapi/SDL_hidapi_gamecube.c
@@ -37,6 +37,7 @@
 #endif
 
 #define MAX_CONTROLLERS 4
+#define PC_RUMBLE_REFRESH 16
 
 typedef struct
 {
@@ -50,6 +51,8 @@ typedef struct
     // Without this variable, hid_write starts to lag a TON
     bool rumbleUpdate;
     bool useRumbleBrake;
+    bool rumbleActive;
+    Uint64 pc_rumble_sent;
 } SDL_DriverGameCube_Context;
 
 static void HIDAPI_DriverGameCube_RegisterHints(SDL_HintCallback callback, void *userdata)
@@ -427,6 +430,14 @@ static void HIDAPI_DriverGameCube_HandleNintendoPacket(SDL_HIDAPI_Device *device
     }
 }
 
+static void HIDAPI_DriverGameCube_SendPCRumble(SDL_HIDAPI_Device *device, SDL_DriverGameCube_Context *ctx)
+{
+    Uint8 rumblepkt[3] = { 0x00, 0x00, 0x00 };
+    rumblepkt[1] = rumblepkt[2] = ctx->rumbleActive ? 0xFF : 0x00;
+    SDL_HIDAPI_SendRumble(device, rumblepkt, sizeof(rumblepkt));
+    ctx->pc_rumble_sent = SDL_GetTicks();
+}
+
 static bool HIDAPI_DriverGameCube_UpdateDevice(SDL_HIDAPI_Device *device)
 {
     SDL_DriverGameCube_Context *ctx = (SDL_DriverGameCube_Context *)device->context;
@@ -443,10 +454,15 @@ static bool HIDAPI_DriverGameCube_UpdateDevice(SDL_HIDAPI_Device *device)
                 // This is the older firmware
                 // The first byte is the index of the connected controller
                 // The C stick has an inverted value range compared to the left stick
+                // I don't have an adapter with an old firmware to check if the rumble works with it so it is set to false
+                ctx->rumbleAllowed[0] = ctx->rumbleAllowed[1] = ctx->rumbleAllowed[2] = ctx->rumbleAllowed[3] = false;
                 HIDAPI_DriverGameCube_HandleJoystickPacket(device, ctx, packet[0] - 1, &packet[1], true);
             } else if (size == 9) {
                 // This is the newer firmware (version 0x7)
                 // The C stick has the same value range compared to the left stick
+                // AFAIK In PC_Mode there is no way to check if the second USB is connected or if the connected controller is a wavebird
+                // So if it passes the firmware size check I set it to true
+                ctx->rumbleAllowed[0] = ctx->rumbleAllowed[1] = ctx->rumbleAllowed[2] = ctx->rumbleAllowed[3] = true; 
                 HIDAPI_DriverGameCube_HandleJoystickPacket(device, ctx, 0, packet, false);
             } else {
                 // How do we handle this packet?
@@ -454,6 +470,11 @@ static bool HIDAPI_DriverGameCube_UpdateDevice(SDL_HIDAPI_Device *device)
         } else {
             HIDAPI_DriverGameCube_HandleNintendoPacket(device, ctx, packet, size);
         }
+    }
+
+    // PC_Mode rumble needs constant packets in order to keep rumble going
+    if (ctx->pc_mode && ctx->rumbleActive && SDL_GetTicks() >= (ctx->pc_rumble_sent + PC_RUMBLE_REFRESH)) {
+        HIDAPI_DriverGameCube_SendPCRumble(device, ctx);
     }
 
     // Write rumble packet
@@ -496,33 +517,51 @@ static bool HIDAPI_DriverGameCube_RumbleJoystick(SDL_HIDAPI_Device *device, SDL_
     SDL_AssertJoysticksLocked();
 
     if (ctx->pc_mode) {
-        return SDL_Unsupported();
-    }
-
-    for (i = 0; i < MAX_CONTROLLERS; i += 1) {
-        if (joystick->instance_id == ctx->joysticks[i]) {
-            if (ctx->wireless[i]) {
-                return SDL_SetError("Nintendo GameCube WaveBird controllers do not support rumble");
-            }
-            if (!ctx->rumbleAllowed[i]) {
-                return SDL_SetError("Second USB cable for WUP-028 not connected");
-            }
-            if (ctx->useRumbleBrake) {
-                if (low_frequency_rumble == 0 && high_frequency_rumble > 0) {
-                    val = 0; // if only low is 0 we want to do a regular stop
-                } else if (low_frequency_rumble == 0 && high_frequency_rumble == 0) {
-                    val = 2; // if both frequencies are 0 we want to do a hard stop
-                } else {
-                    val = 1; // normal rumble
+        for (i = 0; i < MAX_CONTROLLERS; i += 1) {
+            if (joystick->instance_id == ctx->joysticks[i]) {
+                if (!ctx->rumbleAllowed[i]) {
+                    return SDL_SetError("Rumble is disabled because the adapter is not at least of firmware 0x7");
                 }
-            } else {
-                val = (low_frequency_rumble > 0 || high_frequency_rumble > 0);
+                bool shouldrumble = false, coast = false;
+                if (ctx->useRumbleBrake) {
+                    coast = (low_frequency_rumble == 0 && high_frequency_rumble > 0);
+                }
+                shouldrumble = (low_frequency_rumble > 0 || high_frequency_rumble > 0);
+                if (coast) {
+                    ctx->rumbleActive = false;
+                } else if (shouldrumble != ctx->rumbleActive) {
+                    ctx->rumbleActive = shouldrumble;
+                    HIDAPI_DriverGameCube_SendPCRumble(device, ctx);
+                }
+                return true;
             }
-            if (val != ctx->rumble[i + 1]) {
-                ctx->rumble[i + 1] = val;
-                ctx->rumbleUpdate = true;
+        }
+    } else {
+        for (i = 0; i < MAX_CONTROLLERS; i += 1) {
+            if (joystick->instance_id == ctx->joysticks[i]) {
+                if (ctx->wireless[i]) {
+                    return SDL_SetError("Nintendo GameCube WaveBird controllers do not support rumble");
+                }
+                if (!ctx->rumbleAllowed[i]) {
+                    return SDL_SetError("Second USB cable for WUP-028 not connected");
+                }
+                if (ctx->useRumbleBrake) {
+                    if (low_frequency_rumble == 0 && high_frequency_rumble > 0) {
+                        val = 0; // if only low is 0 we want to do a regular stop
+                    } else if (low_frequency_rumble == 0 && high_frequency_rumble == 0) {
+                        val = 2; // if both frequencies are 0 we want to do a hard stop
+                    } else {
+                        val = 1; // normal rumble
+                    }
+                } else {
+                    val = (low_frequency_rumble > 0 || high_frequency_rumble > 0);
+                }
+                if (val != ctx->rumble[i + 1]) {
+                    ctx->rumble[i + 1] = val;
+                    ctx->rumbleUpdate = true;
+                }
+                return true;
             }
-            return true;
         }
     }
 
@@ -541,10 +580,17 @@ static Uint32 HIDAPI_DriverGameCube_GetJoystickCapabilities(SDL_HIDAPI_Device *d
     Uint32 result = 0;
 
     SDL_AssertJoysticksLocked();
-
-    if (!ctx->pc_mode) {
-        Uint8 i;
-
+    Uint8 i;
+    if (ctx->pc_mode) {        
+        for (i = 0; i < MAX_CONTROLLERS; i += 1) {
+            if (joystick->instance_id == ctx->joysticks[i]) {
+                if (ctx->rumbleAllowed[i]) {
+                    result |= SDL_JOYSTICK_CAP_RUMBLE;
+                    break;
+                }
+            }
+        }
+    } else {
         for (i = 0; i < MAX_CONTROLLERS; i += 1) {
             if (joystick->instance_id == ctx->joysticks[i]) {
                 if (!ctx->wireless[i] && ctx->rumbleAllowed[i]) {
@@ -581,6 +627,11 @@ static void HIDAPI_DriverGameCube_CloseJoystick(SDL_HIDAPI_Device *device, SDL_J
     if (ctx->rumbleUpdate) {
         SDL_HIDAPI_SendRumble(device, ctx->rumble, sizeof(ctx->rumble));
         ctx->rumbleUpdate = false;
+    }
+
+    if (ctx->pc_mode && ctx->rumbleActive) {
+        ctx->rumbleActive = false;
+        HIDAPI_DriverGameCube_SendPCRumble(device, ctx);
     }
 }
 

--- a/src/joystick/hidapi/SDL_hidapi_gamecube.c
+++ b/src/joystick/hidapi/SDL_hidapi_gamecube.c
@@ -205,12 +205,26 @@ static bool HIDAPI_DriverGameCube_InitDevice(SDL_HIDAPI_Device *device)
     }
 
     if (ctx->pc_mode) {
+        // Check to see if this firmware supports rumble
+        bool rumbleAllowed = false;
+        if ((size = SDL_hid_read_timeout(device->dev, packet, sizeof(packet), 0)) > 0) {
+#ifdef DEBUG_GAMECUBE_PROTOCOL
+            HIDAPI_DumpPacket("Nintendo GameCube packet: size = %d", packet, size);
+#endif
+            if (size == 9) {
+                // This is firmware version 0x7 or newer
+                // Rumble is supported if the second USB cable is plugged in
+                rumbleAllowed = true;
+            }
+        }
 #ifdef SDL_PLATFORM_WIN32
         // We get a separate device for each slot
+        ctx->rumbleAllowed[0] = rumbleAllowed;
         ResetAxisRange(ctx, 0);
         HIDAPI_JoystickConnected(device, &ctx->joysticks[0]);
 #else
         for (i = 0; i < MAX_CONTROLLERS; ++i) {
+            ctx->rumbleAllowed[i] = rumbleAllowed;
             ResetAxisRange(ctx, i);
             HIDAPI_JoystickConnected(device, &ctx->joysticks[i]);
         }
@@ -454,15 +468,10 @@ static bool HIDAPI_DriverGameCube_UpdateDevice(SDL_HIDAPI_Device *device)
                 // This is the older firmware
                 // The first byte is the index of the connected controller
                 // The C stick has an inverted value range compared to the left stick
-                // I don't have an adapter with an old firmware to check if the rumble works with it so it is set to false
-                ctx->rumbleAllowed[0] = ctx->rumbleAllowed[1] = ctx->rumbleAllowed[2] = ctx->rumbleAllowed[3] = false;
                 HIDAPI_DriverGameCube_HandleJoystickPacket(device, ctx, packet[0] - 1, &packet[1], true);
             } else if (size == 9) {
                 // This is the newer firmware (version 0x7)
                 // The C stick has the same value range compared to the left stick
-                // AFAIK In PC_Mode there is no way to check if the second USB is connected or if the connected controller is a wavebird
-                // So if it passes the firmware size check I set it to true
-                ctx->rumbleAllowed[0] = ctx->rumbleAllowed[1] = ctx->rumbleAllowed[2] = ctx->rumbleAllowed[3] = true; 
                 HIDAPI_DriverGameCube_HandleJoystickPacket(device, ctx, 0, packet, false);
             } else {
                 // How do we handle this packet?
@@ -581,7 +590,7 @@ static Uint32 HIDAPI_DriverGameCube_GetJoystickCapabilities(SDL_HIDAPI_Device *d
 
     SDL_AssertJoysticksLocked();
     Uint8 i;
-    if (ctx->pc_mode) {        
+    if (ctx->pc_mode) {
         for (i = 0; i < MAX_CONTROLLERS; i += 1) {
             if (joystick->instance_id == ctx->joysticks[i]) {
                 if (ctx->rumbleAllowed[i]) {


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->
I added rumble to the gamecube adapter in PC_Mode.

## Description
<!--- Describe your changes in detail -->
I added rumble to the mayflash gamecube adapter in PC_Mode for firmware of at least 0x7, it was tested on firmware 0x10 and on Windows 11. I have done this by adding a function called HIDAPI_DriverGameCube_SendPCRumble to send the packets to the queue. The packets are constructed with 3 values, first the index of 0x00 after that, 2 values of either 0x00 or 0xFF if rumble is off or on.

During UpdateDevice in PC_Mode, if the packet size equals 9, I enable the rumble functionality for the controllers as I did not find a way to make a tighter check, like if the second USB is connected or the device is a Wavebird controller. Should someone be able to test it on a device with a lower firmware than 0x7, this could be done at the initializing stage.

After that, in RumbleJoystick, in PC_Mode, I check if the rumble is allowed, if the useRumbleBreak flag has been set for coasting and then check if the controller should rumble. Should it be the case that it should coast, only the update flag will be set to false. If it should not coast, a check is made to see if the shouldrumble value is different then what the rumbleActive value is. If it is different, rumbleActive value will be updated and a rumblepacket will be send to the queue to update its status.

Since the motor needs constant packets to be send with rumble in order to keep it going a PC_RUMBLE_REFRESH has been made with a value of 16. During UpdateDevice, if the adapter is in PC_Mode, has active rumble and the last packet was send more than 16 ms ago, a new one will be queued.

In CloseJoystick, if in PC_Mode and with active rumble, I flip the rumbleActive flag and send a packet to the queue so it always stops rumbling when closing.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
