### PR TITLE
Don't log game controller buttons in the keyboard handler on Android

### DIFF
--- a/src/video/android/SDL_androidkeyboard.c
+++ b/src/video/android/SDL_androidkeyboard.c
@@ -361,7 +361,11 @@ static SDL_Scancode TranslateKeycode(int keycode)
         scancode = Android_Keycodes[keycode];
     }
     if (scancode == SDL_SCANCODE_UNKNOWN) {
-        __android_log_print(ANDROID_LOG_INFO, "SDL", "Unknown keycode %d", keycode);
+        if (keycode >= 96 /* AKEYCODE_BUTTON_A */ && keycode < 111 /* AKEYCODE_ESCAPE */) {
+            // Ignore game controller buttons
+        } else {
+            __android_log_print(ANDROID_LOG_INFO, "SDL", "Unknown keycode %d", keycode);
+        }
     }
     return scancode;
 }


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").