### PR TITLE
haptic: Enable gamepad haptic support under sdl2-compat

### DIFF
--- a/src/haptic/SDL_haptic.c
+++ b/src/haptic/SDL_haptic.c
@@ -306,9 +306,9 @@ bool SDL_IsJoystickHaptic(SDL_Joystick *joystick)
 
     SDL_LockJoysticks();
     {
-        // Must be a valid joystick
+        // Must be a valid joystick, but not a gamepad unless running under sdl2-compat
         if (SDL_IsJoystickValid(joystick) &&
-            !SDL_IsGamepad(SDL_GetJoystickID(joystick))) {
+            (SDL_GetHintBoolean("SDL2_COMPAT", false) || !SDL_IsGamepad(SDL_GetJoystickID(joystick)))) {
             #ifdef SDL_JOYSTICK_HIDAPI
             result = SDL_SYS_JoystickIsHaptic(joystick) || SDL_HIDAPI_JoystickIsHaptic(joystick);
             #else


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
This implements the interim solution discussed in https://github.com/libsdl-org/sdl2-compat/issues/590 to enable haptic support for gamepads via the evdev force feedback interface when running under sdl2-compat. On modern kernels, this includes most common Xbox and PlayStation controllers (but not when they are using our HIDAPI drivers).

This PR was tested successfully together with https://github.com/libsdl-org/sdl2-compat/pull/594 to restore rumble support in DiRT 4. 

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/libsdl-org/sdl2-compat/issues/590