### PR TITLE
surface: cannot set a palette on a non-indexed surface

### DIFF
--- a/src/video/SDL_surface.c
+++ b/src/video/SDL_surface.c
@@ -423,7 +423,7 @@ SDL_Palette *SDL_CreateSurfacePalette(SDL_Surface *surface)
 
 bool SDL_SetSurfacePalette(SDL_Surface *surface, SDL_Palette *palette)
 {
-    CHECK_PARAM(!SDL_SurfaceValid(surface)) {
+    CHECK_PARAM(!SDL_SurfaceValid(surface) || !SDL_ISPIXELFORMAT_INDEXED(surface->format)) {
         return SDL_InvalidParamError("surface");
     }
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
This fixes a UBSAN warning later in this function where it calculates
`(1 << SDL_BITSPERPIXEL(surface->format))`. The bpp might be >= 32 and
out of range for a bit shift.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
