### PR TITLE
video: don't use NEON blitters when SDL_HasNEON returns false

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -675,6 +675,7 @@ extern "C" {
  * - "avx512f"
  * - "arm-simd"
  * - "neon"
+ * - "sve2"
  * - "lsx"
  * - "lasx"
  *

--- a/src/video/SDL_blit_A.c
+++ b/src/video/SDL_blit_A.c
@@ -1533,17 +1533,15 @@ SDL_BlitFunc SDL_CalculateBlitA(SDL_Surface *surface)
                 }
 #endif
 #if defined(SDL_NEON_INTRINSICS) && (__ARM_ARCH >= 8) && (defined(__aarch64__) || defined(_M_ARM64))
-                // To prevent "unused function" compiler warnings/errors
-                (void)Blit8888to8888PixelAlpha;
-                (void)Blit8888to8888PixelAlphaSwizzle;
-                return Blit8888to8888PixelAlphaSwizzleNEON;
-#else
+                if (SDL_HasNEON()) {
+                    return Blit8888to8888PixelAlphaSwizzleNEON;
+                }
+#endif
                 if (sf->format == df->format) {
                     return Blit8888to8888PixelAlpha;
                 } else {
                     return Blit8888to8888PixelAlphaSwizzle;
                 }
-#endif
             }
             return BlitNtoNPixelAlpha;
 

--- a/src/video/SDL_blit_N.c
+++ b/src/video/SDL_blit_N.c
@@ -3127,7 +3127,9 @@ SDL_BlitFunc SDL_CalculateBlitN(SDL_Surface *surface)
             }
 #endif
 #if defined(SDL_NEON_INTRINSICS) && (__ARM_ARCH >= 8) && (defined(__aarch64__) || defined(_M_ARM64))
-            return Blit8888to8888PixelSwizzleNEON;
+            if (SDL_HasNEON()) {
+                return Blit8888to8888PixelSwizzleNEON;
+            }
 #endif
         }
 #if defined(SDL_SVE2_INTRINSICS) && (__ARM_ARCH >= 8) && (defined(__aarch64__) || defined(_M_ARM64))


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
