### PR TITLE
Ensure Android gamepad mappings don't lose the first button.

### DIFF
--- a/src/joystick/SDL_gamepad.c
+++ b/src/joystick/SDL_gamepad.c
@@ -750,7 +750,7 @@ static GamepadMapping_t *SDL_CreateMappingForAndroidGamepad(SDL_GUID guid)
             return NULL;
         }
 
-        SDL_strlcpy(mapping_string, "*,", sizeof(mapping_string));
+        SDL_strlcat(mapping_string, "*,", sizeof(mapping_string));
 
         if (button_mask & (1 << SDL_GAMEPAD_BUTTON_SOUTH)) {
             SDL_strlcat(mapping_string, "a:b0,", sizeof(mapping_string));


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
While digging into other Android USB issues, I noticed that the `SDL_CreateMappingForAndroidGamepad` function was using `SDL_strcpy` instead of `SDL_strcat` in one place, thus overwriting the `none` placeholder GUID, and causing the first button mapping (`a:b0`) to be used as the gamepad name instead of an actual button mapping.