### PR TITLE
Fix Steam Controller 2026 (triton) rumble

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_steam_triton.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam_triton.c
@@ -360,6 +360,8 @@ static void HIDAPI_DriverSteamTriton_SetDevicePlayerIndex(SDL_HIDAPI_Device *dev
 {
 }
 
+static bool HIDAPI_DriverSteamTriton_RumbleJoystick(SDL_HIDAPI_Device *device, SDL_Joystick *joystick, Uint16 low_frequency_rumble, Uint16 high_frequency_rumble);
+
 static bool HIDAPI_DriverSteamTriton_UpdateDevice(SDL_HIDAPI_Device *device)
 {
     SDL_DriverSteamTriton_Context *ctx = (SDL_DriverSteamTriton_Context *)device->context;

--- a/src/joystick/hidapi/SDL_hidapi_steam_triton.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam_triton.c
@@ -469,8 +469,8 @@ static bool HIDAPI_DriverSteamTriton_RumbleJoystick(SDL_HIDAPI_Device *device, S
     rc = SDL_hid_write(device->dev, buffer, sizeof(buffer));
     if (rc < 0) {
         SDL_LogError(SDL_LOG_CATEGORY_INPUT, 
-            "Steam Controller HID Write FAILED! rc: %d, expected: %zu. SDL_Error: %s", 
-            rc, sizeof(buffer), SDL_GetError());
+            "Steam Controller HID Write FAILED! rc: %d. SDL_Error: %s", 
+            rc, SDL_GetError());
 
         return false;
     }

--- a/src/joystick/hidapi/SDL_hidapi_steam_triton.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam_triton.c
@@ -462,9 +462,9 @@ static bool HIDAPI_DriverSteamTriton_RumbleJoystick(SDL_HIDAPI_Device *device, S
     msg->payload.hapticRumble.type = 0;
     msg->payload.hapticRumble.intensity = 0;
     msg->payload.hapticRumble.left.speed = low_frequency_rumble;
-    msg->payload.hapticRumble.left.gain = low_frequency_rumble;
+    msg->payload.hapticRumble.left.gain = 0;
     msg->payload.hapticRumble.right.speed = high_frequency_rumble;
-    msg->payload.hapticRumble.right.gain = high_frequency_rumble;
+    msg->payload.hapticRumble.right.gain = 0;
 
     rc = SDL_hid_write(device->dev, buffer, sizeof(buffer));
     if (rc < 0) {

--- a/src/joystick/hidapi/SDL_hidapi_steam_triton.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam_triton.c
@@ -35,6 +35,9 @@
 // Always 1kHz according to USB descriptor, but actually about 4 ms.
 #define TRITON_SENSOR_UPDATE_INTERVAL_US 4032
 
+// Steam Controller hardware safety timeout is around 50ms, so we resend rumble every 40ms
+#define TRITON_RUMBLE_RESEND_INTERVAL_MS 40
+
 enum
 {
     SDL_GAMEPAD_BUTTON_STEAM_DECK_QAM = 11,
@@ -96,6 +99,9 @@ typedef struct
     Uint64 sensor_timestamp_ns;
     Uint64 last_button_state;
     Uint64 last_lizard_update;
+    Uint16 low_frequency_rumble;
+    Uint16 high_frequency_rumble;
+    Uint64 last_rumble_time;
 } SDL_DriverSteamTriton_Context;
 
 static bool IsProteusDongle(Uint16 product_id)
@@ -369,6 +375,12 @@ static bool HIDAPI_DriverSteamTriton_UpdateDevice(SDL_HIDAPI_Device *device)
             DisableSteamTritonLizardMode(device->dev);
             ctx->last_lizard_update = now;
         }
+
+        if (ctx->low_frequency_rumble || ctx->high_frequency_rumble) {
+            if ((now - ctx->last_rumble_time) >= TRITON_RUMBLE_RESEND_INTERVAL_MS) {
+                HIDAPI_DriverSteamTriton_RumbleJoystick(device, joystick, ctx->low_frequency_rumble, ctx->high_frequency_rumble);
+            }
+        }
     }
 
     for (;;) {
@@ -436,23 +448,30 @@ static bool HIDAPI_DriverSteamTriton_OpenJoystick(SDL_HIDAPI_Device *device, SDL
 
 static bool HIDAPI_DriverSteamTriton_RumbleJoystick(SDL_HIDAPI_Device *device, SDL_Joystick *joystick, Uint16 low_frequency_rumble, Uint16 high_frequency_rumble)
 {
+    SDL_DriverSteamTriton_Context *ctx = (SDL_DriverSteamTriton_Context *)device->context;
     int rc;
 
-    //RKRK Not sure about size. Probably 64+1 is OK for ORs
-    Uint8 buffer[HID_RUMBLE_OUTPUT_REPORT_BYTES];
+    ctx->low_frequency_rumble = low_frequency_rumble;
+    ctx->high_frequency_rumble = high_frequency_rumble;
+    ctx->last_rumble_time = SDL_GetTicks();
+
+    Uint8 buffer[HID_RUMBLE_OUTPUT_REPORT_BYTES] = { 0 };
     OutputReportMsg *msg = (OutputReportMsg *)(buffer);
 
 	msg->report_id = ID_OUT_REPORT_HAPTIC_RUMBLE;
     msg->payload.hapticRumble.type = 0;
     msg->payload.hapticRumble.intensity = 0;
     msg->payload.hapticRumble.left.speed = low_frequency_rumble;
-    msg->payload.hapticRumble.left.gain = 0;
+    msg->payload.hapticRumble.left.gain = low_frequency_rumble;
     msg->payload.hapticRumble.right.speed = high_frequency_rumble;
-    msg->payload.hapticRumble.right.gain = 0;
-
+    msg->payload.hapticRumble.right.gain = high_frequency_rumble;
 
     rc = SDL_hid_write(device->dev, buffer, sizeof(buffer));
-    if (rc != sizeof(buffer)) {
+    if (rc < 0) {
+        SDL_LogError(SDL_LOG_CATEGORY_INPUT, 
+            "Steam Controller HID Write FAILED! rc: %d, expected: %zu. SDL_Error: %s", 
+            rc, sizeof(buffer), SDL_GetError());
+
         return false;
     }
     return true;


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Fix the long rumble for the new Steam Controller (2026 version).

## Description
The Steam Controller can rumble for about 50 milliseconds max and, using the current implementation, the controller would rumble for 50 milliseconds every two seconds. This is due to the `SDL_RUMBLE_RESEND_MS`  constant from `SDL_sysjoystick.h`. The present change modifies this behavior and allows a hid write to be sent every 40 milliseconds in order to have a proper long rumble. This method will require calling `SDL_PumpEvents` in a loop.

Another change is the expected number of bytes written by `SDL_hid_write`. The buffer has only 10 bytes (9 of content + 1 for report) but in the end, a minimum of 64 bytes are written. It is enough to check if the result is not -1 instead of the exact number of bytes.

## Existing Issue(s)
Fixes part of https://github.com/libsdl-org/SDL/issues/15471
