### PR TITLE
GPU: Fix segfault when copying to Vulkan swapchain

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -2500,6 +2500,12 @@ static void VULKAN_INTERNAL_TrackTextureTransfer(
     VulkanCommandBuffer *commandBuffer,
     VulkanTexture *texture)
 {
+    // Textures not managed by our allocator (i.e. the swapchain) don't need to be refcounted.
+    if (texture->usedRegion == NULL)
+    {
+        return;
+    }
+
     TRACK_RESOURCE(
         texture,
         VulkanTexture *,

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -2501,8 +2501,7 @@ static void VULKAN_INTERNAL_TrackTextureTransfer(
     VulkanTexture *texture)
 {
     // Textures not managed by our allocator (i.e. the swapchain) don't need to be refcounted.
-    if (texture->usedRegion == NULL)
-    {
+    if (texture->usedRegion == NULL) {
         return;
     }
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
Certain textures aren't allocated by us (like the swapchain) so refcounting their allocation region causes a segfault. We can simply ignore refcounting these textures as they are not relevant when defragmenting.

## Existing Issue(s)
Fixes #15542

