### PR TITLE
X11TK: fix late null-check causing segmentation fault

### DIFF
--- a/src/video/x11/SDL_x11messagebox.c
+++ b/src/video/x11/SDL_x11messagebox.c
@@ -250,11 +250,11 @@ static bool X11_ShowMessageBoxImpl(const SDL_MessageBoxData *messageboxdata, int
 #else 
     controls.window = X11Toolkit_CreateWindowStruct(parent_window, NULL, SDL_TOOLKIT_WINDOW_MODE_X11_DIALOG, colorhints, false);
 #endif
-    controls.window->cb_data = &controls;
-    controls.window->cb_on_scale_change = X11_OnMessageBoxScaleChange;
     if (!controls.window) {
         return false;
     }
+    controls.window->cb_data = &controls;
+    controls.window->cb_on_scale_change = X11_OnMessageBoxScaleChange;
 
     /* Create controls */
     controls.buttonID = buttonID;


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description

The code is using `controls.window` before checking if it isn't `NULL`.

I found this bug by accident when [shadPS4 tried to run `SDL_ShowSimpleMessageBox`](https://github.com/shadps4-emu/shadPS4/blob/main/src/main.cpp#L90-L93):

```cpp
        SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_INFORMATION, "shadPS4",
                                 "This is a CLI application. Please use the QTLauncher for a GUI:\n"
                                 "https://github.com/shadps4-emu/shadps4-qtlauncher/releases",
                                 nullptr);
```

Since I'm on Wayland it tried running `Wayland_ShowMessageBox`, which requires `zenity`.
Since I didn't have `zenity`, it fallbacked to `X11_ShowMessageBox`.

I don't know the reason why it fails to create the window, but it's another issue in my opinion.

## Existing Issue(s)

Couldn't find an issue about it. Should I create, or just the PR is enough?