### PR TITLE
renderer: Check the surface validity flag when re-acquiring the surfa…

### DIFF
--- a/src/render/software/SDL_render_sw.c
+++ b/src/render/software/SDL_render_sw.c
@@ -34,6 +34,7 @@
 #include "SDL_triangle.h"
 #include "../../video/SDL_pixels_c.h"
 #include "../../video/SDL_rotate.h"
+#include "../../video/SDL_sysvideo.h"
 
 // SDL surface based renderer implementation
 
@@ -54,12 +55,13 @@ typedef struct
 static SDL_Surface *SW_ActivateRenderer(SDL_Renderer *renderer)
 {
     SW_RenderData *data = (SW_RenderData *)renderer->internal;
+    SDL_Window *window = renderer->window;
 
     if (!data->surface) {
         data->surface = data->window;
     }
-    if (!data->surface) {
-        SDL_Surface *surface = SDL_GetWindowSurface(renderer->window);
+    if (window && (!data->surface || !window->surface_valid)) {
+        SDL_Surface *surface = SDL_GetWindowSurface(window);
         if (surface) {
             data->surface = data->window = surface;
         }


### PR DESCRIPTION
…ce in the software renderer

- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

If a size change occurs, the sdl2-compat event handler will flush the renderer, which will cause the software renderer to re-acquire a surface that was invalidated due to the size change. However, if the OnWindowPixelSizeChanged handler is called afterward, the invalid flag will be set on the surface, causing presentation to fail.

Check both for a null surface pointer and an invalid surface flag when checking surface validity in the software renderer.

Fixes libsdl-org/sdl2-compat#591
