### PR TITLE
mouse: Restrict GCMouse to macOS Sonoma and later

### DIFF
--- a/docs/README-macos.md
+++ b/docs/README-macos.md
@@ -253,14 +253,14 @@ Functionality may be added in the future to help this.
 
 ## Raw Mouse Input
 
-On macOS 11.0 (Big Sur) and later, SDL uses the Game Controller framework's
+On macOS 14.0 (Sonoma) and later, SDL uses the Game Controller framework's
 GCMouse API to provide raw, unaccelerated mouse input in relative mode. This
 is ideal for games and applications requiring precise 1:1 mouse movement.
 
 On older macOS versions, SDL falls back to NSEvent-based mouse input, which
 includes system mouse acceleration.
 
-To use accelerated (system-scaled) mouse movement on macOS 11.0+, set the hint:
+To use accelerated (system-scaled) mouse movement on macOS 14.0+, set the hint:
 
 ```c
 SDL_SetHint(SDL_HINT_MOUSE_RELATIVE_SYSTEM_SCALE, "1");

--- a/src/video/cocoa/SDL_cocoamouse.m
+++ b/src/video/cocoa/SDL_cocoamouse.m
@@ -452,7 +452,10 @@ static void Cocoa_OnGCMouseDisconnected(GCMouse *mouse)
 void Cocoa_InitGCMouse(void)
 {
     @autoreleasepool {
-        if (@available(macOS 11.0, *)) {
+        // These APIs are available starting in macOS Big Sur, but we don't enable
+        // GCMouse until Sonoma due to broken motion and button events on MacBooks
+        // running Monterey and Ventura.
+        if (@available(macOS 14.0, *)) {
             NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
 
             cocoa_mouse_connect_observer = [center
@@ -494,7 +497,7 @@ bool Cocoa_HasGCMouse(void)
 void Cocoa_QuitGCMouse(void)
 {
     @autoreleasepool {
-        if (@available(macOS 11.0, *)) {
+        if (@available(macOS 14.0, *)) {
             NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
 
             if (cocoa_mouse_connect_observer) {


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
`GCMouse` is critically broken on macOS Monterey and macOS Ventura on at least some Macs (tested a 2016 12-inch MacBook and 2020 13-inch MacBook Pro) with mouse motion and mouse button events never being received from either internal trackpads or USB mice.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #15580
