### PR TITLE
emscripten: Fix crash on Safari when probing gamepad rumble support

### DIFF
--- a/src/joystick/emscripten/SDL_sysjoystick.c
+++ b/src/joystick/emscripten/SDL_sysjoystick.c
@@ -506,7 +506,7 @@ static bool EMSCRIPTEN_JoystickOpen(SDL_Joystick *joystick, int device_index)
 
     item->rumble_available = MAIN_THREAD_EM_ASM_INT({
         let gamepad = navigator['getGamepads']()[$0];
-        return gamepad && gamepad['vibrationActuator'] && gamepad['vibrationActuator']['effects']['includes']('dual-rumble');
+        return gamepad && gamepad['vibrationActuator'] && gamepad['vibrationActuator']['effects'] && gamepad['vibrationActuator']['effects']['includes']('dual-rumble');
         }, item->index);
 
     if (item->rumble_available) {
@@ -515,7 +515,7 @@ static bool EMSCRIPTEN_JoystickOpen(SDL_Joystick *joystick, int device_index)
 
     item->trigger_rumble_available = MAIN_THREAD_EM_ASM_INT({
         let gamepad = navigator['getGamepads']()[$0];
-        return gamepad && gamepad['vibrationActuator'] && gamepad['vibrationActuator']['effects']['includes']('trigger-rumble');
+        return gamepad && gamepad['vibrationActuator'] && gamepad['vibrationActuator']['effects'] && gamepad['vibrationActuator']['effects']['includes']('trigger-rumble');
         }, item->index);
 
     if (item->trigger_rumble_available) {


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

This is fixing a crash captured in a Emscripten/SDL-based game I support online:

>   - **Browser:** Safari 26.3.1
>   - **OS:** macOS 10.15.7
>   - **Error:** `TypeError: undefined is not an object (evaluating 'gamepad["vibrationActuator"]["effects"]["includes"]')`
> 
>   Top of stack (Emscripten-generated `isle.js`, which is the `MAIN_THREAD_EM_ASM_INT` block from `SDL_sysjoystick.c:509`
>   post-codegen):
> 
>   ```
>   TypeError: undefined is not an object
>     (evaluating 'gamepad["vibrationActuator"]["effects"]["includes"]')
> ```

Safari's older Gamepad API exposes `vibrationActuator` with `playEffect` and `reset` but no `effects` enumeration array. The probe added in [651136ac7 ](https://github.com/libsdl-org/SDL/pull/15429) dereferences `vibrationActuator['effects']['includes']` unconditionally, throwing `TypeError: undefined is not an object` on every Safari client that opens a connected gamepad. Add the missing `['effects']` null check so the probe returns false on Safari instead of aborting.
