### PR TITLE
coreaudio: unregister interruption observer unconditionally on close

### DIFF
--- a/src/audio/coreaudio/SDL_coreaudio.m
+++ b/src/audio/coreaudio/SDL_coreaudio.m
@@ -351,6 +351,10 @@ static void interruption_end(_THIS)
 - (void)audioSessionInterruption:(NSNotification *)note
 {
     @synchronized(self) {
+        /* Defensive: skip if the device was already torn down. */
+        if (self.device == NULL) {
+            return;
+        }
         NSNumber *type = note.userInfo[AVAudioSessionInterruptionTypeKey];
         if (type.unsignedIntegerValue == AVAudioSessionInterruptionTypeBegan) {
             interruption_begin(self.device);
@@ -363,6 +367,9 @@ static void interruption_end(_THIS)
 - (void)applicationBecameActive:(NSNotification *)note
 {
     @synchronized(self) {
+        if (self.device == NULL) {
+            return;
+        }
         interruption_end(self.device);
     }
 }
@@ -374,6 +381,23 @@ static BOOL update_audio_session(_THIS, SDL_bool open, SDL_bool allow_playandrec
     @autoreleasepool {
         AVAudioSession *session = [AVAudioSession sharedInstance];
         NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+
+        /* Close path: unregister the interruption observer FIRST, before any
+           code that can early-return. [AVAudioSession setCategory:] failures
+           (phone call, Siri, CarPlay / AirPlay handoff, etc.) would otherwise
+           leave the listener registered with a stale device pointer;
+           NotificationCenter later delivers foreground events to freed memory.
+           See #2900 for the sibling setActive:YES leak fix; this closes the
+           setCategory: leak. */
+        if (!open && this->hidden->interruption_listener != NULL) {
+            SDLInterruptionListener *listener =
+                (SDLInterruptionListener *)CFBridgingRelease(this->hidden->interruption_listener);
+            this->hidden->interruption_listener = NULL;
+            [center removeObserver:listener];
+            @synchronized(listener) {
+                listener.device = NULL;
+            }
+        }
 
         NSString *category = AVAudioSessionCategoryPlayback;
         NSString *mode = AVAudioSessionModeDefault;
@@ -498,13 +522,6 @@ static BOOL update_audio_session(_THIS, SDL_bool open, SDL_bool allow_playandrec
                          object:nil];
 
             this->hidden->interruption_listener = CFBridgingRetain(listener);
-        } else {
-            SDLInterruptionListener *listener = nil;
-            listener = (SDLInterruptionListener *)CFBridgingRelease(this->hidden->interruption_listener);
-            [center removeObserver:listener];
-            @synchronized(listener) {
-                listener.device = NULL;
-            }
         }
     }
 

--- a/src/audio/coreaudio/SDL_coreaudio.m
+++ b/src/audio/coreaudio/SDL_coreaudio.m
@@ -351,11 +351,11 @@ static void interruption_end(_THIS)
 - (void)audioSessionInterruption:(NSNotification *)note
 {
     @synchronized(self) {
+        NSNumber *type = note.userInfo[AVAudioSessionInterruptionTypeKey];
         /* Defensive: skip if the device was already torn down. */
         if (self.device == NULL) {
             return;
         }
-        NSNumber *type = note.userInfo[AVAudioSessionInterruptionTypeKey];
         if (type.unsignedIntegerValue == AVAudioSessionInterruptionTypeBegan) {
             interruption_begin(self.device);
         } else {
@@ -382,6 +382,12 @@ static BOOL update_audio_session(_THIS, SDL_bool open, SDL_bool allow_playandrec
         AVAudioSession *session = [AVAudioSession sharedInstance];
         NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
 
+        NSString *category = AVAudioSessionCategoryPlayback;
+        NSString *mode = AVAudioSessionModeDefault;
+        NSUInteger options = AVAudioSessionCategoryOptionMixWithOthers;
+        NSError *err = nil;
+        const char *hint;
+
         /* Close path: unregister the interruption observer FIRST, before any
            code that can early-return. [AVAudioSession setCategory:] failures
            (phone call, Siri, CarPlay / AirPlay handoff, etc.) would otherwise
@@ -398,12 +404,6 @@ static BOOL update_audio_session(_THIS, SDL_bool open, SDL_bool allow_playandrec
                 listener.device = NULL;
             }
         }
-
-        NSString *category = AVAudioSessionCategoryPlayback;
-        NSString *mode = AVAudioSessionModeDefault;
-        NSUInteger options = AVAudioSessionCategoryOptionMixWithOthers;
-        NSError *err = nil;
-        const char *hint;
 
         hint = SDL_GetHint(SDL_HINT_AUDIO_CATEGORY);
         if (hint) {


### PR DESCRIPTION
## Summary

Fix a long-standing CoreAudio observer-lifetime bug where `SDLInterruptionListener` outlives its backing `SDL_AudioDevice`, leading to an EXC_BAD_ACCESS on the next app foreground.

`update_audio_session()` registers the listener on open and unregisters it on close — but the close-path unregister sits at the bottom of the function, after `[AVAudioSession setCategory:…error:&err]` and `[setActive:…error:&err]` calls that can `return NO` early. If any of those AVAudioSession calls fails during close (which happens in the wild: phone calls, Siri, CarPlay / AirPlay handoff, session owned by another app), the listener is never removed from `NSNotificationCenter`. Its `device` pointer continues to reference memory that is freed by `SDL_free(this->hidden)` in `COREAUDIO_CloseDevice` right after `update_audio_session` returns. A later `UIApplicationWillEnterForegroundNotification` or `UIApplicationDidBecomeActiveNotification` is then delivered to the now-dangling listener, which calls `interruption_end(self.device)` and crashes.

This is the same class of bug as #2900 (2018) — except that fix only closed the `setActive:YES` early-return path on last-device close. The `setCategory:` early-return paths have remained since. We're seeing it in production from a real-world app with ~40 crashes over 7 days on a single app version, all with the exact stack pattern (`SDL_SemPost` / `interruption_end`-adjacent → `__CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__` → `-[UIApplication _sendWillEnterForegroundCallbacks]`). The same root cause is still reported against SDL3 in #12660.

## Change

- Move the close-path observer unregister to the **top** of `update_audio_session()`, so it runs unconditionally before any `setCategory:` / `setActive:` early-return. Close is a teardown path; session-config failures should not be able to leak resources.
- Remove the now-dead close-side cleanup from the bottom `else` branch.
- Add `if (self.device == NULL) return;` guards at the top of both `SDLInterruptionListener` callbacks (`audioSessionInterruption:` and `applicationBecameActive:`). These are defense-in-depth — with the top-of-function unregister in place, the callbacks should never fire post-close, but the guards prevent any future edit to the cleanup flow from silently re-introducing the crash.

No API surface changes, no behavioral change on the open path, no behavioral change on the close path when all AVAudioSession calls succeed.

## Testing

- `testautomation` suite passes locally on macOS (no new failures vs. the baseline).
- Integration-verified on-device against the real production crash: with the patch applied to an FcLib-consuming iOS app (which calls `SDL_OpenAudioDevice` / `SDL_CloseAudioDevice` inside an Fc2AudioMixer wrapper), the `willEnterForeground`-after-background crash stops reproducing. Without the patch, injecting a simulated `setCategory:` failure at close reproduces the crash reliably.

## Notes

- Mirror fix for SDL3 `main` (file renamed to `UpdateAudioSession`, same structural bug) can be done as a follow-up PR if the project prefers it separated.
- Related: #2900 (closed), #12660 (open, SDL3, same root cause).
