### PR TITLE
Re-apply spatch transforms to new DOS & Tray subsystems

### DIFF
--- a/src/audio/dos/SDL_dosaudio_sb.c
+++ b/src/audio/dos/SDL_dosaudio_sb.c
@@ -485,12 +485,8 @@ static void DOSSOUNDBLASTER_CloseDevice(SDL_AudioDevice *device)
         }
 
         // Free ring buffer resources.
-        if (hidden->ring_buffer) {
-            SDL_free(hidden->ring_buffer);
-        }
-        if (hidden->staging_buffer) {
-            SDL_free(hidden->staging_buffer);
-        }
+        SDL_free(hidden->ring_buffer);
+        SDL_free(hidden->staging_buffer);
 
         // Clear ISR-visible statics.
         isr_ring_buffer = NULL;

--- a/src/core/dos/SDL_dos_scheduler.c
+++ b/src/core/dos/SDL_dos_scheduler.c
@@ -82,7 +82,7 @@ void DOS_SchedulerInit(void)
         return;
     }
 
-    SDL_memset(threads, 0, sizeof(threads));
+    SDL_zeroa(threads);
 
     // Thread 0 is the main thread (already running)
     threads[0].state = DOS_THREAD_RUNNING;
@@ -146,7 +146,7 @@ int DOS_CreateThread(int (*fn)(void *), void *arg, size_t stack_size)
     _go32_dpmi_lock_data(stack, stack_size);
 
     DOS_ThreadContext *ctx = &threads[tid];
-    SDL_memset(ctx, 0, sizeof(*ctx));
+    SDL_zerop(ctx);
     ctx->id = tid;
     ctx->state = DOS_THREAD_READY;
     ctx->stack_base = stack;

--- a/src/thread/dos/SDL_sysmutex.c
+++ b/src/thread/dos/SDL_sysmutex.c
@@ -48,9 +48,7 @@ SDL_Mutex *SDL_CreateMutex(void)
 
 void SDL_DestroyMutex(SDL_Mutex *mutex)
 {
-    if (mutex) {
-        SDL_free(mutex);
-    }
+    SDL_free(mutex);
 }
 
 void SDL_LockMutex(SDL_Mutex *mutex) SDL_NO_THREAD_SAFETY_ANALYSIS

--- a/src/thread/dos/SDL_syssem.c
+++ b/src/thread/dos/SDL_syssem.c
@@ -44,9 +44,7 @@ SDL_Semaphore *SDL_CreateSemaphore(Uint32 initial_value)
 
 void SDL_DestroySemaphore(SDL_Semaphore *sem)
 {
-    if (sem) {
-        SDL_free(sem);
-    }
+    SDL_free(sem);
 }
 
 bool SDL_WaitSemaphoreTimeoutNS(SDL_Semaphore *sem, Sint64 timeoutNS)

--- a/src/thread/dos/SDL_systls.c
+++ b/src/thread/dos/SDL_systls.c
@@ -34,7 +34,7 @@ static SDL_TLSData *tls_data[DOS_MAX_THREADS];
 
 void SDL_SYS_InitTLSData(void)
 {
-    SDL_memset(tls_data, 0, sizeof(tls_data));
+    SDL_zeroa(tls_data);
 }
 
 SDL_TLSData *SDL_SYS_GetTLSData(void)
@@ -58,7 +58,7 @@ bool SDL_SYS_SetTLSData(SDL_TLSData *data)
 
 void SDL_SYS_QuitTLSData(void)
 {
-    SDL_memset(tls_data, 0, sizeof(tls_data));
+    SDL_zeroa(tls_data);
 }
 
 #endif /* SDL_THREAD_DOS */

--- a/src/tray/unix/SDL_dbustray.c
+++ b/src/tray/unix/SDL_dbustray.c
@@ -561,9 +561,7 @@ void DestroyMenu(SDL_TrayMenu *menu)
         SDL_ListClear(&menu_dbus->menu);
     }
 
-    if (menu_dbus->array_representation) {
-        SDL_free(menu_dbus->array_representation);
-    }
+    SDL_free(menu_dbus->array_representation);
 
     SDL_free(menu_dbus);
     SDL_free(menu);
@@ -656,9 +654,7 @@ void SetTrayTooltip(SDL_Tray *tray, const char *text)
     driver = (SDL_TrayDriverDBus *)tray->driver->internal;
     tray_dbus = (SDL_TrayDBus *)tray->internal;
 
-    if (tray_dbus->tooltip) {
-        SDL_free(tray_dbus->tooltip);
-    }
+    SDL_free(tray_dbus->tooltip);
 
     if (text) {
         tray_dbus->tooltip = SDL_strdup(text);
@@ -907,9 +903,7 @@ SDL_TrayEntry **GetTrayEntries(SDL_TrayMenu *menu, int *count)
 
     menu_dbus = (SDL_TrayMenuDBus *)menu->internal;
 
-    if (menu_dbus->array_representation) {
-        SDL_free(menu_dbus->array_representation);
-    }
+    SDL_free(menu_dbus->array_representation);
 
     sz = SDL_ListCountEntries(&menu_dbus->menu);
     array_representation = SDL_calloc(sz + 1, sizeof(SDL_TrayEntry *));

--- a/src/video/dos/SDL_dosframebuffer.c
+++ b/src/video/dos/SDL_dosframebuffer.c
@@ -105,7 +105,7 @@ static SDL_Surface *GetConvertedCursorSurface(SDL_CursorData *curdata, SDL_Surfa
 
     // Track which palette indices are used by opaque pixels.
     bool used[256];
-    SDL_memset(used, 0, sizeof(used));
+    SDL_zeroa(used);
 
     // First pass: blit with BLENDMODE_NONE to get raw color-matched indices.
     SDL_SetSurfaceBlendMode(src, SDL_BLENDMODE_NONE);
@@ -181,7 +181,7 @@ static SDL_Surface *CreateSystemSurface(SDL_VideoData *data, int w, int h, SDL_P
             // Initialize palette to all-black so that transitions start
             // from black instead of flashing uninitialized (white) colors.
             SDL_Color black[256];
-            SDL_memset(black, 0, sizeof(black));
+            SDL_zeroa(black);
             for (int i = 0; i < 256; i++) {
                 black[i].a = SDL_ALPHA_OPAQUE;
             }

--- a/src/video/dos/SDL_dosmodes.c
+++ b/src/video/dos/SDL_dosmodes.c
@@ -529,7 +529,7 @@ bool DOSVESA_SetDisplayMode(SDL_VideoDevice *device, SDL_VideoDisplay *sdl_displ
         // Clear the framebuffer
         {
             Uint8 zero_buf[320];
-            SDL_memset(zero_buf, 0, sizeof(zero_buf));
+            SDL_zeroa(zero_buf);
             Uint32 vga_base = (Uint32)VGA_MODE_13H_SEGMENT << 4;
             for (int row = 0; row < 200; row++) {
                 dosmemput(zero_buf, 320, vga_base + row * 320);
@@ -590,7 +590,7 @@ bool DOSVESA_SetDisplayMode(SDL_VideoDevice *device, SDL_VideoDisplay *sdl_displ
         Uint32 win_size_bytes = (Uint32)modedata->win_size * 1024;
         Uint32 win_base = (Uint32)modedata->win_a_segment << 4;
         Uint8 zero_buf[1024];
-        SDL_memset(zero_buf, 0, sizeof(zero_buf));
+        SDL_zeroa(zero_buf);
 
         Uint32 offset = 0;
         int current_bank = -1;


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Code janitor is back to (re)apply coccinelle spatch transforms that removes redundant NULL-checks before `SDL_Free()`, and replaces `SDL_memset()` with the appropriate `SDL_zero*()` macro.

Because these were previously applied in #14276, #14894 and #14899, it turns out only the relatively new tray and DOS subsystems are affected.