### PR TITLE
video: NULL-check display in SDL_DestroyWindow

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -3360,7 +3360,7 @@ void SDL_DestroyWindow(SDL_Window *window)
     }
 
     display = SDL_GetDisplayForWindow(window);
-    if (display->fullscreen_window == window) {
+    if (display && display->fullscreen_window == window) {
         display->fullscreen_window = NULL;
     }
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

Fixes crash when SDL_DestroyWindow is called, but we have no longer any display.

## Description
<!--- Describe your changes in detail -->

By the time, when SDL_DestroyWindow runs, the display might be already removed. Got hit by this on KWin/wayland: when compositor sends wl_registry::global_remove on a wl_output, that was the last display, it is removed and SDL_GetDisplayForWindow() return NULL, leading to NULL pointer dereference...

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
