### PR TITLE
pen: Fix enabling touch emulation while a pen is connected

### DIFF
--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -188,18 +188,6 @@ static void SDLCALL SDL_PenMouseEventsChanged(void *userdata, const char *name, 
     mouse->pen_mouse_events = SDL_GetStringBoolean(hint, true);
 }
 
-static void SDLCALL SDL_PenTouchEventsChanged(void *userdata, const char *name, const char *oldValue, const char *hint)
-{
-    SDL_Mouse *mouse = (SDL_Mouse *)userdata;
-
-    mouse->pen_touch_events = SDL_GetStringBoolean(hint, true);
-
-    if (!mouse->pen_touch_events && mouse->added_pen_touch_device) {
-        SDL_DelTouch(SDL_PEN_TOUCHID);
-        mouse->added_pen_touch_device = false;
-    }
-}
-
 static void SDLCALL SDL_MouseAutoCaptureChanged(void *userdata, const char *name, const char *oldValue, const char *hint)
 {
     SDL_Mouse *mouse = (SDL_Mouse *)userdata;
@@ -281,9 +269,6 @@ bool SDL_PreInitMouse(void)
 
     SDL_AddHintCallback(SDL_HINT_PEN_MOUSE_EVENTS,
                         SDL_PenMouseEventsChanged, mouse);
-
-    SDL_AddHintCallback(SDL_HINT_PEN_TOUCH_EVENTS,
-                        SDL_PenTouchEventsChanged, mouse);
 
     SDL_AddHintCallback(SDL_HINT_MOUSE_AUTO_CAPTURE,
                         SDL_MouseAutoCaptureChanged, mouse);
@@ -1148,9 +1133,6 @@ void SDL_QuitMouse(void)
 
     SDL_RemoveHintCallback(SDL_HINT_PEN_MOUSE_EVENTS,
                         SDL_PenMouseEventsChanged, mouse);
-
-    SDL_RemoveHintCallback(SDL_HINT_PEN_TOUCH_EVENTS,
-                        SDL_PenTouchEventsChanged, mouse);
 
     SDL_RemoveHintCallback(SDL_HINT_MOUSE_AUTO_CAPTURE,
                         SDL_MouseAutoCaptureChanged, mouse);

--- a/src/events/SDL_pen.c
+++ b/src/events/SDL_pen.c
@@ -93,6 +93,33 @@ SDL_PenID SDL_FindPenByCallback(bool (*callback)(void *handle, void *userdata), 
     return result;
 }
 
+static void UpdateTouchEmulationDevicePresence(void)
+{
+    SDL_Mouse *mouse = SDL_GetMouse();
+
+    SDL_LockRWLockForReading(pen_device_rwlock);
+    bool has_pen = (pen_device_count != 0);
+    SDL_UnlockRWLock(pen_device_rwlock);
+
+    if (!mouse->pen_touch_events || !has_pen) {
+        if (mouse->added_pen_touch_device) {
+            SDL_DelTouch(SDL_PEN_TOUCHID);
+            mouse->added_pen_touch_device = false;
+        }
+    } else if (!mouse->added_pen_touch_device) {
+        SDL_AddTouch(SDL_PEN_TOUCHID, SDL_TOUCH_DEVICE_DIRECT, "pen_input");
+        mouse->added_pen_touch_device = true;
+    }
+}
+
+static void SDLCALL SDL_PenTouchEventsChanged(void *userdata, const char *name, const char *oldValue, const char *hint)
+{
+    SDL_Mouse *mouse = SDL_GetMouse();
+
+    mouse->pen_touch_events = SDL_GetStringBoolean(hint, true);
+
+    UpdateTouchEmulationDevicePresence();
+}
 
 
 // public API ...
@@ -106,11 +133,18 @@ bool SDL_InitPen(void)
     if (!pen_device_rwlock) {
         return false;
     }
+
+    SDL_AddHintCallback(SDL_HINT_PEN_TOUCH_EVENTS,
+                        SDL_PenTouchEventsChanged, NULL);
+
     return true;
 }
 
 void SDL_QuitPen(void)
 {
+    SDL_RemoveHintCallback(SDL_HINT_PEN_TOUCH_EVENTS,
+                           SDL_PenTouchEventsChanged, NULL);
+
     SDL_RemoveAllPenDevices(NULL, NULL);
     SDL_DestroyRWLock(pen_device_rwlock);
     pen_device_rwlock = NULL;
@@ -228,7 +262,6 @@ SDL_PenID SDL_AddPenDevice(Uint64 timestamp, const char *name, SDL_Window *windo
 
     SDL_LockRWLockForWriting(pen_device_rwlock);
 
-    bool first_device = false;
     SDL_Pen *pen = NULL;
     void *ptr = SDL_realloc(pen_devices, (pen_device_count + 1) * sizeof (*pen));
     if (ptr) {
@@ -236,8 +269,6 @@ SDL_PenID SDL_AddPenDevice(Uint64 timestamp, const char *name, SDL_Window *windo
         pen_devices = (SDL_Pen *) ptr;
         pen = &pen_devices[pen_device_count];
         pen_device_count++;
-
-        first_device = (pen_device_count == 1);
 
         SDL_zerop(pen);
         pen->instance_id = result;
@@ -254,13 +285,7 @@ SDL_PenID SDL_AddPenDevice(Uint64 timestamp, const char *name, SDL_Window *windo
         SDL_free(namecpy);
     }
 
-    if (first_device) {
-        SDL_Mouse *mouse = SDL_GetMouse();
-        if (mouse->pen_touch_events && !mouse->added_pen_touch_device) {
-            SDL_AddTouch(SDL_PEN_TOUCHID, SDL_TOUCH_DEVICE_DIRECT, "pen_input");
-            mouse->added_pen_touch_device = true;
-        }
-    }
+    UpdateTouchEmulationDevicePresence();
 
     if (result && in_proximity) {
         SDL_SendPenProximity(timestamp, result, window, true, true);
@@ -278,7 +303,6 @@ void SDL_RemovePenDevice(Uint64 timestamp, SDL_Window *window, SDL_PenID instanc
     SDL_SendPenProximity(timestamp, instance_id, window, false, true);  // bye bye
 
     SDL_LockRWLockForWriting(pen_device_rwlock);
-    bool last_device = false;
     SDL_Pen *pen = FindPenByInstanceId(instance_id);
     if (pen) {
         SDL_free(pen->name);
@@ -300,18 +324,11 @@ void SDL_RemovePenDevice(Uint64 timestamp, SDL_Window *window, SDL_PenID instanc
         } else {
             SDL_free(pen_devices);
             pen_devices = NULL;
-            last_device = true;
         }
     }
     SDL_UnlockRWLock(pen_device_rwlock);
 
-    if (last_device) {
-        SDL_Mouse *mouse = SDL_GetMouse();
-        if (mouse->added_pen_touch_device) {
-            SDL_DelTouch(SDL_PEN_TOUCHID);
-            mouse->added_pen_touch_device = false;
-        }
-    }
+    UpdateTouchEmulationDevicePresence();
 }
 
 // This presumably is happening during video quit, so we don't send PROXIMITY_OUT events here.


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
This reworks the on-demand pen touch emulation change in #15476 to properly handle transitioning `SDL_HINT_PEN_TOUCH_EVENTS` from `0` to `1` while a pen is connected.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
