### PR TITLE
Ensure Android hidapi does not drop the report byte

### DIFF
--- a/src/hidapi/android/hid.cpp
+++ b/src/hidapi/android/hid.cpp
@@ -730,8 +730,8 @@ public:
 			if ( m_reportResponse.size() > 0 )
 			{
 				// Make sure we preserve the report value if it isn't already in the report.
-				bool bHasReportAlready = *pData == *m_reportResponse.data();
-				
+				bool bHasReportAlready = ( *pData == *m_reportResponse.data() );
+
 				// Make sure we only copy as much as will fit, deducting one byte for the report if we need to leave it intact.
 				size_t nSafeDataLen = nDataLen - ( bHasReportAlready ? 0 : 1 );
 				uBytesToCopy = m_reportResponse.size() < nSafeDataLen ? m_reportResponse.size() : nSafeDataLen;

--- a/src/hidapi/android/hid.cpp
+++ b/src/hidapi/android/hid.cpp
@@ -725,9 +725,27 @@ public:
 				}
 			}
 
-			size_t uBytesToCopy = m_reportResponse.size() > nDataLen ? nDataLen : m_reportResponse.size();
-			SDL_memcpy( pData, m_reportResponse.data(), uBytesToCopy );
-			m_reportResponse.clear();
+			size_t uBytesToCopy = 0;
+
+			if ( m_reportResponse.size() > 0 )
+			{
+				// Make sure we preserve the report value if it isn't already in the report.
+				bool bHasReportAlready = *pData == *m_reportResponse.data();
+				
+				// Make sure we only copy as much as will fit, deducting one byte for the report if we need to leave it intact.
+				size_t nSafeDataLen = nDataLen - ( bHasReportAlready ? 0 : 1 );
+				uBytesToCopy = m_reportResponse.size() < nSafeDataLen ? m_reportResponse.size() : nSafeDataLen;
+
+				SDL_memcpy( pData + ( bHasReportAlready ? 0 : 1 ), m_reportResponse.data(), uBytesToCopy );
+				m_reportResponse.clear();
+
+				if ( !bHasReportAlready )
+				{
+					// Add the report byte back on to return the real length.
+					uBytesToCopy++;
+				}
+			}
+
 			LOGV( "=== Got %zu bytes", uBytesToCopy );
 
 			return (int)uBytesToCopy;


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
While many HID devices return the report number as part of a get feature report response, this is not technically *required*, and not all HID-over-GATT devices do so. As a result, the new Steam Controller (among potentially others) did not work properly on Android.

This change basically mirrors the logic to handle the report byte on other platforms, which was missing on Android.