### PR TITLE
Allow formats with alpha channels for window textures

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -424,7 +424,7 @@ static bool SDL_CreateWindowTexture(SDL_VideoDevice *_this, SDL_Window *window, 
             !SDL_ISPIXELFORMAT_10BIT(texture_format) &&
             !SDL_ISPIXELFORMAT_FLOAT(texture_format) &&
             !SDL_ISPIXELFORMAT_INDEXED(texture_format) &&
-            transparent == SDL_ISPIXELFORMAT_ALPHA(texture_format)) {
+            (!transparent || SDL_ISPIXELFORMAT_ALPHA(texture_format))) {
             *format = texture_format;
             break;
         }


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Because the blend mode is explicitly set to `SDL_BLENDMODE_NONE`, it doesn't matter if there's a transparency channel in the texture format or not for opaque windows. This ensures that a 32-bit format is used with Metal instead of `SDL_PIXELFORMAT_RGB565`.