### PR TITLE
Fix web joystick vibration on Safari

### DIFF
--- a/src/joystick/emscripten/SDL_sysjoystick.c
+++ b/src/joystick/emscripten/SDL_sysjoystick.c
@@ -506,7 +506,7 @@ static bool EMSCRIPTEN_JoystickOpen(SDL_Joystick *joystick, int device_index)
 
     item->rumble_available = MAIN_THREAD_EM_ASM_INT({
         let gamepad = navigator['getGamepads']()[$0];
-        return gamepad && gamepad['vibrationActuator'] && gamepad['vibrationActuator']['effects'] && gamepad['vibrationActuator']['effects']['includes']('dual-rumble');
+        return gamepad && gamepad['vibrationActuator']; // Don't check the vibrationActuator.effects array here, because it's not defined in Safari
         }, item->index);
 
     if (item->rumble_available) {
@@ -515,6 +515,7 @@ static bool EMSCRIPTEN_JoystickOpen(SDL_Joystick *joystick, int device_index)
 
     item->trigger_rumble_available = MAIN_THREAD_EM_ASM_INT({
         let gamepad = navigator['getGamepads']()[$0];
+        // This effect is not supported in Safari, so it's okay for us to check the vibrationActuator.effects array here for the browsers that do support it
         return gamepad && gamepad['vibrationActuator'] && gamepad['vibrationActuator']['effects'] && gamepad['vibrationActuator']['effects']['includes']('trigger-rumble');
         }, item->index);
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
This PR fixes joystick rumble support on Safari, see also https://github.com/libsdl-org/SDL/pull/15622#discussion_r3254843235
See also https://developer.mozilla.org/en-US/docs/Web/API/GamepadHapticActuator/playEffect#browser_compatibility

I don't have a way to test this PR on Safari myself, so it would be appreciated if someone else could test it! :)

## Existing Issue(s)
None