### PR TITLE
Remove mach_absolute_time() [With correct branch]

### DIFF
--- a/docs/README-macos.md
+++ b/docs/README-macos.md
@@ -253,12 +253,12 @@ Functionality may be added in the future to help this.
 
 ## Raw Mouse Input
 
-On macOS 14.0 (Sonoma) and later, SDL uses the Game Controller framework's
-GCMouse API to provide raw, unaccelerated mouse input in relative mode. This
-is ideal for games and applications requiring precise 1:1 mouse movement.
+SDL uses the Game Controller framework's GCMouse API to provide raw,
+unaccelerated mouse input in relative mode. This is ideal for games
+and applications requiring precise 1:1 mouse movement.
 
-On older macOS versions, SDL falls back to NSEvent-based mouse input, which
-includes system mouse acceleration.
+On versions older than macOS 11.0 (Big Sur), SDL would fall back to
+NSEvent-based mouse input, which includes system mouse acceleration.
 
 To use accelerated (system-scaled) mouse movement on macOS 14.0+, set the hint:
 

--- a/include/SDL3/SDL_platform_defines.h
+++ b/include/SDL3/SDL_platform_defines.h
@@ -221,9 +221,9 @@
  */
 #define SDL_PLATFORM_MACOS 1
 
-#if MAC_OS_X_VERSION_MIN_REQUIRED < 1070
-    #error SDL for macOS only supports deploying on 10.7 and above.
-#endif /* MAC_OS_X_VERSION_MIN_REQUIRED < 1070 */
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 101200
+    #error SDL for macOS only supports deploying on 10.12 and above.
+#endif /* MAC_OS_X_VERSION_MIN_REQUIRED < 101200 */
 #endif /* TARGET_OS_IPHONE */
 #endif /* defined(__APPLE__) */
 

--- a/src/timer/unix/SDL_systimer.c
+++ b/src/timer/unix/SDL_systimer.c
@@ -101,7 +101,8 @@ Uint64 SDL_GetPerformanceCounter(void)
         ticks *= SDL_NS_PER_SECOND;
         ticks += now.tv_nsec;
 #elif defined(SDL_PLATFORM_APPLE)
-        ticks = mach_absolute_time();
+        // With HAVE_NANOSLEEP defined, time.h is included
+        ticks = clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
 #else
         SDL_assert(false);
         ticks = 0;


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

I forgot to commit my 3 commits to a separate branch. After syncing with the libsdl-org/SDL branch to my main branch, the original pull request was ruined, as I found no way to change the base branch and got desperate as for how to clean it up. This pull request should be much cleaner.  
I apologize for any inconveniences.  

Edit: This pull request is continued from here:  
https://github.com/libsdl-org/SDL/pull/15493

mach_absolute_time() was replaced with clock_gettime_nsec_np(CLOCK_UPTIME_RAW).

## Description

[Apple Documentation](https://developer.apple.com/documentation/kernel/1462446-mach_absolute_time) says, to paraphrase, that mach_absolute_time can be abused for nefarious purposes, most notably fingerprinting. The recommended and equivalent replacement is clock_gettime_nsec_np(CLOCK_UPTIME_RAW), which doesn't have such defects.

The function clock_gettime_nsec_np and macro definition of CLOCK_UPTIME_RAW are both provided in time.h, which is included if HAVE_NANOSLEEP is defined via SDL_build_config_macos.h.

## Existing Issue(s)
[#15115](https://github.com/libsdl-org/SDL/issues/15115)