### PR TITLE
Correctly support OG Steam Controller when connected via USB on Android

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/HIDDeviceUSB.java
+++ b/android-project/app/src/main/java/org/libsdl/app/HIDDeviceUSB.java
@@ -99,17 +99,6 @@ class HIDDeviceUSB implements HIDDevice {
         return getManufacturerName() + " " + getProductName() + "(0x" + String.format("%x", getVendorId()) + "/0x" + String.format("%x", getProductId()) + ")";
     }
 
-
-    private boolean isOriginalSteamController()
-    {
-        return mDevice.getVendorId() == 0x28de && mDevice.getProductId() == 0x1102;
-    }
-
-    private boolean isOriginalSteamControllerDongle()
-    {
-        return mDevice.getVendorId() == 0x28de && mDevice.getProductId() == 0x1142;        
-    }
-
     @Override
     public boolean open() {
         mConnection = mManager.getUSBManager().openDevice(mDevice);
@@ -146,7 +135,7 @@ class HIDDeviceUSB implements HIDDevice {
         // Make sure the required endpoints were present. The original Steam Controller and the wireless dongle for it do NOT
         // actually have -- or require -- output endpoints, so we need to accept only an input one for them or else we'll fall
         // back to the Android system gamepad functionality (and lose our paddles et al).
-        if (mInputEndpoint == null || (mOutputEndpoint == null && !isOriginalSteamController() && !isOriginalSteamControllerDongle())) {
+        if (mInputEndpoint == null) {
             Log.w(TAG, "Missing required endpoint on USB device " + getDeviceName());
             close();
             return false;
@@ -198,6 +187,11 @@ class HIDDeviceUSB implements HIDDevice {
             }
             return length;
         } else {
+            if (mOutputEndpoint == null)
+            {
+                Log.e(TAG, "Tried to write an output report to an interface with no output endpoint!");
+                return -1;
+            }
             int res = mConnection.bulkTransfer(mOutputEndpoint, report, report.length, 1000);
             if (res != report.length) {
                 Log.w(TAG, "writeOutputReport() returned " + res + " on device " + getDeviceName());

--- a/android-project/app/src/main/java/org/libsdl/app/HIDDeviceUSB.java
+++ b/android-project/app/src/main/java/org/libsdl/app/HIDDeviceUSB.java
@@ -99,6 +99,17 @@ class HIDDeviceUSB implements HIDDevice {
         return getManufacturerName() + " " + getProductName() + "(0x" + String.format("%x", getVendorId()) + "/0x" + String.format("%x", getProductId()) + ")";
     }
 
+
+    private boolean isOriginalSteamController()
+    {
+        return mDevice.getVendorId() == 0x28de && mDevice.getProductId() == 0x1102;
+    }
+
+    private boolean isOriginalSteamControllerDongle()
+    {
+        return mDevice.getVendorId() == 0x28de && mDevice.getProductId() == 0x1142;        
+    }
+
     @Override
     public boolean open() {
         mConnection = mManager.getUSBManager().openDevice(mDevice);
@@ -132,8 +143,10 @@ class HIDDeviceUSB implements HIDDevice {
             }
         }
 
-        // Make sure the required endpoints were present
-        if (mInputEndpoint == null || mOutputEndpoint == null) {
+        // Make sure the required endpoints were present. The original Steam Controller and the wireless dongle for it do NOT
+        // actually have -- or require -- output endpoints, so we need to accept only an input one for them or else we'll fall
+        // back to the Android system gamepad functionality (and lose our paddles et al).
+        if (mInputEndpoint == null || (mOutputEndpoint == null && !isOriginalSteamController() && !isOriginalSteamControllerDongle())) {
             Log.w(TAG, "Missing required endpoint on USB device " + getDeviceName());
             close();
             return false;


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
One last small change. Right now, on Android, we require HID devices to have an input and output endpoint when validating them and grabbing them on the Java side. Which is reasonable for most things!

However, the original Steam Controller (and the dongle) do not actually have output endpoints, so we exclude them as valid HID devices. This means we fall back to Android gamepad support (since the kernel now supports the Steam Controller), and thus lose access to the paddles and gyro, as well as the ability to use the dpad touchpad as a touchpad.

This change makes it so that we do not require the output endpoint to be present if the VID/PID matches the OG Steam Controller (or its USB dongle), so that we can use it properly via HIDAPI with all features enabled.