### PR TITLE
atomic: Use __atomic_thread_fence() when available (SDL2)

### DIFF
--- a/include/SDL_atomic.h
+++ b/include/SDL_atomic.h
@@ -174,7 +174,10 @@ extern __inline void SDL_CompilerBarrier(void);
 extern DECLSPEC void SDLCALL SDL_MemoryBarrierReleaseFunction(void);
 extern DECLSPEC void SDLCALL SDL_MemoryBarrierAcquireFunction(void);
 
-#if defined(__GNUC__) && (defined(__powerpc__) || defined(__ppc__))
+#if _SDL_HAS_BUILTIN(__atomic_thread_fence) || (defined(__GNUC__) && (__GNUC__ >= 5))
+#define SDL_MemoryBarrierRelease()   __atomic_thread_fence(__ATOMIC_RELEASE)
+#define SDL_MemoryBarrierAcquire()   __atomic_thread_fence(__ATOMIC_ACQUIRE)
+#elif defined(__GNUC__) && (defined(__powerpc__) || defined(__ppc__))
 #define SDL_MemoryBarrierRelease()   __asm__ __volatile__ ("lwsync" : : : "memory")
 #define SDL_MemoryBarrierAcquire()   __asm__ __volatile__ ("lwsync" : : : "memory")
 #elif defined(__GNUC__) && defined(__aarch64__)


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
This avoids requiring inline assembly for each architecture.

It also fixes some weakly ordered architectures which lacked said inline assembly (RISC-V, MIPS, LoongArch, etc) and were thus disasterously broken.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
