### PR TITLE
Metal: Added missing lock in METAL_INTERNAL_PerformPendingDestroys.

### DIFF
--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -3551,6 +3551,8 @@ static void METAL_INTERNAL_PerformPendingDestroys(
     Sint32 i;
     Uint32 j;
 
+    SDL_LockMutex(renderer->disposeLock);
+
     for (i = renderer->bufferContainersToDestroyCount - 1; i >= 0; i -= 1) {
         referenceCount = 0;
         for (j = 0; j < renderer->bufferContainersToDestroy[i]->bufferCount; j += 1) {
@@ -3580,6 +3582,8 @@ static void METAL_INTERNAL_PerformPendingDestroys(
             renderer->textureContainersToDestroyCount -= 1;
         }
     }
+
+    SDL_UnlockMutex(renderer->disposeLock);
 }
 
 // Fences


### PR DESCRIPTION
Without this lock, a concurrent call to SDL_ReleaseGPUBuffer, SDL_ReleaseGPUTransferBuffer or SDL_ReleaseGPUTexture can cause one of the arrays to be reallocated while METAL_INTERNAL_PerformPendingDestroys is iterating over it, causing a bad day all around.

## Existing Issue(s)
Fixes #15477. 

- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").
