### PR TITLE
cygwin: patch egl / ogles / vulkan headers for calling convention

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,7 +378,7 @@ dep_option(SDL_RENDER_D3D12        "Enable the Direct3D 12 render driver" ON "SD
 dep_option(SDL_RENDER_METAL        "Enable the Metal render driver" ON "SDL_RENDER;APPLE" OFF)
 dep_option(SDL_RENDER_GPU          "Enable the SDL_GPU render driver" ON "SDL_RENDER;SDL_GPU" OFF)
 dep_option(SDL_VIVANTE             "Use Vivante EGL video driver" ON "${UNIX_SYS};SDL_CPU_ARM32" OFF)
-dep_option(SDL_VULKAN              "Enable Vulkan support" "${SDL_VULKAN_DEFAULT}" "SDL_VIDEO;ANDROID OR APPLE OR LINUX OR FREEBSD OR OPENBSD OR WINDOWS" OFF)
+dep_option(SDL_VULKAN              "Enable Vulkan support" "${SDL_VULKAN_DEFAULT}" "SDL_VIDEO;ANDROID OR APPLE OR LINUX OR FREEBSD OR OPENBSD OR WINDOWS OR CYGWIN" OFF)
 dep_option(SDL_RENDER_VULKAN       "Enable the Vulkan render driver" ON "SDL_RENDER;SDL_VULKAN" OFF)
 dep_option(SDL_METAL               "Enable Metal support" ON "APPLE" OFF)
 set_option(SDL_OPENVR              "Use OpenVR video driver" OFF)

--- a/include/SDL3/SDL_egl.h
+++ b/include/SDL3/SDL_egl.h
@@ -164,6 +164,8 @@
 #if defined(_WIN32) && !defined(_WIN32_WCE) && !defined(__SCITECH_SNAP__)
     /* Win32 but not WinCE */
 #   define KHRONOS_APIENTRY __stdcall
+#elif defined(__CYGWIN__) /* __CYGWIN__ added by SDL */
+#   define KHRONOS_APIENTRY __stdcall
 #else
 #   define KHRONOS_APIENTRY
 #endif

--- a/src/video/khronos/KHR/khrplatform.h
+++ b/src/video/khronos/KHR/khrplatform.h
@@ -122,6 +122,8 @@
 #if defined(_WIN32) && !defined(_WIN32_WCE) && !defined(__SCITECH_SNAP__)
     /* Win32 but not WinCE */
 #   define KHRONOS_APIENTRY __stdcall
+#elif defined(__CYGWIN__) /* __CYGWIN__ added by SDL */
+#   define KHRONOS_APIENTRY __stdcall
 #else
 #   define KHRONOS_APIENTRY
 #endif

--- a/src/video/khronos/vulkan/vk_platform.h
+++ b/src/video/khronos/vulkan/vk_platform.h
@@ -36,7 +36,7 @@ extern "C"
  * Function declaration:  VKAPI_ATTR void VKAPI_CALL vkCommand(void);
  * Function pointer type: typedef void (VKAPI_PTR *PFN_vkCommand)(void);
  */
-#if defined(_WIN32)
+#if defined(_WIN32) || defined(__CYGWIN__) /* __CYGWIN__ added by SDL */
     // On Windows, Vulkan commands use the stdcall convention
     #define VKAPI_ATTR
     #define VKAPI_CALL __stdcall

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,11 +35,18 @@ else()
 endif()
 set(HAVE_TESTS_LINK_SHARED "${SDL_TESTS_LINK_SHARED}" PARENT_SCOPE)
 
+if(CYGWIN)
+# FindOpenGL from cmake >= 3.19 or cygwin-provided cmake versions don't
+# test for native windows opengl32, but we want native windows opengl32.
+    set(OPENGL_gl_LIBRARY opengl32)
+    set(OPENGL_FOUND TRUE)
+else()
 # CMake incorrectly detects opengl32.lib being present on MSVC ARM64
 if(NOT (MSVC AND SDL_CPU_ARM64))
     # Prefer GLVND, if present
     set(OpenGL_GL_PREFERENCE GLVND)
     find_package(OpenGL)
+endif()
 endif()
 
 add_library(sdltests_utils OBJECT


### PR DESCRIPTION
Tested by running testgl, testgles2 and testvulkan from both cygwin32 and cygwin64 builds on a windows-10 setup.

- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Existing Issue(s)
#15614 

/cc @TrueCat17, @stahta01 

