### PR TITLE
emscripten: don't dispatch user input to hidden windows

### DIFF
--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -713,6 +713,15 @@ static void Emscripten_UpdateMouseFromEvent(SDL_WindowData *window_data, const E
 {
     SDL_assert(event->pointer_type == PTRTYPE_MOUSE);
 
+    // Hidden windows (e.g. a shared GL-context window) may share the DOM canvas with the
+    // visible window. Their pointer-event listeners would otherwise fire alongside the
+    // visible window's, fighting over `mouse->focus` and producing events tagged with the
+    // hidden window's ID -- causing downstream consumers that key by window ID to silently
+    // drop them. Hidden windows shouldn't take part in user-input dispatch.
+    if (window_data->window->flags & SDL_WINDOW_HIDDEN) {
+        return;
+    }
+
     // rescale (in case canvas is being scaled)
     double client_w, client_h;
     emscripten_get_element_css_size(window_data->canvas_id, &client_w, &client_h);
@@ -837,6 +846,11 @@ static void Emscripten_UpdatePointerFromEvent(SDL_WindowData *window_data, const
 static void Emscripten_HandleMouseFocus(SDL_WindowData *window_data, const Emscripten_PointerEvent *event, bool isenter)
 {
     SDL_assert(event->pointer_type == PTRTYPE_MOUSE);
+
+    // Hidden windows shouldn't ever become the mouse-focus target.
+    if (window_data->window->flags & SDL_WINDOW_HIDDEN) {
+        return;
+    }
 
     const bool isPointerLocked = window_data->has_pointer_lock;
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

**DISCLAIMER:** AI assistance was used to identify and understand the bug. The fix was hand-written.

## Summary

When two `SDL_Window`s share the same DOM canvas on Emscripten (e.g. a visible main window alongside a hidden 1×1 window for a shared GL context -- same setup as #15511), mouse button events end up tagged with the hidden window's ID and are silently dropped by code that filters events on `event.button.windowID`. Symptom: a single physical click behaves as if held down, because the release event never reaches the application.

## Details

Both windows register pointer-event listeners on `#canvas`; both fire on every event. 

Each calls `SDL_SendMouseMotion(window_data->window, ...)`, which calls `SDL_UpdateMouseFocus`. 

The motion coordinates are pre-scaled by `window->w / canvas_css_w` -- so for the hidden 1×1 window, a real cursor at canvas pixel 800 becomes 0.625, which *is* inside `[0, 1)`.

`SDL_UpdateMouseFocus` then sets `mouse->focus` to the hidden window. The next `SDL_PrivateSendMouseButton` tags `event.button.windowID = mouse->focus->id` with the hidden window's ID.

Other SDL backends (Win32, Cocoa, X11, Wayland) get an invariant for free: the OS doesn't deliver input events to non-visible windows. Emscripten has no such invariant -- `SDL_WINDOW_HIDDEN` is just `display: none` on a (possibly shared) DOM canvas.

## Fix

Two early-returns in `src/video/emscripten/SDL_emscriptenevents.c`, both gated on the runtime `SDL_WINDOW_HIDDEN` flag:

- `Emscripten_UpdateMouseFromEvent`: hidden windows neither update cursor position nor dispatch button events.

- `Emscripten_HandleMouseFocus`: hidden windows can't claim `mouse->focus` on `pointerenter`.

Checking the flag at dispatch time (rather than gating handler registration) means a window that toggles between hidden and shown via `SDL_ShowWindow` / `SDL_HideWindow` participates in input correctly while shown, with no re-registration needed.

## Testing

Manually verified on Chrome via `emrun` using the same multi-window setup as #15511.

## Notes

This PR is a follow-up to #15511: same [VRSFML](https://github.com/vittorioromeo/VRSFML) hidden-window-for-shared-GL-context pattern. 

Similarly, this PR is also related to https://github.com/libsdl-org/SDL/issues/12512.