### PR TITLE
Fix Xbox controller names in MFI joystick backend

### DIFF
--- a/src/joystick/apple/SDL_mfijoystick.m
+++ b/src/joystick/apple/SDL_mfijoystick.m
@@ -429,7 +429,7 @@ static bool IOS_AddMFIJoystickDevice(SDL_JoystickDeviceItem *device, GCControlle
 
             // controller.vendorName returns a generic name for Xbox controllers ("Controller"),
             // and controller.productCategory only returns "Xbox One" for those controllers,
-            // so we have to give them proper names based on the ones from "SDL_gamepad_db.h".
+            // so we give them proper names based on the ones from SDL_gamepad_db.h
             name = "Xbox One Elite 2 Controller";
         } else if (device->has_xbox_share_button) {
             // Assume Xbox Series X Controller unless/until GCController flows VID/PID

--- a/src/joystick/apple/SDL_mfijoystick.m
+++ b/src/joystick/apple/SDL_mfijoystick.m
@@ -340,8 +340,6 @@ static bool IOS_AddMFIJoystickDevice(SDL_JoystickDeviceItem *device, GCControlle
         name = "MFi Gamepad";
     }
 
-    device->name = SDL_CreateJoystickName(0, 0, NULL, name);
-
 #ifdef DEBUG_CONTROLLER_PROFILE
     NSLog(@"Product name: %@\n", controller.vendorName);
     NSLog(@"Product category: %@\n", controller.productCategory);
@@ -428,12 +426,19 @@ static bool IOS_AddMFIJoystickDevice(SDL_JoystickDeviceItem *device, GCControlle
         if (device->has_xbox_paddles) {
             // Assume Xbox One Elite Series 2 Controller unless/until GCController flows VID/PID
             product = USB_PRODUCT_XBOX_ONE_ELITE_SERIES_2_BLUETOOTH;
+
+            // controller.vendorName returns a generic name for Xbox controllers ("Controller"),
+            // and controller.productCategory only returns "Xbox One" for those controllers,
+            // so we have to give them proper names based on the ones from "SDL_gamepad_db.h".
+            name = "Xbox One Elite 2 Controller";
         } else if (device->has_xbox_share_button) {
             // Assume Xbox Series X Controller unless/until GCController flows VID/PID
             product = USB_PRODUCT_XBOX_SERIES_X_BLE;
+            name = "Xbox Series X Controller";
         } else {
             // Assume Xbox One S Bluetooth Controller unless/until GCController flows VID/PID
             product = USB_PRODUCT_XBOX_ONE_S_REV1_BLUETOOTH;
+            name = "Xbox One Wireless Controller";
         }
     } else if (device->is_ps4) {
         // Assume DS4 Slim unless/until GCController flows VID/PID
@@ -611,6 +616,8 @@ static bool IOS_AddMFIJoystickDevice(SDL_JoystickDeviceItem *device, GCControlle
         // We don't know how to get input events from this device
         return false;
     }
+    
+    device->name = SDL_CreateJoystickName(0, 0, NULL, name);
 
     Uint16 signature;
     if (@available(macOS 11.0, iOS 14.0, tvOS 14.0, *)) {


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
`controller.vendorName` returns a generic name for Xbox controllers (`"Controller"`), so we have to give them proper names.

MFI backend used to use [`controller.productCategory` by default](https://github.com/libsdl-org/SDL/commit/964bedfdd906673944ea5fce52c2e748a62f4994), but then it was [reverted](https://github.com/libsdl-org/SDL/commit/ef0ae4c90326ddcba2dfd84ac0690ceb2f2b02ed) and then [used as a fallback if `controller.vendorName` is not available](https://github.com/libsdl-org/SDL/commit/fa3467a94dac9a13bedd87b1459176089f12c851).

Using `productCategory` instead of `vendorName` is useful for Xbox controllers [since `vendorName` returns a generic name for Xbox controllers (`"Controller"`)](https://github.com/godotengine/godot/pull/119024#discussion_r3172601920) (the PR changed the functionality to use `productCategory` by default, but that comment was made before that change, so it uses `vendorName`).

After I looked at the code for this backend I found out that SDL tries to differentiate between different Xbox controllers based on their characteristics: Xbox One Elite Series 2 Controller, Xbox Series X Controller, and Xbox One S Bluetooth Controller, so using `productCategory` for all of them will make them have the same name, I assume (`"Xbox One"`), so it's probably better to use hardcoded names to differentiate them by the name too.

## Existing Issue(s)
None in this repository.
See also https://github.com/godotengine/godot/issues/98008