### PR TITLE
x11: Store the mouse button serial for emulated pointer events as well

### DIFF
--- a/src/video/x11/SDL_x11xinput2.c
+++ b/src/video/x11/SDL_x11xinput2.c
@@ -605,6 +605,9 @@ void X11_HandleXinput2Event(SDL_VideoDevice *_this, XGenericEventCookie *cookie)
         bool pointer_emulated = false;
 #endif
 
+        // Store the button serial to filter out redundant core button events.
+        videodata->xinput_last_button_serial = xev->serial;
+
         if (pen) {
             if (xev->deviceid != xev->sourceid) {
                 // Discard events from "Master" devices to avoid duplicates.
@@ -621,9 +624,6 @@ void X11_HandleXinput2Event(SDL_VideoDevice *_this, XGenericEventCookie *cookie)
             // Otherwise assume a regular mouse
             SDL_WindowData *windowdata = X11_FindWindow(videodata, xev->event);
             int x_ticks = 0, y_ticks = 0;
-
-            // Store the button serial to filter out redundant core button events.
-            videodata->xinput_last_button_serial = xev->serial;
 
             if (xev->deviceid != videodata->xinput_master_pointer_device) {
                 // Ignore slave button events on non-focused windows, or focus can be incorrectly set while a grab is active.


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Otherwise, filtered emulated button events, such as for mouse wheel events, can slip through the core event handler when the mouse is grabbed.

Fixes libsdl-org/sdl2-compat#596