### PR TITLE
pen: Only create touch emulation device when a pen is present

### DIFF
--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -194,16 +194,9 @@ static void SDLCALL SDL_PenTouchEventsChanged(void *userdata, const char *name, 
 
     mouse->pen_touch_events = SDL_GetStringBoolean(hint, true);
 
-    if (mouse->pen_touch_events) {
-        if (!mouse->added_pen_touch_device) {
-            SDL_AddTouch(SDL_PEN_TOUCHID, SDL_TOUCH_DEVICE_DIRECT, "pen_input");
-            mouse->added_pen_touch_device = true;
-        }
-    } else {
-        if (mouse->added_pen_touch_device) {
-            SDL_DelTouch(SDL_PEN_TOUCHID);
-            mouse->added_pen_touch_device = false;
-        }
+    if (!mouse->pen_touch_events && mouse->added_pen_touch_device) {
+        SDL_DelTouch(SDL_PEN_TOUCHID);
+        mouse->added_pen_touch_device = false;
     }
 }
 

--- a/src/events/SDL_pen.c
+++ b/src/events/SDL_pen.c
@@ -228,6 +228,7 @@ SDL_PenID SDL_AddPenDevice(Uint64 timestamp, const char *name, SDL_Window *windo
 
     SDL_LockRWLockForWriting(pen_device_rwlock);
 
+    bool first_device = false;
     SDL_Pen *pen = NULL;
     void *ptr = SDL_realloc(pen_devices, (pen_device_count + 1) * sizeof (*pen));
     if (ptr) {
@@ -235,6 +236,8 @@ SDL_PenID SDL_AddPenDevice(Uint64 timestamp, const char *name, SDL_Window *windo
         pen_devices = (SDL_Pen *) ptr;
         pen = &pen_devices[pen_device_count];
         pen_device_count++;
+
+        first_device = (pen_device_count == 1);
 
         SDL_zerop(pen);
         pen->instance_id = result;
@@ -249,6 +252,14 @@ SDL_PenID SDL_AddPenDevice(Uint64 timestamp, const char *name, SDL_Window *windo
 
     if (!pen) {
         SDL_free(namecpy);
+    }
+
+    if (first_device) {
+        SDL_Mouse *mouse = SDL_GetMouse();
+        if (mouse->pen_touch_events && !mouse->added_pen_touch_device) {
+            SDL_AddTouch(SDL_PEN_TOUCHID, SDL_TOUCH_DEVICE_DIRECT, "pen_input");
+            mouse->added_pen_touch_device = true;
+        }
     }
 
     if (result && in_proximity) {
@@ -267,6 +278,7 @@ void SDL_RemovePenDevice(Uint64 timestamp, SDL_Window *window, SDL_PenID instanc
     SDL_SendPenProximity(timestamp, instance_id, window, false, true);  // bye bye
 
     SDL_LockRWLockForWriting(pen_device_rwlock);
+    bool last_device = false;
     SDL_Pen *pen = FindPenByInstanceId(instance_id);
     if (pen) {
         SDL_free(pen->name);
@@ -288,9 +300,18 @@ void SDL_RemovePenDevice(Uint64 timestamp, SDL_Window *window, SDL_PenID instanc
         } else {
             SDL_free(pen_devices);
             pen_devices = NULL;
+            last_device = true;
         }
     }
     SDL_UnlockRWLock(pen_device_rwlock);
+
+    if (last_device) {
+        SDL_Mouse *mouse = SDL_GetMouse();
+        if (mouse->added_pen_touch_device) {
+            SDL_DelTouch(SDL_PEN_TOUCHID);
+            mouse->added_pen_touch_device = false;
+        }
+    }
 }
 
 // This presumably is happening during video quit, so we don't send PROXIMITY_OUT events here.


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
The cause for the phantom `pen_input` touch device was [this code](https://github.com/libsdl-org/SDL/blob/e1e6cbe6ecf78da703829c62ff5335e7e9a16774/src/events/SDL_mouse.c#L195-L201) which creates the device by default during video init. This can confuse apps into thinking there's a real touchscreen present, so let's only create it when an actual pen device is present.

This change _might_ confuse apps that are expecting all touch devices to be present at startup, but the documentation for `SDL_GetTouchDevices()` warns against assuming that.

## Existing Issue(s)
Fixes #15330 
<!--- If it fixes an open issue, please link to the issue here. -->
