### PR TITLE
Add libusb-1.0-0-dev to Linux deps doc

### DIFF
--- a/docs/README-linux.md
+++ b/docs/README-linux.md
@@ -20,7 +20,7 @@ Ubuntu 18.04, all available features enabled:
     libaudio-dev libfribidi-dev libjack-dev libsndio-dev libx11-dev libxext-dev \
     libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev libxtst-dev \
     libxkbcommon-dev libdrm-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev \
-    libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev libthai-dev
+    libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev libthai-dev libusb-1.0-0-dev
 
 Ubuntu 22.04+ can also add `libpipewire-0.3-dev libwayland-dev libdecor-0-dev liburing-dev` to that command line.
 


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
libusb-1.0-0 is needed to enable SDL_HIDAPI_LIBUSB. It does not work with the `libusb-dev` package on Ubuntu, which is for the older version.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
N/A