### PR TITLE
emscripten: dedupe keyboard event listeners across multiple windows

### DIFF
--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -1327,11 +1327,33 @@ void Emscripten_RegisterEventHandlers(SDL_WindowData *data)
 
     keyElement = Emscripten_GetKeyboardTargetElement(data->keyboard_element);
     if (keyElement) {
+        // Emscripten's HTML5 helpers do not deduplicate `addEventListener` calls:
+        // see `registerOrRemoveHandler` in `emscripten/src/lib/libhtml5.js`.
+        //
+        // If a previous SDL window already registered keyboard handlers on the same
+        // target, the new registration would *stack* a second listener, causing every
+        // browser keydown to fire `Emscripten_HandleKey` twice.
+        //
+        // The duplicate calls then produce two `SDL_EVENT_KEY_DOWN` events per physical
+        // keypress (the second one with `repeat=true`, due to the keystate-based repeat
+        // detection in `SDL_SendKeyboardKeyInternal`).
+        //
+        // We must clear any prior handler on this target before installing ours:
+        emscripten_set_keydown_callback(keyElement, NULL, 0, NULL);
+        emscripten_set_keyup_callback(keyElement, NULL, 0, NULL);
+        emscripten_set_keypress_callback(keyElement, NULL, 0, NULL);
+
         MAIN_THREAD_EM_ASM_INT({
             var data = $0;
             // our keymod state can get confused in various ways (changed capslock when browser didn't have focus, etc), and you can't query the current
             //  state from the DOM, outside of a keyboard event, so catch keypresses globally and reset mod state if it's unexpectedly wrong. Best we can do.
             //  Note that this thing _only_ adjusts the lock keys if necessary; the real SDL keypress handling happens elsewhere.
+
+            // Remove any prior listener first -- `addEventListener` does not deduplicate either.
+            if (document.sdlEventHandlerLockKeysCheck) {
+                document.removeEventListener("keydown", document.sdlEventHandlerLockKeysCheck);
+            }
+
             document.sdlEventHandlerLockKeysCheck = function(event) {
                 // don't try to adjust the state on the actual lock key presses; the normal key handler will catch that and adjust.
                 if ((event.key != "CapsLock") && (event.key != "NumLock") && (event.key != "ScrollLock"))


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

**DISCLAIMER:** AI assistance was used to identify and understand the bug. The fix was hand-written.

## Summary

On Emscripten, every browser `keydown` produces *two* `SDL_EVENT_KEY_DOWN` events per physical keypress when more than one SDL window has been created. The second event carries `repeat=true` and shares the *same timestamp* as the first. 

The cause is a missing dedupe step in `Emscripten_RegisterEventHandlers`: each SDL window stacks another listener on the same DOM target.

## Reproduction

MCVE: [repro_emscripten_keyboard_dup.c](https://github.com/user-attachments/files/27380001/repro_emscripten_keyboard_dup.c)

Compile with `emcc`, linking against SDL3, and run with `emrun`. Press any key -- prior to this PR, you should see two log lines being printed out (with identical timestamps). After this fix, only one log line should be printed.

## Description

`Emscripten_RegisterEventHandlers` in `src/video/emscripten/SDL_emscriptenevents.c` is called once per SDL window. Each invocation does:

```c
emscripten_set_keydown_callback(keyElement, data, 0, Emscripten_HandleKey);
emscripten_set_keyup_callback(keyElement, data, 0, Emscripten_HandleKey);
emscripten_set_keypress_callback(keyElement, data, 0, Emscripten_HandleKeyPress);
```

These funnel into emscripten's `JSEvents.registerOrRemoveHandler` (`src/lib/libhtml5.js`):

```js
registerOrRemoveHandler(eventHandler) {
  // ...
  if (eventHandler.callbackfunc) {
    eventHandler.target.addEventListener(...);   // <-- always adds
    JSEvents.eventHandlers.push(eventHandler);   // <-- never dedupes
  } else {
    // Dedup happens ONLY when callback is null (the unregister path)
    for (/* ... */) { _removeHandler(i--); }
  }
}
```

When two SDL windows share the same keyboard target, the second `emscripten_set_keydown_callback(...)` does not replace the first -- it appends another `addEventListener` and another entry in `JSEvents.eventHandlers`. 

Every browser `keydown` then fires the C-side `Emscripten_HandleKey` twice in the same JS task, which calls `SDL_SendKeyboardKeyAndKeycode` twice in a row. Inside `SDL_SendKeyboardKeyInternal` (`src/events/SDL_keyboard.c`):

```c
if (down) {
    if (keyboard->keystate[scancode]) {
        // ...
        repeat = true;  // <-- second dispatch sees keystate==true
    }
    // ...
}
keyboard->keystate[scancode] = down;
```

The same stacking issue affects the JS-side document listener `sdlEventHandlerLockKeysCheck`.


## Fix

Two changes to `Emscripten_RegisterEventHandlers`, both in `src/video/emscripten/SDL_emscriptenevents.c`:

1. Before registering keyboard callbacks, call each setter with `NULL` first to clear any prior handler on the same target. 

2. Before assigning a new `document.sdlEventHandlerLockKeysCheck` closure and adding it as a `keydown` listener on `document`, remove the previous one if present.

## Testing

Manually tested on Chrome via `emrun` with the attached repro.

## Notes

I encountered this issue as part of the development of my [VRSFML](https://github.com/vittorioromeo/VRSFML) library, an opinionated C++23 fork of SFML that also targets Emscripten natively.

The fork maintains the same GL context model as upstream SFML: one hidden GL context (shared between all windows), and one GL context per window.

Having a shared GL context is actually nice because many resources such as textures or shaders can be reused between windows. Internally, I keep the same logic also for the Emscripten target, creating a hidden window:

```cpp
SDL_CreateWindow("", 1, 1, SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN);
```

The presence of this hidden window plus enabling repeated key presses led to the discovery of this bug.