### PR TITLE
unix: Fix infinite looping in SDL_FriBidi_Process if len > 127

### DIFF
--- a/src/core/unix/SDL_fribidi.c
+++ b/src/core/unix/SDL_fribidi.c
@@ -84,8 +84,8 @@ char *SDL_FriBidi_Process(SDL_FriBidi *fribidi, char *utf8, ssize_t utf8_len, bo
     char *result;
     FriBidiStrIndex len;
     FriBidiLevel max_level;
-    FriBidiLevel start;
-    FriBidiLevel end;
+    FriBidiStrIndex start;
+    FriBidiStrIndex end;
     FriBidiParType direction;
     FriBidiParType str_direction;
     unsigned int i;


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`SDL_FriBidi_Process` will loop on inputs > 127.  It seems start/end should be `FriBidiStrIndex` here -- using `FriBidiLevel` makes them `signed char` and thus the loop will wrap and never terminate.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
