### PR TITLE
atomic: Fix infinite recursion in SDL_CompilerBarrier() fallback

### DIFF
--- a/include/SDL3/SDL_atomic.h
+++ b/include/SDL3/SDL_atomic.h
@@ -167,8 +167,9 @@ void _ReadWriteBarrier(void);
 extern __inline void SDL_CompilerBarrier(void);
 #pragma aux SDL_CompilerBarrier = "" parm [] modify exact [];
 #else
+/* We don't unlock here to avoid possible infinite recursion */
 #define SDL_CompilerBarrier()   \
-{ SDL_SpinLock _tmp = 0; SDL_LockSpinlock(&_tmp); SDL_UnlockSpinlock(&_tmp); }
+{ SDL_SpinLock _tmp = 0; SDL_LockSpinlock(&_tmp); }
 #endif
 
 /**


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
I realized there's a possible infinite recursion in 95ae0c194ec785d5a7ecf8b83a34f7f2ae29b07a on platforms which:
- Use the generic codepath in `SDL_UnlockSpinlock()`
- Define `SDL_MemoryBarrierRelease()` as `SDL_CompilerBarrier()`
- Don't define a specific `SDL_CompilerBarrier()` and thus fall back to a `SDL_LockSpinlock()`+`SDL_UnlockSpinlock()`

The result is:
`SDL_UnlockSpinlock()` -> `SDL_MemoryBarrierRelease()` -> `SDL_CompilerBarrier()` -> `SDL_UnlockSpinlock()`

Since the spinlock we create there is temporary, we don't actually need to unlock it. Removing `SDL_UnlockSpinlock()` there fixes the infinite recursion.

If we'd rather not remove `SDL_UnlockSpinlock()` (or solve this some other way), then I'll just revert 95ae0c194ec785d5a7ecf8b83a34f7f2ae29b07a (excluding the Solaris fix).

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
