### PR TITLE
Enable text editing events in checkkeys

### DIFF
--- a/test/checkkeys.c
+++ b/test/checkkeys.c
@@ -467,6 +467,9 @@ int main(int argc, char *argv[])
     /* Disable mouse emulation */
     SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
 
+    /* Enable text editing events and tell SDL that we'll handle rendering compositions. */
+    SDL_SetHint(SDL_HINT_IME_IMPLEMENTED_UI, "composition");
+
     /* Initialize SDL */
     if (!SDLTest_CommonInit(state)) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't initialize SDL: %s", SDL_GetError());


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Enable SDL_EVENT_TEXT_EDITING events in the `checkkeys` test per the documentation in https://wiki.libsdl.org/SDL3/SDL_HINT_IME_IMPLEMENTED_UI. This was broken since that hint was introduced.

checkkeys handles these events just fine, printing them to the console and rendering them on-screen (although non-ASCII characters will just be rendered as checkerboard blocks).