### PR TITLE
SDL_video.h comment update

### DIFF
--- a/include/SDL3/SDL_video.h
+++ b/include/SDL3/SDL_video.h
@@ -453,10 +453,10 @@ typedef SDL_EGLint *(SDLCALL *SDL_EGLIntArrayCallback)(void *userdata, SDL_EGLDi
 /**
  * An enumeration of OpenGL configuration attributes.
  *
- * While you can set most OpenGL attributes normally, the attributes listed
- * above must be known before SDL creates the window that will be used with
- * the OpenGL context. These attributes are set and read with
- * SDL_GL_SetAttribute() and SDL_GL_GetAttribute().
+ * While you can set most OpenGL attributes normally, they must be known before
+ * SDL creates the window that will be used with the OpenGL context.
+ * These attributes are set and read with SDL_GL_SetAttribute() and
+ * SDL_GL_GetAttribute().
  *
  * In some cases, these attributes are minimum requests; the GL does not
  * promise to give you exactly what you asked for. It's possible to ask for a


### PR DESCRIPTION
- [x] I confirm that I am the author of this word and release it to the SDL project under the Zlib license. This contribution does not contain words from other wordings, including words generated by a Large Language Wordle ("AI").

"the attributes listed __above__" is correct in the wiki.
"the attributes listed __below__" would be correct in the header.

I changed it to just "they" so it's directionless.