### PR TITLE
*Only* preserve report byte for feature reports. Oops.

### DIFF
--- a/src/hidapi/android/hid.cpp
+++ b/src/hidapi/android/hid.cpp
@@ -727,7 +727,7 @@ public:
 
 			size_t uBytesToCopy = 0;
 
-			if ( m_reportResponse.size() > 0 )
+			if ( bFeature && m_reportResponse.size() > 0 )
 			{
 				// Make sure we preserve the report value if it isn't already in the report.
 				bool bHasReportAlready = ( *pData == *m_reportResponse.data() );


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
The previous change to make Android HID work right for some controllers worked well for some controllers (including all I tested on), but unintentionally broke others because I forgot one check. We only need to preserve the report byte for *feature* reports, so this now leaves things untouched for *input* reports.
