### PR TITLE
Fix HIDAPI support for Flydigi Vader 5 Pro

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_flydigi.c
+++ b/src/joystick/hidapi/SDL_hidapi_flydigi.c
@@ -301,7 +301,7 @@ static int HIDAPI_DriverFlydigi_WritePacket(SDL_HIDAPI_Device *device, const Uin
     // If other Flydigi things prove to do the same, we can tweak this check to be more general.
     bool bUsesUnnumberedReports = (device->vendor_id == USB_VENDOR_FLYDIGI_V2 && device->product_id == USB_PRODUCT_FLYDIGI_V2_VADER);
 
-    if (bUsesUnnumberedReports && data[0] == FLYDIGI_V2_CMD_REPORT_ID ) {
+    if (bUsesUnnumberedReports && data[0] == FLYDIGI_V2_CMD_REPORT_ID) {
         // Zero out the report byte.
         Uint8 output[USB_PACKET_LENGTH];
         SDL_memcpy(output, data, SDL_min(size, USB_PACKET_LENGTH));

--- a/src/joystick/hidapi/SDL_hidapi_flydigi.c
+++ b/src/joystick/hidapi/SDL_hidapi_flydigi.c
@@ -295,6 +295,24 @@ static void HIDAPI_DriverFlydigi_SetAvailable(SDL_HIDAPI_Device *device, bool av
     ctx->available = available;
 }
 
+static int HIDAPI_DriverFlydigi_WritePacket(SDL_HIDAPI_Device *device, const Uint8 *data, size_t size)
+{
+    // We know that at the very least the Vader 5 now uses unnumbered reports for commands instead of FLYDIGI_V2_CMD_REPORT_ID.
+    // If other Flydigi things prove to do the same, we can tweak this check to be more general.
+    bool bUsesUnnumberedReports = (device->vendor_id == USB_VENDOR_FLYDIGI_V2 && device->product_id == USB_PRODUCT_FLYDIGI_V2_VADER);
+
+    if (bUsesUnnumberedReports && data[0] == FLYDIGI_V2_CMD_REPORT_ID ) {
+        // Zero out the report byte.
+        Uint8 output[USB_PACKET_LENGTH];
+        SDL_memcpy(output, data, SDL_min(size, USB_PACKET_LENGTH));
+        output[0] = 0;
+        return SDL_hid_write(device->dev, output, SDL_min(size, USB_PACKET_LENGTH));
+    }
+
+    return SDL_hid_write(device->dev, data, size);
+}
+
+
 static bool HIDAPI_DriverFlydigi_InitControllerV1(SDL_HIDAPI_Device *device)
 {
     SDL_DriverFlydigi_Context *ctx = (SDL_DriverFlydigi_Context *)device->context;
@@ -303,7 +321,7 @@ static bool HIDAPI_DriverFlydigi_InitControllerV1(SDL_HIDAPI_Device *device)
     for (int attempt = 0; ctx->deviceID == 0 && attempt < 30; ++attempt) {
         const Uint8 request[] = { FLYDIGI_V1_CMD_REPORT_ID, FLYDIGI_V1_GET_INFO_COMMAND, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
         // This write will occasionally return -1, so ignore failure here and try again
-        (void)SDL_hid_write(device->dev, request, sizeof(request));
+        (void)HIDAPI_DriverFlydigi_WritePacket(device, request, sizeof(request));
 
         // Read the reply
         for (int i = 0; i < 100; ++i) {
@@ -399,7 +417,8 @@ static bool SDL_HIDAPI_Flydigi_SendInfoRequest(SDL_HIDAPI_Device *device)
         2,
         0
     };
-    if (SDL_hid_write(device->dev, cmd, sizeof(cmd)) < 0) {
+
+    if (HIDAPI_DriverFlydigi_WritePacket(device, cmd, sizeof(cmd)) < 0) {
         return SDL_SetError("Couldn't query controller info");
     }
     return true;
@@ -441,7 +460,8 @@ static bool SDL_HIDAPI_Flydigi_SendStatusRequest(SDL_HIDAPI_Device *device)
         FLYDIGI_V2_MAGIC2,
         FLYDIGI_V2_GET_STATUS_COMMAND
     };
-    if (SDL_hid_write(device->dev, cmd, sizeof(cmd)) < 0) {
+
+    if (HIDAPI_DriverFlydigi_WritePacket(device, cmd, sizeof(cmd)) < 0) {
         return SDL_SetError("Couldn't query controller status");
     }
     return true;
@@ -469,7 +489,7 @@ static bool SDL_HIDAPI_Flydigi_SendAcquireRequest(SDL_HIDAPI_Device *device, boo
         'S', 'D', 'L', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
     };
 
-    if (SDL_hid_write(device->dev, cmd, sizeof(cmd)) < 0) {
+    if (HIDAPI_DriverFlydigi_WritePacket(device, cmd, sizeof(cmd)) < 0) {
         return SDL_SetError("Couldn't send acquire command");
     }
     return true;


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
The Flydigi Vader 5 seemingly uses unnumbered reports (e.g. report `0x00`, for hidapi purposes) rather than the old `FLYDIGI_V2_CMD_REPORT_ID` (`0x03`). This just wraps our hid_write calls and, if we're using a Vader 5 and writing to that report, zeros out the byte before passing on to hidapi.

I have tested this on several Linux variants and macOS, with the Vader 5 and *also* with a Vader 4 and Vader 2 (to ensure no regressions). But as we discussed, you'll probably still want to test this on Windows to make sure nothing blew up there before committing.

The side effect -- which we also discussed -- is that once the Flydigi HIDAPI driver works for the Vader 5, it shows up as *two* controllers because they do still export the Xbox 360 interface _entirely separately_. We may, at the very least, want to document that behavior somewhere until the driver rework that lets us handle that more cleanly.