### PR TITLE
thread: Remove semaphore in thread creation.

### DIFF
--- a/src/thread/SDL_thread.c
+++ b/src/thread/SDL_thread.c
@@ -335,11 +335,6 @@ void SDL_RunThread(SDL_Thread *thread)
     // Perform any system-dependent setup - this function may not fail
     SDL_SYS_SetupThread(thread->name);
 
-    // Get the thread id
-    thread->threadid = SDL_GetCurrentThreadID();
-
-    SDL_SignalSemaphore(thread->ready_sem);  // the thread is officially ready to run!
-
     // Run the function
     *statusloc = userfunc(userdata);
 
@@ -396,13 +391,6 @@ SDL_Thread *SDL_CreateThreadWithPropertiesRuntime(SDL_PropertiesID props,
         }
     }
 
-    thread->ready_sem = SDL_CreateSemaphore(0);
-    if (!thread->ready_sem) {
-        SDL_free(thread->name);
-        SDL_free(thread);
-        return NULL;
-    }
-
     thread->userfunc = fn;
     thread->userdata = userdata;
     thread->stacksize = stacksize;
@@ -413,15 +401,10 @@ SDL_Thread *SDL_CreateThreadWithPropertiesRuntime(SDL_PropertiesID props,
     if (!SDL_SYS_CreateThread(thread, pfnBeginThread, pfnEndThread)) {
         // Oops, failed.  Gotta free everything
         SDL_SetObjectValid(thread, SDL_OBJECT_TYPE_THREAD, false);
-        SDL_DestroySemaphore(thread->ready_sem);
         SDL_free(thread->name);
         SDL_free(thread);
 		return NULL;
     }
-
-    SDL_WaitSemaphore(thread->ready_sem);
-    SDL_DestroySemaphore(thread->ready_sem);
-    thread->ready_sem = NULL;
 
     // Everything is running now
     return thread;

--- a/src/thread/SDL_thread_c.h
+++ b/src/thread/SDL_thread_c.h
@@ -56,7 +56,6 @@ struct SDL_Thread
     SDL_error errbuf;
     char *name;
     size_t stacksize; // 0 for default, >0 for user-specified stack size.
-    SDL_Semaphore *ready_sem;  // signals when the thread is set up and about to start running.
     int(SDLCALL *userfunc)(void *);
     void *userdata;
     void *data;

--- a/src/thread/dos/SDL_systhread.c
+++ b/src/thread/dos/SDL_systhread.c
@@ -51,6 +51,8 @@ bool SDL_SYS_CreateThread(SDL_Thread *thread,
     }
 
     thread->handle = tid;
+    thread->threadid = (SDL_ThreadID) tid;
+
     return true;
 }
 

--- a/src/thread/n3ds/SDL_systhread.c
+++ b/src/thread/n3ds/SDL_systhread.c
@@ -72,6 +72,10 @@ bool SDL_SYS_CreateThread(SDL_Thread *thread,
         return SDL_SetError("Couldn't create thread");
     }
 
+    u32 thread_ID = 0;
+    svcGetThreadId(&thread_ID, threadGetHandle(thread->handle));
+    thread->threadid = (SDL_ThreadID) thread_ID;
+
     return true;
 }
 

--- a/src/thread/ps2/SDL_systhread.c
+++ b/src/thread/ps2/SDL_systhread.c
@@ -95,6 +95,9 @@ bool SDL_SYS_CreateThread(SDL_Thread *thread,
     if (StartThread(thread->handle, thread) < 0) {
         return SDL_SetError("StartThread() failed");
     }
+
+    thread->threadid = (SDL_ThreadID) thread->handle;
+
     return true;
 }
 

--- a/src/thread/psp/SDL_systhread.c
+++ b/src/thread/psp/SDL_systhread.c
@@ -66,6 +66,8 @@ bool SDL_SYS_CreateThread(SDL_Thread *thread,
         return SDL_SetError("sceKernelCreateThread() failed");
     }
 
+    thread->threadid = (SDL_ThreadID) thread->handle;
+
     sceKernelStartThread(thread->handle, 4, &thread);
     return true;
 }

--- a/src/thread/pthread/SDL_systhread.c
+++ b/src/thread/pthread/SDL_systhread.c
@@ -116,6 +116,8 @@ bool SDL_SYS_CreateThread(SDL_Thread *thread,
         return SDL_SetError("Not enough resources to create thread");
     }
 
+    thread->threadid = (SDL_ThreadID) thread->handle;  // the SDL thread ID is just the pthread_t.
+
     return true;
 }
 

--- a/src/thread/vita/SDL_systhread.c
+++ b/src/thread/vita/SDL_systhread.c
@@ -86,6 +86,8 @@ bool SDL_SYS_CreateThread(SDL_Thread *thread,
         return SDL_SetError("sceKernelCreateThread() failed");
     }
 
+    thread->threadid = (SDL_ThreadID) thread->handle;
+
     sceKernelStartThread(thread->handle, 4, &thread);
     return true;
 }

--- a/src/thread/windows/SDL_systhread.c
+++ b/src/thread/windows/SDL_systhread.c
@@ -77,15 +77,18 @@ bool SDL_SYS_CreateThread(SDL_Thread *thread,
         thread->handle = (SYS_ThreadHandle)((size_t)pfnBeginThread(NULL, (unsigned int)thread->stacksize,
                                                                    RunThreadViaBeginThreadEx,
                                                                    thread, flags, &threadid));
+        thread->threadid = (SDL_ThreadID) threadid;
     } else {
         DWORD threadid = 0;
         thread->handle = CreateThread(NULL, thread->stacksize,
                                       RunThreadViaCreateThread,
                                       thread, flags, &threadid);
+        thread->threadid = (SDL_ThreadID) threadid;
     }
     if (!thread->handle) {
         return SDL_SetError("Not enough resources to create thread");
     }
+
     return true;
 }
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

The semaphore was added so that the new thread definitely has its threadid set, via SDL_GetCurrentThreadID(), before SDL_CreatThread returns, but this broke Emscripten, which can't wait on a newly-created thread, since the thread won't start until a later mainloop iteration.

Now we have the creating thread set this id in SDL_SYS_CreateThread, where platform-specific logic can figure out how to calculate the new thread's ID from the parent thread, without using SDL_GetCurrentThreadID().

Fixes #15509.

(This has all the platform-specific code updated, but I'm letting the buildbot make sure I didn't break, like, PS2 or whatever.)