### PR TITLE
GPU: Allow depth texture arrays

### DIFF
--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -1363,10 +1363,6 @@ SDL_GPUTexture *SDL_CreateGPUTexture(
         } else {
             if (createinfo->type == SDL_GPU_TEXTURETYPE_2D_ARRAY) {
                 // Array Texture Validation
-                if (createinfo->usage & SDL_GPU_TEXTUREUSAGE_DEPTH_STENCIL_TARGET) {
-                    SDL_assert_release(!"For array textures: usage must not contain DEPTH_STENCIL_TARGET");
-                    failed = true;
-                }
                 if (createinfo->sample_count > SDL_GPU_SAMPLECOUNT_1) {
                     SDL_assert_release(!"For array textures: sample_count must be SDL_GPU_SAMPLECOUNT_1");
                     failed = true;


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
SDL GPU doesn't allow clients to create depth texture arrays. There was not a technical reason for this, only that we hadn't verified that it actually worked.

I have now written an example here: https://github.com/TheSpydog/SDL_gpu_examples/blob/main/Examples/DepthArray.c

Verified that it works on D3D12/Vulkan, just waiting on Metal verification

## Existing Issue(s)
Resolves #15529
