### PR TITLE
cmake: fix OmniOS pkgsrc

### DIFF
--- a/cmake/sdlchecks.cmake
+++ b/cmake/sdlchecks.cmake
@@ -442,6 +442,7 @@ macro(CheckX11)
         /usr/openwin/share/include
         /opt/graphics/OpenGL/include
         /opt/X11/include
+        /opt/local/include/X11
     )
 
     if(X_INCLUDEDIR)

--- a/cmake/sdlchecks.cmake
+++ b/cmake/sdlchecks.cmake
@@ -527,7 +527,11 @@ macro(CheckX11)
             XGetEventData(display, cookie);
             XFreeEventData(display, cookie);
             return 0; }" HAVE_XGENERICEVENT)
-      if(HAVE_XGENERICEVENT)
+
+      # In OmniOS pkgsrc, XGenericEventCookie is defined as "typedef struct { ... } XGenericEventCookie;"
+      # which differs from every other implementation where it's
+      # "typedef struct XGenericEventCookie { ... } XGenericEventCookie;"
+      if(HAVE_XGENERICEVENT AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL "SunOS")
         set(SDL_VIDEO_DRIVER_X11_SUPPORTS_GENERIC_EVENTS 1)
       endif()
 

--- a/cmake/sdlchecks.cmake
+++ b/cmake/sdlchecks.cmake
@@ -442,7 +442,7 @@ macro(CheckX11)
         /usr/openwin/share/include
         /opt/graphics/OpenGL/include
         /opt/X11/include
-        /opt/local/include/X11
+        /opt/local/include
     )
 
     if(X_INCLUDEDIR)

--- a/cmake/sdlchecks.cmake
+++ b/cmake/sdlchecks.cmake
@@ -529,7 +529,14 @@ macro(CheckX11)
             return 0; }" HAVE_XGENERICEVENT)
 
       # In OmniOS pkgsrc, XGenericEventCookie is defined, but fails to compile due to unrelated circumstances
-      if(HAVE_XGENERICEVENT OR ${CMAKE_SYSTEM_NAME} STREQUAL "SunOS")
+      # thus, if this check fails, it means that OmniOS's outdated X11 is being used
+      check_c_source_compiles("
+          #include <X11/Xlib.h>
+          typedef struct XGenericCookie XGenericCookie;
+          int main(int argc, char **argv) {
+            return 0; }" HAVE_XGENERICEVENT_TYPEDEF_QUIRK)
+
+      if(HAVE_XGENERICEVENT OR NOT HAVE_XGENERICEVENT_TYPEDEF_QUIRK)
         set(SDL_VIDEO_DRIVER_X11_SUPPORTS_GENERIC_EVENTS 1)
       endif()
 

--- a/cmake/sdlchecks.cmake
+++ b/cmake/sdlchecks.cmake
@@ -528,10 +528,8 @@ macro(CheckX11)
             XFreeEventData(display, cookie);
             return 0; }" HAVE_XGENERICEVENT)
 
-      # In OmniOS pkgsrc, XGenericEventCookie is defined as "typedef struct { ... } XGenericEventCookie;"
-      # which differs from every other implementation where it's
-      # "typedef struct XGenericEventCookie { ... } XGenericEventCookie;"
-      if(HAVE_XGENERICEVENT AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL "SunOS")
+      # In OmniOS pkgsrc, XGenericEventCookie is defined, but fails to compile due to unrelated circumstances
+      if(HAVE_XGENERICEVENT OR ${CMAKE_SYSTEM_NAME} STREQUAL "SunOS")
         set(SDL_VIDEO_DRIVER_X11_SUPPORTS_GENERIC_EVENTS 1)
       endif()
 


### PR DESCRIPTION
pkgsrc installs X11 by default on /opt/local/include/X11

- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
fixes missing path

## Existing Issue(s)
no existing issues except omniOS would fail to build packages dependant upon sdl
<img width="677" height="154" alt="image" src="https://github.com/user-attachments/assets/49b3ac24-c4ab-47de-841e-e1181adbc2c0" />

