### PR TITLE
Fix #15500: deprecation warning on Android for slCreateEngine

### DIFF
--- a/src/audio/openslES/SDL_openslES.c
+++ b/src/audio/openslES/SDL_openslES.c
@@ -33,6 +33,11 @@
 #include <SLES/OpenSLES_Android.h>
 #include <android/log.h>
 
+// OpenSL ES is deprecated, but we still support it for now.
+#ifdef HAVE_GCC_DIAGNOSTIC_PRAGMA
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif // HAVE_GCC_DIAGNOSTIC_PRAGMA
 
 #define NUM_BUFFERS 2 // -- Don't lower this!
 
@@ -804,5 +809,9 @@ void OPENSLES_PauseDevices(void)
         }
     }
 }
+
+#ifdef HAVE_GCC_DIAGNOSTIC_PRAGMA
+#pragma GCC diagnostic pop
+#endif // HAVE_GCC_DIAGNOSTIC_PRAGMA
 
 #endif // SDL_AUDIO_DRIVER_OPENSLES


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Fix #15500: deprecation warning on Android for slCreateEngine
