### PR TITLE
pen: fix buttons incorrectly remapped on linux backends

### DIFF
--- a/src/events/SDL_pen.c
+++ b/src/events/SDL_pen.c
@@ -617,16 +617,7 @@ void SDL_SendPenButton(Uint64 timestamp, SDL_PenID instance_id, SDL_Window *wind
             if (window && (!pen_touching || (pen_touching == instance_id))) {
                 SDL_Mouse *mouse = SDL_GetMouse();
                 if (mouse && mouse->pen_mouse_events) {
-                    static const Uint8 mouse_buttons[] = {
-                        SDL_BUTTON_LEFT,
-                        SDL_BUTTON_RIGHT,
-                        SDL_BUTTON_MIDDLE,
-                        SDL_BUTTON_X1,
-                        SDL_BUTTON_X2
-                    };
-                    if (button < SDL_arraysize(mouse_buttons)) {
-                        SDL_SendMouseButton(timestamp, window, SDL_PEN_MOUSEID, mouse_buttons[button], down);
-                    }
+                    SDL_SendMouseButton(timestamp, window, SDL_PEN_MOUSEID, button, down);
                 }
             }
         }

--- a/src/video/android/SDL_androidpen.c
+++ b/src/video/android/SDL_androidpen.c
@@ -69,7 +69,16 @@ void Android_OnPen(SDL_Window *window, int pen_id_in, SDL_PenDeviceType device_t
         for (Uint8 i = 1; i <= 5; ++i) {
             Uint8 mask = (1 << i);
             if (diff & mask) {
-                SDL_SendPenButton(0, pen, window, i, (button & mask) != 0);
+                // Android convention: Primary(1) = Left; Secondary(2) = Right; Ternary(3) = Middle
+                static const Uint8 mouse_buttons[] = {
+                    SDL_BUTTON_LEFT,
+                    SDL_BUTTON_RIGHT,
+                    SDL_BUTTON_MIDDLE,
+                    SDL_BUTTON_X1,
+                    SDL_BUTTON_X2,
+					SDL_BUTTON_X2 + 1
+                };
+                SDL_SendPenButton(0, pen, window, mouse_buttons[i], (button & mask) != 0);
             }
         }
     }

--- a/src/video/android/SDL_androidpen.c
+++ b/src/video/android/SDL_androidpen.c
@@ -76,7 +76,7 @@ void Android_OnPen(SDL_Window *window, int pen_id_in, SDL_PenDeviceType device_t
                     SDL_BUTTON_MIDDLE,
                     SDL_BUTTON_X1,
                     SDL_BUTTON_X2,
-					SDL_BUTTON_X2 + 1
+                    SDL_BUTTON_X2 + 1
                 };
                 SDL_SendPenButton(0, pen, window, mouse_buttons[i], (button & mask) != 0);
             }

--- a/src/video/cocoa/SDL_cocoapen.m
+++ b/src/video/cocoa/SDL_cocoapen.m
@@ -138,8 +138,8 @@ static void Cocoa_HandlePenPointEvent(SDL_CocoaWindowData *_data, NSEvent *event
 
     SDL_SendPenTouch(timestamp, pen, window, handle->is_eraser, is_touching);
     SDL_SendPenMotion(timestamp, pen, window, (float) point.x, (float) (window->h - point.y));
-    SDL_SendPenButton(timestamp, pen, window, 1, ((buttons & NSEventButtonMaskPenLowerSide) != 0));
-    SDL_SendPenButton(timestamp, pen, window, 2, ((buttons & NSEventButtonMaskPenUpperSide) != 0));
+    SDL_SendPenButton(timestamp, pen, window, SDL_BUTTON_RIGHT, ((buttons & NSEventButtonMaskPenLowerSide) != 0));
+    SDL_SendPenButton(timestamp, pen, window, SDL_BUTTON_MIDDLE, ((buttons & NSEventButtonMaskPenUpperSide) != 0));
     SDL_SendPenAxis(timestamp, pen, window, SDL_PEN_AXIS_PRESSURE, [event pressure]);
     SDL_SendPenAxis(timestamp, pen, window, SDL_PEN_AXIS_ROTATION, [event rotation]);
     SDL_SendPenAxis(timestamp, pen, window, SDL_PEN_AXIS_XTILT, ((float) tilt.x) * 90.0f);

--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -806,10 +806,10 @@ static void Emscripten_UpdatePenFromEvent(SDL_WindowData *window_data, const Ems
             SDL_SendPenTouch(0, pen, window_data->window, true, down);
         } else if (event->button == 1) {
             bool down = ((event->buttons & 4) != 0);
-            SDL_SendPenButton(0, pen, window_data->window, 2, down);
+            SDL_SendPenButton(0, pen, window_data->window, SDL_BUTTON_MIDDLE, down);
         } else if (event->button == 2) {
             bool down = ((event->buttons & 2) != 0);
-            SDL_SendPenButton(0, pen, window_data->window, 1, down);
+            SDL_SendPenButton(0, pen, window_data->window, SDL_BUTTON_RIGHT, down);
         }
 
         SDL_SendPenAxis(0, pen, window_data->window, SDL_PEN_AXIS_PRESSURE, event->pressure);

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -3510,7 +3510,7 @@ static void tablet_tool_handle_frame(void *data, struct zwp_tablet_tool_v2 *tool
     for (int i = 0; i < SDL_arraysize(sdltool->frame.buttons); i++) {
         const int state = sdltool->frame.buttons[i];
         if (state) {
-            SDL_SendPenButton(timestamp, instance_id, window, (Uint8)(i + 1), state == WAYLAND_TABLET_TOOL_BUTTON_DOWN);
+            SDL_SendPenButton(timestamp, instance_id, window, (Uint8)(i + 2), state == WAYLAND_TABLET_TOOL_BUTTON_DOWN);
         }
     }
 

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -1403,8 +1403,8 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
         }
 
         SDL_SendPenMotion(timestamp, pen, window, fx, fy);
-        SDL_SendPenButton(timestamp, pen, window, 1, (pen_info.penFlags & PEN_FLAG_BARREL) != 0);
-        SDL_SendPenButton(timestamp, pen, window, 2, (pen_info.penFlags & PEN_FLAG_ERASER) != 0);
+        SDL_SendPenButton(timestamp, pen, window, SDL_BUTTON_RIGHT, (pen_info.penFlags & PEN_FLAG_BARREL) != 0);
+        SDL_SendPenButton(timestamp, pen, window, SDL_BUTTON_MIDDLE, (pen_info.penFlags & PEN_FLAG_ERASER) != 0);
 
         if (pen_info.penMask & PEN_MASK_PRESSURE) {
             SDL_SendPenAxis(timestamp, pen, window, SDL_PEN_AXIS_PRESSURE, ((float) pen_info.pressure) / 1024.0f);  // pen_info.pressure is in the range 0..1024.

--- a/src/video/x11/SDL_x11xinput2.c
+++ b/src/video/x11/SDL_x11xinput2.c
@@ -615,7 +615,7 @@ void X11_HandleXinput2Event(SDL_VideoDevice *_this, XGenericEventCookie *cookie)
             if (button == 1) { // button 1 is the pen tip
                 SDL_SendPenTouch(0, pen->pen, window, pen->is_eraser, down);
             } else {
-                SDL_SendPenButton(0, pen->pen, window, button - 1, down);
+                SDL_SendPenButton(0, pen->pen, window, button, down);
             }
         } else if (!pointer_emulated) {
             // Otherwise assume a regular mouse


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Solves first of the two problems described in #14788 (will create a second PR for the other one).

On linux backends (confirmed that X11 and Wayland were both affected), the second remapping applied in `SDL_pen.c` confused RMB with MMB by hardcoding RMB to button 2 and MMB to button 3 (windows/android-canon).

While fixing this issue I also realized that, since button number to its canonical interpretation is backend-dependent (windows/android button 2 = RMB; unix button 2 = MMB), the logic for determining buttons should be located in the backend themselves, whereas `SDL_pen.c` should be backend-agnostic, transparent and all the button interpretations (if any) should be done in the specific backends. So I moved them there.
Now it's backends' job to provide the correct per-backend's-canon button to the `SendPenButton`, and `SendPenButton` must trust that the correct button is passed (as it should).

To improve clarity of intent, when hardcoded values are passed from backend to `SendPenButton` they are now done so using the `SDL_BUTTON_` macros instead of passing int literals.

## Per-backend net changes / anti-regression sanity check
I am only able to test on linux, so for other backends I ensured the changes are minimal and preserve the way things worked. For non-linux backends the button number in mouse event is preserved exactly, but the button numbers passed in pen event can be different (made to match the mouse event button number).

- **X11 backend**: Verified on my machine that the issue was present before (MMB confused with RMB), and is fixed by the changes in this PR. Button numbers match `xev` exactly, including any remappings (done via `xsetwacom`, `input-remapper` or any other method) .
 
| Device button pressed | pen event button before | pen event button after | mouse event button before | mouse event button after |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| 2  | SDL_BUTTON_LEFT  | SDL_BUTTON_MIDDLE | SDL_BUTTON_RIGHT | SDL_BUTTON_MIDDLE
| 3  | SDL_BUTTON_MIDDLE | SDL_BUTTON_RIGHT | SDL_BUTTON_MIDDLE | SDL_BUTTON_RIGHT

**This has been tested before and after.**

- **Wayland backend**: Verified on my machine that the issue was present before (MMB confused with RMB), and is fixed by the changes in this PR (event button numbers match device button numbers exactly)

| Device button pressed | pen event button before | pen event button after | mouse event button before | mouse event button after |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| 2  | SDL_BUTTON_LEFT  | SDL_BUTTON_MIDDLE | SDL_BUTTON_RIGHT | SDL_BUTTON_MIDDLE
| 3  | SDL_BUTTON_MIDDLE | SDL_BUTTON_RIGHT | SDL_BUTTON_MIDDLE | SDL_BUTTON_RIGHT

**This has been tested before and after.**

- **Windows backend**: Did not test, but the `SDL_SendMouseButton` arguments are identical as before. The "mappings" table was an identity table for windows-canon and was redundant.

| Device button pressed | pen event button before | pen event button after | mouse event button before | mouse event button after |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| 2  | SDL_BUTTON_LEFT | SDL_BUTTON_RIGHT | SDL_BUTTON_RIGHT | SDL_BUTTON_RIGHT
| 3  | SDL_BUTTON_RIGHT | SDL_BUTTON_MIDDLE | SDL_BUTTON_MIDDLE | SDL_BUTTON_MIDDLE

**This has not been tested; the "after" values are expected following the logic flow.**

- **Android backend**: Did not test, but the `SDL_SendMouseButton` arguments are identical as before. The mapping is kept per android-canon (Button 2 = Secondary = "technically" RMB), but moved to backend. _I cannot verify if this is actually necessary, but preserving this anyway to not introduce changes/regression risk._ Button 6 is still clamped inside `SDL_pen.c` as it was before, even if the backend recognizes it now.

| Device button pressed | pen event button before | pen event button after | mouse event button before | mouse event button after |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| 2  | SDL_BUTTON_LEFT | SDL_BUTTON_RIGHT | SDL_BUTTON_RIGHT | SDL_BUTTON_RIGHT
| 3  | SDL_BUTTON_RIGHT | SDL_BUTTON_MIDDLE | SDL_BUTTON_MIDDLE | SDL_BUTTON_MIDDLE

**This has not been tested; the "after" values are expected following the logic flow.**

- **Emscripten backend**: Did not test, but the `SDL_SendMouseButton` arguments are identical as before. Formerly values `2` and `1` were passed and mapped to `SDL_BUTTON_MIDDLE` and `SDL_BUTTON_RIGHT` respectively. Now the mapping is gone and the expected `SDL_BUTTON_`s are passed instead.

| Device button pressed | pen event button before | pen event button after | mouse event button before | mouse event button after |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| 2  | SDL_BUTTON_LEFT | SDL_BUTTON_RIGHT | SDL_BUTTON_RIGHT | SDL_BUTTON_RIGHT
| 3  | SDL_BUTTON_RIGHT | SDL_BUTTON_MIDDLE | SDL_BUTTON_MIDDLE | SDL_BUTTON_MIDDLE

**This has not been tested; the "after" values are expected following the logic flow.**

- **Cocoapen backend**: Did not test, but the `SDL_SendMouseButton` arguments are identical as before. Formerly values `2` and `1` were passed and mapped to `SDL_BUTTON_MIDDLE` and `SDL_BUTTON_RIGHT` respectively. Now the mapping is gone and the expected `SDL_BUTTON_`s are passed instead.

| Device button pressed | pen event button before | pen event button after | mouse event button before | mouse event button after |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| 2  | SDL_BUTTON_LEFT | SDL_BUTTON_RIGHT | SDL_BUTTON_RIGHT | SDL_BUTTON_RIGHT
| 3  | SDL_BUTTON_RIGHT | SDL_BUTTON_MIDDLE | SDL_BUTTON_MIDDLE | SDL_BUTTON_MIDDLE

**This has not been tested; the "after" values are expected following the logic flow.**


**Depending on what's the approach to event consumers hardcoding expected event button this may warrant marking the change as breaking for downsteam.** The change is that different buttons numbers will be present in `SDL_EVENT_PEN_BUTTON_` for all backends except windows. After this change they will match the accompanying button in `SDL_EVENT_MOUSE_BUTTON_`.

## TL;DR: changes
- pen/linux: fixed bad mouse event buttons
- pen/all: fixed bad pen event buttons
- (side effect) button passed in pen and mouse events is now consistent.

## TL;DR: technical
- button passed to `SendPenButton` (and also present in pen events) increased by `1` to align with `SDL_BUTTON_` macros across the board.
- fixed incorrect windows-canonization of mouse buttons passed to mouse events on linux (x11 & wayland).

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes partially #14788
The second part will be fixed in a separate PR.