### PR TITLE
Android: Support defaultLocation with SDL_ShowSaveFileDialog

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -2043,7 +2043,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     /**
      * This method is called by SDL using JNI.
      */
-    public static boolean showFileDialog(String[] filters, boolean allowMultiple, boolean forWrite, int requestCode) {
+    public static boolean showFileDialog(String[] filters, boolean allowMultiple, String defaultLocation, boolean forWrite, int requestCode) {
         if (mSingleton == null) {
             return false;
         }
@@ -2077,6 +2077,10 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
         Intent intent = new Intent(forWrite ? Intent.ACTION_CREATE_DOCUMENT : Intent.ACTION_OPEN_DOCUMENT);
         intent.addCategory(Intent.CATEGORY_OPENABLE);
         intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, allowMultiple);
+
+        intent.putExtra("android.content.extra.SHOW_ADVANCED", true);
+        intent.putExtra("android.intent.extra.TITLE", defaultLocation);
+
         switch (mimes.size()) {
             case 0:
                 intent.setType("*/*");

--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -688,7 +688,7 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(nativeSetupJNI)(JNIEnv *env, jclass cl
     midShowTextInput = (*env)->GetStaticMethodID(env, mActivityClass, "showTextInput", "(IIIII)Z");
     midSupportsRelativeMouse = (*env)->GetStaticMethodID(env, mActivityClass, "supportsRelativeMouse", "()Z");
     midOpenFileDescriptor = (*env)->GetStaticMethodID(env, mActivityClass, "openFileDescriptor", "(Ljava/lang/String;Ljava/lang/String;)I");
-    midShowFileDialog = (*env)->GetStaticMethodID(env, mActivityClass, "showFileDialog", "([Ljava/lang/String;ZZI)Z");
+    midShowFileDialog = (*env)->GetStaticMethodID(env, mActivityClass, "showFileDialog", "([Ljava/lang/String;ZLjava/lang/String;ZI)Z");
     midGetPreferredLocales = (*env)->GetStaticMethodID(env, mActivityClass, "getPreferredLocales", "()Ljava/lang/String;");
 
     if (!midClipboardGetText ||
@@ -3374,7 +3374,7 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(onNativeFileDialog)(
 bool Android_JNI_OpenFileDialog(
     SDL_DialogFileCallback callback, void *userdata,
     const SDL_DialogFileFilter *filters, int nfilters, bool forwrite,
-    bool multiple)
+    bool multiple, const char* defaultLocation)
 {
     if (mAndroidFileDialogData.callback != NULL) {
         SDL_SetError("Only one file dialog can be run at a time.");
@@ -3408,9 +3408,11 @@ bool Android_JNI_OpenFileDialog(
     mAndroidFileDialogData.userdata = userdata;
     mAndroidFileDialogData.callback = callback;
 
+    jstring jstringDefaultLocation = (*env)->NewStringUTF(env, defaultLocation);
+
     // Invoke JNI
     jboolean success = (*env)->CallStaticBooleanMethod(env, mActivityClass,
-        midShowFileDialog, filtersArray, (jboolean) multiple, (jboolean) forwrite, mAndroidFileDialogData.request_code);
+        midShowFileDialog, filtersArray, (jboolean) multiple, jstringDefaultLocation, (jboolean) forwrite, mAndroidFileDialogData.request_code);
     (*env)->DeleteLocalRef(env, filtersArray);
     if (!success) {
         mAndroidFileDialogData.callback = NULL;

--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -3374,7 +3374,7 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(onNativeFileDialog)(
 bool Android_JNI_OpenFileDialog(
     SDL_DialogFileCallback callback, void *userdata,
     const SDL_DialogFileFilter *filters, int nfilters, bool forwrite,
-    bool multiple, const char* defaultLocation)
+    bool multiple, const char *defaultLocation)
 {
     if (mAndroidFileDialogData.callback != NULL) {
         SDL_SetError("Only one file dialog can be run at a time.");

--- a/src/core/android/SDL_android.h
+++ b/src/core/android/SDL_android.h
@@ -156,7 +156,7 @@ bool SDL_IsAndroidTV(void);
 // File Dialogs
 bool Android_JNI_OpenFileDialog(SDL_DialogFileCallback callback, void *userdata,
     const SDL_DialogFileFilter *filters, int nfilters, bool forwrite,
-    bool multiple);
+    bool multiple, const char* defaultLocation);
 
 // Ends C function definitions when using C++
 #ifdef __cplusplus

--- a/src/core/android/SDL_android.h
+++ b/src/core/android/SDL_android.h
@@ -156,7 +156,7 @@ bool SDL_IsAndroidTV(void);
 // File Dialogs
 bool Android_JNI_OpenFileDialog(SDL_DialogFileCallback callback, void *userdata,
     const SDL_DialogFileFilter *filters, int nfilters, bool forwrite,
-    bool multiple, const char* defaultLocation);
+    bool multiple, const char *defaultLocation);
 
 // Ends C function definitions when using C++
 #ifdef __cplusplus

--- a/src/dialog/android/SDL_androiddialog.c
+++ b/src/dialog/android/SDL_androiddialog.c
@@ -28,6 +28,7 @@ void SDL_SYS_ShowFileDialogWithProperties(SDL_FileDialogType type, SDL_DialogFil
     SDL_DialogFileFilter *filters = SDL_GetPointerProperty(props, SDL_PROP_FILE_DIALOG_FILTERS_POINTER, NULL);
     int nfilters = (int) SDL_GetNumberProperty(props, SDL_PROP_FILE_DIALOG_NFILTERS_NUMBER, 0);
     bool allow_many = SDL_GetBooleanProperty(props, SDL_PROP_FILE_DIALOG_MANY_BOOLEAN, false);
+    const char* default_location = SDL_GetStringProperty(props, SDL_PROP_FILE_DIALOG_LOCATION_STRING, "");
     bool is_save;
 
     if (SDL_GetHint(SDL_HINT_FILE_DIALOG_DRIVER) != NULL) {
@@ -51,7 +52,7 @@ void SDL_SYS_ShowFileDialogWithProperties(SDL_FileDialogType type, SDL_DialogFil
         return;
     }
 
-    if (!Android_JNI_OpenFileDialog(callback, userdata, filters, nfilters, is_save, allow_many)) {
+    if (!Android_JNI_OpenFileDialog(callback, userdata, filters, nfilters, is_save, allow_many, default_location)) {
         // SDL_SetError is already called when it fails
         callback(userdata, NULL, -1);
     }


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Make SDL_ShowSaveFileDialog use the defaultLocation on android  instead of leaving the default title empty.

(Uses https://developer.android.com/reference/android/content/Intent#EXTRA_TITLE)

## Existing Issue(s)
None I think.
