### PR TITLE
atomic: Use __atomic_signal_fence() for SDL_CompilerBarrier()

### DIFF
--- a/include/SDL3/SDL_atomic.h
+++ b/include/SDL3/SDL_atomic.h
@@ -156,6 +156,8 @@ extern SDL_DECLSPEC void SDLCALL SDL_UnlockSpinlock(SDL_SpinLock *lock);
  */
 #define SDL_CompilerBarrier() DoCompilerSpecificReadWriteBarrier()
 
+#elif SDL_HAS_BUILTIN(__atomic_signal_fence) || (defined(__GNUC__) && (__GNUC__ >= 5))
+#define SDL_CompilerBarrier()   __atomic_signal_fence(__ATOMIC_SEQ_CST)
 #elif defined(_MSC_VER) && (_MSC_VER > 1200) && !defined(__clang__)
 void _ReadWriteBarrier(void);
 #pragma intrinsic(_ReadWriteBarrier)


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
`__atomic_signal_fence()` is slightly nicer than `__asm__ __volatile__ ("" : : : "memory")` and should work under Emscripten too. 

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
