### PR TITLE
Stop defining SDL_PLATFORM_WIN32 under Cygwin

### DIFF
--- a/include/SDL3/SDL_main.h
+++ b/include/SDL3/SDL_main.h
@@ -149,7 +149,7 @@
         /* Private platforms may have their own ideas about entry points. */
         #include "SDL_main_private.h"
 
-    #elif defined(SDL_PLATFORM_WIN32)
+    #elif defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
         /* On Windows SDL provides WinMain(), which parses the command line and passes
            the arguments to your main function.
 

--- a/include/SDL3/SDL_platform_defines.h
+++ b/include/SDL3/SDL_platform_defines.h
@@ -414,7 +414,9 @@
  *
  * \since This macro is available since SDL 3.2.0.
  */
+#ifndef __CYGWIN__
 #define SDL_PLATFORM_WIN32 1
+#endif
 
 #endif
 #endif /* (defined(_WIN32) || defined(__CYGWIN__)) && !defined(__NGAGE__) */

--- a/include/SDL3/SDL_system.h
+++ b/include/SDL3/SDL_system.h
@@ -97,7 +97,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_SetWindowsMessageHook(SDL_WindowsMessageHoo
 
 #endif /* defined(SDL_PLATFORM_WINDOWS) */
 
-#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK) || defined(SDL_PLATFORM_CYGWIN)
 
 /**
  * Get the D3D9 adapter index that matches the specified display.
@@ -130,7 +130,7 @@ extern SDL_DECLSPEC int SDLCALL SDL_GetDirect3D9AdapterIndex(SDL_DisplayID displ
  */
 extern SDL_DECLSPEC bool SDLCALL SDL_GetDXGIOutputInfo(SDL_DisplayID displayID, int *adapterIndex, int *outputIndex);
 
-#endif /* defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK) */
+#endif /* SDL_PLATFORM_WIN32 || SDL_PLATFORM_WINGDK || SDL_PLATFORM_CYGWIN */
 
 
 /*

--- a/src/SDL.c
+++ b/src/SDL.c
@@ -897,7 +897,7 @@ SDL_Sandbox SDL_GetSandbox(void)
     return sandbox;
 }
 
-#ifdef SDL_PLATFORM_WIN32
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
 
 #if !defined(HAVE_LIBC) && !defined(SDL_STATIC_LIB)
 BOOL APIENTRY MINGW32_FORCEALIGN _DllMainCRTStartup(HANDLE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
@@ -913,4 +913,4 @@ BOOL APIENTRY MINGW32_FORCEALIGN _DllMainCRTStartup(HANDLE hModule, DWORD ul_rea
 }
 #endif // Building DLL
 
-#endif // defined(SDL_PLATFORM_WIN32)
+#endif // SDL_PLATFORM_WIN32 || SDL_PLATFORM_CYGWIN

--- a/src/SDL_log.c
+++ b/src/SDL_log.c
@@ -651,7 +651,7 @@ void SDL_LogMessageV(int category, SDL_LogPriority priority, SDL_PRINTF_FORMAT_S
     }
 }
 
-#if defined(SDL_PLATFORM_WIN32) && !defined(SDL_PLATFORM_GDK)
+#if defined(SDL_PLATFORM_WIN32) && !defined(SDL_PLATFORM_GDK) || defined(SDL_PLATFORM_CYGWIN)
 enum {
     CONSOLE_UNATTACHED = 0,
     CONSOLE_ATTACHED_CONSOLE = 1,
@@ -804,7 +804,8 @@ static void SDLCALL SDL_LogOutput(void *userdata, int category, SDL_LogPriority 
 #if defined(HAVE_STDIO_H) && \
     !(defined(SDL_PLATFORM_APPLE) && (defined(SDL_VIDEO_DRIVER_COCOA) || defined(SDL_VIDEO_DRIVER_UIKIT))) && \
     !(defined(SDL_PLATFORM_NGAGE)) && \
-    !(defined(SDL_PLATFORM_WIN32))
+    !(defined(SDL_PLATFORM_WIN32)) && \
+    !(defined(SDL_PLATFORM_CYGWIN))
     (void)fprintf(stderr, "%s%s\n", GetLogPriorityPrefix(priority), message);
 #endif
 }

--- a/src/core/windows/SDL_windows.h
+++ b/src/core/windows/SDL_windows.h
@@ -24,7 +24,7 @@
 #ifndef SDL_windows_h_
 #define SDL_windows_h_
 
-#ifdef SDL_PLATFORM_WIN32
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
 
 #ifndef _WIN32_WINNT_NT4
 #define _WIN32_WINNT_NT4 0x0400

--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -53,7 +53,7 @@ static void SDLCALL SDL_MouseDoubleClickTimeChanged(void *userdata, const char *
     if (hint && *hint) {
         mouse->double_click_time = SDL_atoi(hint);
     } else {
-#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK) || defined(SDL_PLATFORM_CYGWIN)
         mouse->double_click_time = GetDoubleClickTime();
 #else
         mouse->double_click_time = 500;
@@ -1487,7 +1487,7 @@ bool SDL_CaptureMouse(bool enabled)
         return SDL_Unsupported();
     }
 
-#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK) || defined(SDL_PLATFORM_CYGWIN)
     /* Windows mouse capture is tied to the current thread, and must be called
      * from the thread that created the window being captured. Since we update
      * the mouse capture state from the event processing, any application state
@@ -1496,7 +1496,7 @@ bool SDL_CaptureMouse(bool enabled)
     if (!SDL_OnVideoThread()) {
         return SDL_SetError("SDL_CaptureMouse() must be called on the main thread");
     }
-#endif // defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)
+#endif // SDL_PLATFORM_WIN32 || SDL_PLATFORM_WINGDK || SDL_PLATFORM_CYGWIN
 
     if (enabled && SDL_GetKeyboardFocus() == NULL) {
         return SDL_SetError("No window has focus");
@@ -1516,12 +1516,12 @@ SDL_Cursor *SDL_CreateCursor(const Uint8 *data, const Uint8 *mask, int w, int h,
     const Uint32 black = 0xFF000000;
     const Uint32 white = 0xFFFFFFFF;
     const Uint32 transparent = 0x00000000;
-#if defined(SDL_PLATFORM_WIN32)
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
     // Only Windows backend supports inverted pixels in mono cursors.
     const Uint32 inverted = 0x00FFFFFF;
 #else
     const Uint32 inverted = 0xFF000000;
-#endif // defined(SDL_PLATFORM_WIN32)
+#endif // SDL_PLATFORM_WIN32 || SDL_PLATFORM_CYGWIN
 
     // Make sure the width is a multiple of 8
     w = ((w + 7) & ~7);

--- a/src/hidapi/SDL_hidapi.c
+++ b/src/hidapi/SDL_hidapi.c
@@ -50,7 +50,7 @@ SDL_ELF_NOTE_DLOPEN(
 )
 #endif
 
-#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK) || defined(SDL_PLATFORM_CYGWIN)
 #include "../core/windows/SDL_windows.h"
 #endif
 
@@ -110,7 +110,7 @@ static struct
     bool m_bCanGetNotifications;
     Uint64 m_unLastDetect;
 
-#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK) || defined(SDL_PLATFORM_CYGWIN)
     SDL_ThreadID m_nThreadID;
     WNDCLASSEXA m_wndClass;
     HWND m_hwndMsg;
@@ -130,7 +130,7 @@ static struct
 #endif
 } SDL_HIDAPI_discovery;
 
-#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK) || defined(SDL_PLATFORM_CYGWIN)
 struct _DEV_BROADCAST_HDR
 {
     DWORD dbch_size;
@@ -176,7 +176,7 @@ static LRESULT CALLBACK ControllerWndProc(HWND hwnd, UINT message, WPARAM wParam
 
     return DefWindowProc(hwnd, message, wParam, lParam);
 }
-#endif // defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)
+#endif // SDL_PLATFORM_WIN32 || SDL_PLATFORM_WINGDK || SDL_PLATFORM_CYGWIN
 
 #ifdef SDL_PLATFORM_MACOS
 static void CallbackIOServiceFunc(void *context, io_iterator_t portIterator)
@@ -239,7 +239,7 @@ static void HIDAPI_InitializeDiscovery(void)
     SDL_HIDAPI_discovery.m_bCanGetNotifications = false;
     SDL_HIDAPI_discovery.m_unLastDetect = 0;
 
-#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK) || defined(SDL_PLATFORM_CYGWIN)
     SDL_HIDAPI_discovery.m_nThreadID = SDL_GetCurrentThreadID();
 
     SDL_zero(SDL_HIDAPI_discovery.m_wndClass);
@@ -266,7 +266,7 @@ static void HIDAPI_InitializeDiscovery(void)
         SDL_HIDAPI_discovery.m_hNotify = RegisterDeviceNotification(SDL_HIDAPI_discovery.m_hwndMsg, &devBroadcast, DEVICE_NOTIFY_WINDOW_HANDLE | DEVICE_NOTIFY_ALL_INTERFACE_CLASSES);
         SDL_HIDAPI_discovery.m_bCanGetNotifications = (SDL_HIDAPI_discovery.m_hNotify != 0);
     }
-#endif // defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)
+#endif // SDL_PLATFORM_WIN32 || SDL_PLATFORM_WINGDK || SDL_PLATFORM_CYGWIN
 
 #ifdef SDL_PLATFORM_MACOS
     SDL_HIDAPI_discovery.m_notificationPort = IONotificationPortCreate(kIOMainPortDefault);
@@ -387,7 +387,7 @@ static void HIDAPI_UpdateDiscovery(void)
         return;
     }
 
-#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK) || defined(SDL_PLATFORM_CYGWIN)
     if (SDL_IsVideoThread()) {
         // just let the usual SDL_PumpEvents loop dispatch these, fixing bug 2998. --ryan.
     } else {
@@ -402,7 +402,7 @@ static void HIDAPI_UpdateDiscovery(void)
             }
         }
     }
-#endif // defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)
+#endif // SDL_PLATFORM_WIN32 || SDL_PLATFORM_WINGDK || SDL_PLATFORM_CYGWIN
 
 #ifdef SDL_PLATFORM_MACOS
     if (SDL_HIDAPI_discovery.m_notificationPort) {
@@ -496,7 +496,7 @@ static void HIDAPI_ShutdownDiscovery(void)
         return;
     }
 
-#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK) || defined(SDL_PLATFORM_CYGWIN)
     if (SDL_HIDAPI_discovery.m_hNotify) {
         UnregisterDeviceNotification(SDL_HIDAPI_discovery.m_hNotify);
     }
@@ -589,7 +589,7 @@ typedef struct PLATFORM_hid_device_ PLATFORM_hid_device;
 #include "SDL_hidapi_netbsd.h"
 #elif defined(SDL_PLATFORM_MACOS)
 #include "SDL_hidapi_mac.h"
-#elif defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)
+#elif defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK) || defined(SDL_PLATFORM_CYGWIN)
 #include "SDL_hidapi_windows.h"
 #elif defined(SDL_PLATFORM_ANDROID)
 #include "SDL_hidapi_android.h"
@@ -1075,7 +1075,7 @@ bool SDL_HIDAPI_ShouldIgnoreDevice(int bus, Uint16 vendor_id, Uint16 product_id,
         if (vendor_id == USB_VENDOR_VALVE) {
             // Ignore the mouse/keyboard interface on Steam Controllers
             if (
-#ifdef SDL_PLATFORM_WIN32
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
                 // Check the usage page and usage on both USB and Bluetooth
 #else
                 // Only check the usage page and usage on USB

--- a/src/joystick/SDL_gamepad.c
+++ b/src/joystick/SDL_gamepad.c
@@ -35,7 +35,7 @@
 #include "../events/SDL_events_c.h"
 #include "../SDL_hints_c.h"
 
-#ifdef SDL_PLATFORM_WIN32
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
 #include "../core/windows/SDL_windows.h"
 #endif
 
@@ -2044,7 +2044,7 @@ static char *SDL_PrivateGetGamepadGUIDFromMappingString(const char *pMapping)
         pchGUID[pFirstComma - pMapping] = '\0';
 
         // Convert old style GUIDs to the new style in 2.0.5
-#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK) || defined(SDL_PLATFORM_CYGWIN)
         if (SDL_strlen(pchGUID) == 32 &&
             SDL_memcmp(&pchGUID[20], "504944564944", 12) == 0) {
             SDL_memcpy(&pchGUID[20], "000000000000", 12);
@@ -3294,7 +3294,7 @@ bool SDL_ShouldIgnoreGamepad(Uint16 vendor_id, Uint16 product_id, Uint16 version
 #else
     const char *hint = SDL_getenv_unsafe("SDL_GAMECONTROLLER_ALLOW_STEAM_VIRTUAL_GAMEPAD");
     bool allow_steam_virtual_gamepad = SDL_GetStringBoolean(hint, false);
-#ifdef SDL_PLATFORM_WIN32
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
     if (allow_steam_virtual_gamepad && WIN_IsWine()) {
         // We are launched by Steam and running under Proton or Wine
         // We can't tell whether this controller is a Steam Virtual Gamepad,
@@ -3302,7 +3302,7 @@ bool SDL_ShouldIgnoreGamepad(Uint16 vendor_id, Uint16 product_id, Uint16 version
         // and anything we see here is fine to use.
         return false;
     }
-#endif // SDL_PLATFORM_WIN32
+#endif // SDL_PLATFORM_WIN32 || SDL_PLATFORM_CYGWIN
 
     if (SDL_IsJoystickSteamVirtualGamepad(vendor_id, product_id, version)) {
         return !allow_steam_virtual_gamepad;

--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -36,7 +36,7 @@
 // This is included in only one place because it has a large static list of controllers
 #include "controller_type.h"
 
-#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK) || defined(SDL_PLATFORM_CYGWIN)
 // Needed for checking for input remapping programs
 #include "../core/windows/SDL_windows.h"
 

--- a/src/joystick/SDL_steam_virtual_gamepad.c
+++ b/src/joystick/SDL_steam_virtual_gamepad.c
@@ -26,7 +26,7 @@
 #ifdef SDL_PLATFORM_LINUX
 #include "../core/unix/SDL_appid.h"
 #endif
-#ifdef SDL_PLATFORM_WIN32
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
 #include "../core/windows/SDL_windows.h"
 #else
 #include <sys/types.h>
@@ -44,7 +44,7 @@ static Uint64 GetFileModificationTime(const char *file)
 {
     Uint64 modification_time = 0;
 
-#ifdef SDL_PLATFORM_WIN32
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
     WCHAR *wFile = WIN_UTF8ToStringW(file);
     if (wFile) {
         HANDLE hFile = CreateFileW(wFile, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, NULL);

--- a/src/joystick/hidapi/SDL_hidapi_gamecube.c
+++ b/src/joystick/hidapi/SDL_hidapi_gamecube.c
@@ -202,7 +202,7 @@ static bool HIDAPI_DriverGameCube_InitDevice(SDL_HIDAPI_Device *device)
     }
 
     if (ctx->pc_mode) {
-#ifdef SDL_PLATFORM_WIN32
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
         // We get a separate device for each slot
         ResetAxisRange(ctx, 0);
         HIDAPI_JoystickConnected(device, &ctx->joysticks[0]);
@@ -283,7 +283,7 @@ static void HIDAPI_DriverGameCube_HandleJoystickPacket(SDL_HIDAPI_Device *device
     Sint16 axis_value;
     Uint64 timestamp = SDL_GetTicksNS();
 
-#ifdef SDL_PLATFORM_WIN32
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
     // We get a separate device for each slot
     i = 0;
 #else

--- a/src/joystick/hidapi/SDL_hidapi_gamesir.c
+++ b/src/joystick/hidapi/SDL_hidapi_gamesir.c
@@ -143,7 +143,7 @@ static bool HIDAPI_DriverGameSir_IsSupportedDevice(SDL_HIDAPI_Device *device, co
 
 static SDL_hid_device *HIDAPI_DriverGameSir_GetOutputHandle(SDL_HIDAPI_Device *device)
 {
-#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK) || defined(SDL_PLATFORM_CYGWIN)
     SDL_DriverGamesir_Context *ctx = (SDL_DriverGamesir_Context *)device->context;
     return ctx->output_handle;
 #else
@@ -196,7 +196,7 @@ static bool SendGameSirModeSwitch(SDL_HIDAPI_Device *device)
 /* This helper requires full desktop Win32 HID APIs.
  * These APIs are NOT available on GDK platforms.
  */
-#if defined(SDL_PLATFORM_WIN32) && !defined(SDL_PLATFORM_GDK)
+#if (defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)) && !defined(SDL_PLATFORM_GDK)
 
 /* --- Win32 HID includes ------------------------------------------------- */
 #include <windows.h>
@@ -315,7 +315,7 @@ static char *FindHIDInterfacePath(Uint16 vid, Uint16 pid, int collection_index)
     return NULL;
 }
 
-#endif // SDL_PLATFORM_WIN32 && !SDL_PLATFORM_GDK
+#endif // (SDL_PLATFORM_WIN32 || SDL_PLATFORM_CYGWIN) && !SDL_PLATFORM_GDK
 
 static SDL_hid_device *GetOutputHandle(SDL_HIDAPI_Device *device)
 {
@@ -325,7 +325,7 @@ static SDL_hid_device *GetOutputHandle(SDL_HIDAPI_Device *device)
     struct SDL_hid_device_info *devs = SDL_hid_enumerate(vendor_id, product_id);
     for (struct SDL_hid_device_info *info = devs; info && !output_handle; info = info->next) {
         if (info->interface_number == 0) {
-#if defined(SDL_PLATFORM_WIN32) && !defined(SDL_PLATFORM_GDK)
+#if (defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)) && !defined(SDL_PLATFORM_GDK)
             char *col02_path = FindHIDInterfacePath(vendor_id, product_id, 2);
             if (col02_path) {
                 output_handle = SDL_hid_open_path(col02_path);
@@ -333,7 +333,7 @@ static SDL_hid_device *GetOutputHandle(SDL_HIDAPI_Device *device)
             }
 #endif
         } else if (info->interface_number == -1) {
-#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK) || defined(SDL_PLATFORM_CYGWIN)
             if (info->usage_page == 0x0001 && info->usage == 0x0005) {
                 output_handle = SDL_hid_open_path(info->path);
             }

--- a/src/joystick/hidapi/SDL_hidapi_lg4ff.c
+++ b/src/joystick/hidapi/SDL_hidapi_lg4ff.c
@@ -110,7 +110,7 @@ static void HIDAPI_DriverLg4ff_UnregisterHints(SDL_HintCallback callback, void *
 
 static bool HIDAPI_DriverLg4ff_IsEnabled(void)
 {
-    #if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)
+    #if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK) || defined(SDL_PLATFORM_CYGWIN)
     /*
      * hid.dll simply cannot send 7 bytes reports unlike other platforms
      * it enforces full length repots of 17 from the device's descriptor, which does not work on the device

--- a/src/joystick/hidapi/SDL_hidapi_ps3.c
+++ b/src/joystick/hidapi/SDL_hidapi_ps3.c
@@ -106,7 +106,7 @@ static bool HIDAPI_DriverPS3_IsEnabled(void)
 #ifdef SDL_PLATFORM_MACOS
     // This works well on macOS
     default_value = true;
-#elif defined(SDL_PLATFORM_WIN32)
+#elif defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
     /* For official Sony driver (sixaxis.sys) use SDL_HINT_JOYSTICK_HIDAPI_PS3_SIXAXIS_DRIVER.
      *
      * See https://github.com/ViGEm/DsHidMini as an alternative driver
@@ -1122,7 +1122,7 @@ static void HIDAPI_DriverPS3SonySixaxis_UnregisterHints(SDL_HintCallback callbac
 
 static bool HIDAPI_DriverPS3SonySixaxis_IsEnabled(void)
 {
-#ifdef SDL_PLATFORM_WIN32
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
     return SDL_GetHintBoolean(SDL_HINT_JOYSTICK_HIDAPI_PS3_SIXAXIS_DRIVER, false);
 #else
     return false;

--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -364,7 +364,7 @@ static int GetFeatureReport(SDL_HIDAPI_Device *dev, unsigned char uBuffer[65])
         // On Windows and macOS, BLE devices get 2 copies of the feature report ID, one that is removed by ReadFeatureReport,
         // and one that's included in the buffer we receive. We pad the bytes to read and skip over the report ID
         // if necessary.
-#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_MACOS)
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_MACOS) || defined(SDL_PLATFORM_CYGWIN)
         ++ucBytesToRead;
         ++ucDataStartOffset;
 #endif
@@ -1134,13 +1134,13 @@ static bool HIDAPI_DriverSteam_InitDevice(SDL_HIDAPI_Device *device)
     ctx->device = device;
     device->context = ctx;
 
-#ifdef SDL_PLATFORM_WIN32
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
     if (device->serial) {
         // We get a garbage serial number on Windows
         SDL_free(device->serial);
         device->serial = NULL;
     }
-#endif // SDL_PLATFORM_WIN32
+#endif // SDL_PLATFORM_WIN32 || SDL_PLATFORM_CYGWIN
 
     HIDAPI_SetDeviceName(device, "Steam Controller");
 

--- a/src/joystick/hidapi/SDL_hidapi_xboxone.c
+++ b/src/joystick/hidapi/SDL_hidapi_xboxone.c
@@ -38,7 +38,7 @@
 #define DEBUG_XBOX_PROTOCOL
 #endif
 
-#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK) || defined(SDL_PLATFORM_CYGWIN)
 #define XBOX_ONE_DRIVER_ACTIVE  1
 #else
 #define XBOX_ONE_DRIVER_ACTIVE  0
@@ -375,7 +375,7 @@ static bool HIDAPI_DriverXboxOne_IsSupportedDevice(SDL_HIDAPI_Device *device, co
         return false;
     }
 #endif
-#ifdef SDL_PLATFORM_WIN32
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
     if (device && SDL_strncmp(device->path, "\\\\?\\HID#", 8) == 0) {
         // Windows provides a fake HID endpoint for XGIP controllers, don't use this
         return false;

--- a/src/joystick/hidapi/SDL_hidapijoystick.c
+++ b/src/joystick/hidapi/SDL_hidapijoystick.c
@@ -27,7 +27,7 @@
 #include "SDL_hidapi_rumble.h"
 #include "../../SDL_hints_c.h"
 
-#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK) || defined(SDL_PLATFORM_CYGWIN)
 #include "../windows/SDL_rawinputjoystick_c.h"
 #endif
 

--- a/src/main/SDL_runapp.c
+++ b/src/main/SDL_runapp.c
@@ -24,6 +24,7 @@
 // Add your platform here if you define a custom SDL_RunApp() implementation
 #if !defined(SDL_PLATFORM_WIN32) && \
     !defined(SDL_PLATFORM_GDK) && \
+    !defined(SDL_PLATFORM_CYGWIN) && \
     !defined(SDL_PLATFORM_IOS) && \
     !defined(SDL_PLATFORM_TVOS) && \
     !defined(SDL_PLATFORM_EMSCRIPTEN) && \

--- a/src/main/windows/SDL_sysmain_runapp.c
+++ b/src/main/windows/SDL_sysmain_runapp.c
@@ -20,7 +20,7 @@
 */
 #include "SDL_internal.h"
 
-#ifdef SDL_PLATFORM_WIN32
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
 
 #include "../../core/windows/SDL_windows.h"
 #include "../SDL_main_callbacks.h"
@@ -46,4 +46,4 @@ int MINGW32_FORCEALIGN SDL_RunApp(int argc, char *argv[], SDL_main_func mainFunc
     return result;
 }
 
-#endif // SDL_PLATFORM_WIN32
+#endif // SDL_PLATFORM_WIN32 || SDL_PLATFORM_CYGWIN

--- a/src/render/direct3d11/SDL_render_d3d11.c
+++ b/src/render/direct3d11/SDL_render_d3d11.c
@@ -876,7 +876,7 @@ static HRESULT D3D11_CreateSwapChain(SDL_Renderer *renderer, int w, int h)
             goto done;
         }
     } else {
-#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK)
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK) || defined(SDL_PLATFORM_CYGWIN)
         HWND hwnd = (HWND)SDL_GetPointerProperty(SDL_GetWindowProperties(renderer->window), SDL_PROP_WINDOW_WIN32_HWND_POINTER, NULL);
         if (!hwnd) {
             SDL_SetError("Couldn't get window handle");
@@ -900,7 +900,7 @@ static HRESULT D3D11_CreateSwapChain(SDL_Renderer *renderer, int w, int h)
 #else
         SDL_SetError(SDL_FUNCTION ", Unable to find something to attach a swap chain to");
         goto done;
-#endif // defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK) / else
+#endif // defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK) || defined(SDL_PLATFORM_CYGWIN) / else
     }
     data->swapEffect = swapChainDesc.SwapEffect;
 

--- a/src/test/SDL_test_memory.c
+++ b/src/test/SDL_test_memory.c
@@ -29,7 +29,7 @@ static bool s_unwind_symbol_names = true;
 #endif
 #endif
 
-#ifdef SDL_PLATFORM_WIN32
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
 #include <windows.h>
 #include <dbghelp.h>
 
@@ -177,7 +177,7 @@ static void SDL_TrackAllocation(void *mem, size_t size)
             }
         }
     }
-#elif defined(SDL_PLATFORM_WIN32)
+#elif defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
     {
         Uint32 count;
         PVOID frames[63];
@@ -309,7 +309,7 @@ void SDLTest_TrackAllocations(void)
         }
     } while (0);
 
-#elif defined(SDL_PLATFORM_WIN32)
+#elif defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
     do {
         dyn_dbghelp.module = SDL_LoadObject("dbghelp.dll");
         if (!dyn_dbghelp.module) {
@@ -414,7 +414,7 @@ void SDLTest_LogAllocations(void)
                     (void)SDL_snprintf(stack_entry_description, sizeof(stack_entry_description), "%s+0x%llx", name, (long long unsigned int)offset);
 #endif
                 }
-#elif defined(SDL_PLATFORM_WIN32)
+#elif defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
                 {
                     DWORD64 dwDisplacement = 0;
                     char symbol_buffer[sizeof(SYMBOL_INFO) + MAX_SYM_NAME * sizeof(TCHAR)];

--- a/test/testffmpeg.c
+++ b/test/testffmpeg.c
@@ -62,10 +62,10 @@
 #include <CoreVideo/CoreVideo.h>
 #endif
 
-#ifdef SDL_PLATFORM_WIN32
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
 #define COBJMACROS
 #include <libavutil/hwcontext_d3d11va.h>
-#endif /* SDL_PLATFORM_WIN32 */
+#endif /* SDL_PLATFORM_WIN32 || SDL_PLATFORM_CYGWIN */
 
 #include "testffmpeg_vulkan.h"
 
@@ -90,7 +90,7 @@ static bool has_EGL_EXT_image_dma_buf_import_modifiers;
 static PFNGLACTIVETEXTUREARBPROC glActiveTextureARBFunc;
 static PFNGLEGLIMAGETARGETTEXTURE2DOESPROC glEGLImageTargetTexture2DOESFunc;
 #endif
-#ifdef SDL_PLATFORM_WIN32
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
 static ID3D11Device *d3d11_device;
 static ID3D11DeviceContext *d3d11_context;
 #endif
@@ -214,7 +214,7 @@ static bool CreateWindowAndRenderer(SDL_WindowFlags window_flags, const char *dr
     }
 #endif /* HAVE_EGL */
 
-#ifdef SDL_PLATFORM_WIN32
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
     d3d11_device = (ID3D11Device *)SDL_GetPointerProperty(SDL_GetRendererProperties(renderer), SDL_PROP_RENDERER_D3D11_DEVICE_POINTER, NULL);
     if (d3d11_device) {
         ID3D11Device_AddRef(d3d11_device);
@@ -341,7 +341,7 @@ static bool SupportedPixelFormat(enum AVPixelFormat format)
             return true;
         }
 #endif
-#ifdef SDL_PLATFORM_WIN32
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
         if (d3d11_device && format == AV_PIX_FMT_D3D11) {
             return true;
         }
@@ -423,7 +423,7 @@ static AVCodecContext *OpenVideoStream(AVFormatContext *ic, int stream, const AV
             continue;
         }
 
-#ifdef SDL_PLATFORM_WIN32
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
         if (d3d11_device && config->device_type == AV_HWDEVICE_TYPE_D3D11VA) {
             AVD3D11VADeviceContext *device_context;
 
@@ -965,7 +965,7 @@ static bool GetTextureForVAAPIFrame(AVFrame *frame, SDL_Texture **texture)
 
 static bool GetTextureForD3D11Frame(AVFrame *frame, SDL_Texture **texture)
 {
-#ifdef SDL_PLATFORM_WIN32
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
     AVHWFramesContext *frames = (AVHWFramesContext *)(frame->hw_frames_ctx->data);
     int texture_width = 0, texture_height = 0;
     ID3D11Texture2D *pTexture = (ID3D11Texture2D *)frame->data[0];
@@ -1374,7 +1374,7 @@ int main(int argc, char *argv[])
     window_flags = SDL_WINDOW_HIDDEN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY;
 #ifdef SDL_PLATFORM_APPLE
     window_flags |= SDL_WINDOW_METAL;
-#elif !defined(SDL_PLATFORM_WIN32)
+#elif !(defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN))
     window_flags |= SDL_WINDOW_OPENGL;
 #endif
     if (SDL_GetHint(SDL_HINT_RENDER_DRIVER) != NULL) {
@@ -1391,7 +1391,7 @@ int main(int argc, char *argv[])
         CreateWindowAndRenderer(window_flags, "metal");
     }
 #endif
-#ifdef SDL_PLATFORM_WIN32
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
     if (!window) {
         CreateWindowAndRenderer(window_flags, "direct3d11");
     }
@@ -1576,7 +1576,7 @@ int main(int argc, char *argv[])
     }
     return_code = 0;
 quit:
-#ifdef SDL_PLATFORM_WIN32
+#if defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_CYGWIN)
     if (d3d11_context) {
         ID3D11DeviceContext_Release(d3d11_context);
         d3d11_context = NULL;

--- a/test/testsymbols.c
+++ b/test/testsymbols.c
@@ -55,7 +55,7 @@ extern SDL_DECLSPEC void SDLCALL SDL_SetLinuxThreadPriority(void);
 extern SDL_DECLSPEC void SDLCALL SDL_SetLinuxThreadPriorityAndPolicy(void);
 #endif
 
-#if !(defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK))
+#if !(defined(SDL_PLATFORM_WIN32) || defined(SDL_PLATFORM_WINGDK) || defined(SDL_PLATFORM_CYGWIN))
 extern SDL_DECLSPEC void SDLCALL SDL_GetDXGIOutputInfo(void);
 extern SDL_DECLSPEC void SDLCALL SDL_GetDirect3D9AdapterIndex(void);
 #endif


### PR DESCRIPTION

- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->
 Stop defining SDL_PLATFORM_WIN32 under Cygwin and add SDL_PLATFORM_CYGWIN to where SDL_PLATFORM_WIN32 is used.

## Description
<!--- Describe your changes in detail -->
If I recall correctly, @sezero was surprised that `SDL_PLATFORM_WIN32` was defined under Cygwin. And, looking at the code it might have been done accidently. If that guess is correct than this PR corrects it.
1. Add CYGWIN guard around SDL_PLATFORM_WIN32 define
2. Look for locations with SDL_PLATFORM_WIN32 and add SDL_PLATFORM_CYGWIN to them

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
