### PR TITLE
testcontroller: free/allocate touchpads only when needed

### DIFF
--- a/test/gamepadutils.c
+++ b/test/gamepadutils.c
@@ -706,6 +706,7 @@ static void FreeTouchpads(GamepadImage *ctx)
 void UpdateGamepadImageFromGamepad(GamepadImage *ctx, SDL_Gamepad *gamepad)
 {
     int i;
+    int num_touchpads;
 
     if (!ctx) {
         return;
@@ -763,9 +764,12 @@ void UpdateGamepadImageFromGamepad(GamepadImage *ctx, SDL_Gamepad *gamepad)
     ctx->connection_state = SDL_GetGamepadConnectionState(gamepad);
     ctx->battery_state = SDL_GetGamepadPowerInfo(gamepad, &ctx->battery_percent);
 
-    FreeTouchpads(ctx);
-    ctx->num_touchpads = SDL_GetNumGamepadTouchpads(gamepad);
-    ctx->num_touchpads = SDL_min(ctx->num_touchpads, MAX_TOUCHPADS);
+    num_touchpads = SDL_GetNumGamepadTouchpads(gamepad);
+    num_touchpads = SDL_min(num_touchpads, MAX_TOUCHPADS);
+    if (num_touchpads != ctx->num_touchpads) {
+        FreeTouchpads(ctx);
+        ctx->num_touchpads = num_touchpads;
+    }
     if (ctx->num_touchpads > 0) {
         ctx->touchpads = (GamepadTouchpad *)SDL_malloc(sizeof(*ctx->touchpads) * ctx->num_touchpads);
         if (ctx->touchpads) {


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
Fixes an issue introduced by an earlier change I made here: https://github.com/libsdl-org/SDL/commit/006959ca87eb1406a3d1f7021b6852b01600bcb0#diff-aed067a3c220a579e69ef5af3da4b40ee595b782d23c8dfcd09bbba9d0f3fd1bL729-R768

## Existing Issue(s)
None.
