### PR TITLE
Fix build with SVE2

### DIFF
--- a/include/SDL3/SDL_intrin.h
+++ b/include/SDL3/SDL_intrin.h
@@ -291,8 +291,8 @@ _m_prefetch(void *__P)
 #  elif defined(SDL_PLATFORM_MACOS)
 /* Apple has no AArch64 device supporting SVE2 */
 #  elif defined(__ARM_ARCH) && (__ARM_ARCH >= 8) && (defined(__aarch64__) || defined(_M_ARM64))
-#      define SDL_SVE2_INTRINSICS 1
-#      include <arm_sve.h>
+#    define SDL_SVE2_INTRINSICS 1
+#    include <arm_sve.h>
 #  endif
 #endif
 #endif /* compiler version */

--- a/include/SDL3/SDL_intrin.h
+++ b/include/SDL3/SDL_intrin.h
@@ -288,9 +288,11 @@ _m_prefetch(void *__P)
 #      define __ARM_FEATURE_SVE2 1 /* Set __ARM_FEATURE_SVE2 so that it can be used elsewhere, at compile time */
 #      define __ARM_ARCH 8
 #    endif
-#  elif !defined(SDL_PLATFORM_MACOS)  /* Apple has no AArch64 device supporting SVE2 */
-#    define SDL_SVE2_INTRINSICS 1
-#    include <arm_sve.h>
+#  elif defined(SDL_PLATFORM_MACOS)
+/* Apple has no AArch64 device supporting SVE2 */
+#  elif defined(__ARM_ARCH) && (__ARM_ARCH >= 8) && (defined(__aarch64__) || defined(_M_ARM64))
+#      define SDL_SVE2_INTRINSICS 1
+#      include <arm_sve.h>
 #  endif
 #endif
 #endif /* compiler version */


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

fix building for platform with no SVE2