### PR TITLE
stdinc: use _Countof in SDL_arraysize

### DIFF
--- a/include/SDL3/SDL_begin_code.h
+++ b/include/SDL3/SDL_begin_code.h
@@ -282,6 +282,22 @@
 #define SDL_HAS_BUILTIN(x) __has_builtin(x)
 
 /**
+ * Check if the compiler supports a given extension.
+ *
+ * This allows preprocessor checks for things that otherwise might fail to
+ * compile.
+ *
+ * Supported by virtually all clang versions and more-recent GCCs. Use this
+ * instead of checking the clang version if possible.
+ *
+ * On compilers without has_extension support, this is defined to 0 (always
+ * false).
+ *
+ * \since This macro is available since SDL 3.2.0.
+ */
+#define SDL_HAS_EXTENSION(x) __has_extension(x)
+
+/**
  * A macro to specify data alignment.
  *
  * This informs the compiler that a given datatype or variable must be aligned
@@ -341,6 +357,14 @@
 #define SDL_HAS_BUILTIN(x) __has_builtin(x)
 #else
 #define SDL_HAS_BUILTIN(x) 0
+#endif
+#endif
+
+#ifndef SDL_HAS_EXTENSION
+#ifdef __has_extension
+#define SDL_HAS_EXTENSION(x) __has_extension(x)
+#else
+#define SDL_HAS_EXTENSION(x) 0
 #endif
 #endif
 

--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -52,6 +52,8 @@
 #include <string.h>
 #include <wchar.h>
 
+#include <SDL3/SDL_begin_code.h>
+
 /* Most everything except Visual Studio 2008 and earlier has stdint.h now */
 #if defined(_MSC_VER) && (_MSC_VER < 1600)
 typedef signed __int8 int8_t;
@@ -237,6 +239,8 @@ void *alloca(size_t);
        typedef int SDL_compile_time_assert_ ## name[(x) * 2 - 1]
 #endif
 
+#ifdef SDL_WIKI_DOCUMENTATION_SECTION
+
 /**
  * The number of elements in a static array.
  *
@@ -249,7 +253,15 @@ void *alloca(size_t);
  *
  * \since This macro is available since SDL 3.2.0.
  */
+#define SDL_arraysize(array) (sizeof(array)/sizeof(array[0]))  /* or `_Countof(array)` on recent gcc and clang */
+
+#else
+#if (defined(__GNUC__) && __GNUC__ >= 16) || SDL_HAS_EXTENSION(c_countof)
+#define SDL_arraysize(array) _Countof(array)
+#else
 #define SDL_arraysize(array) (sizeof(array)/sizeof(array[0]))
+#endif
+#endif
 
 /**
  * Macro useful for building other macros with strings in them.
@@ -1209,7 +1221,6 @@ SDL_COMPILE_TIME_ASSERT(enum, sizeof(SDL_DUMMY_ENUM) == sizeof(int));
 #endif /* DOXYGEN_SHOULD_IGNORE_THIS */
 /** \endcond */
 
-#include <SDL3/SDL_begin_code.h>
 /* Set up for C function definitions, even when using C++ */
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
_Countof is a compiler intrinsics that errors when using a pointer argument.
With this change, the following code will fail:
```c
int *array;
size_t count = SDL_arraysize(array);
```

- [gcc documentation](https://gcc.gnu.org/onlinedocs/gcc/_005fCountof.html)
- [llvm documentation](https://clang.llvm.org/docs/LanguageExtensions.html#c2y-countof)

Trying the example from gcc documentation with the current `SDL_arraysize` implementation results in division by 0 at runtime for me.

It's also [a proposal for C29](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3369.pdf) (maybe renamed to `_Lengthof`)

- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->


/cc @icculus to see if the documentation needs a change