### PR TITLE
Extend SDL_GamepadCapSenseType definitions

### DIFF
--- a/include/SDL3/SDL_gamepad.h
+++ b/include/SDL3/SDL_gamepad.h
@@ -247,6 +247,22 @@ typedef enum SDL_GamepadCapSenseType
     SDL_GAMEPAD_CAPSENSE_RIGHT_STICK,   /**< Activated by touching the top of the right thumbstick */
     SDL_GAMEPAD_CAPSENSE_LEFT_GRIP,     /**< Activated by gripping the left handle of the controller */
     SDL_GAMEPAD_CAPSENSE_RIGHT_GRIP,    /**< Activated by gripping the right handle of the controller */
+    SDL_GAMEPAD_CAPSENSE_LEFT_BUMPER,   /**< Activated by touching the surface of the left bumper */
+    SDL_GAMEPAD_CAPSENSE_RIGHT_BUMPER,  /**< Activated by touching the surface of the right bumper */
+    SDL_GAMEPAD_CAPSENSE_LEFT_TRIGGER,  /**< Activated by touching the surface of the left trigger */
+    SDL_GAMEPAD_CAPSENSE_RIGHT_TRIGGER, /**< Activated by touching the surface of the right trigger */
+    SDL_GAMEPAD_CAPSENSE_LEFT_THUMB,    /**< Activated by touching the surface of the left thumbrest */
+    SDL_GAMEPAD_CAPSENSE_RIGHT_THUMB,   /**< Activated by touching the surface of the right thumbrest */
+    SDL_GAMEPAD_CAPSENSE_SEWN,          /**< Activated by touching the surface of the SEWN buttons */
+    SDL_GAMEPAD_CAPSENSE_SOUTH,         /**< Activated by touching the surface of the South button */
+    SDL_GAMEPAD_CAPSENSE_EAST,          /**< Activated by touching the surface of the East button */
+    SDL_GAMEPAD_CAPSENSE_WEST,          /**< Activated by touching the surface of the West button */
+    SDL_GAMEPAD_CAPSENSE_NORTH,         /**< Activated by touching the surface of the North button */
+    SDL_GAMEPAD_CAPSENSE_DPAD,          /**< Activated by touching the surface of the Dpad buttons */
+    SDL_GAMEPAD_CAPSENSE_DOWN,          /**< Activated by touching the surface of the Down button */
+    SDL_GAMEPAD_CAPSENSE_RIGHT,         /**< Activated by touching the surface of the Right button */
+    SDL_GAMEPAD_CAPSENSE_LEFT,          /**< Activated by touching the surface of the Left button */
+    SDL_GAMEPAD_CAPSENSE_UP,            /**< Activated by touching the surface of the Up button */
     SDL_GAMEPAD_CAPSENSE_COUNT
 } SDL_GamepadCapSenseType;
 


### PR DESCRIPTION
This PR draft expands on #15627 by @ceski-1 to implement more types of capacitive sensing surfaces. 

Real world references for the expansion:
- Gamepads such as OculusMeta Quest Touch controllers feature individual sensing on face buttons, finger rest areas, and triggers/bumpers: https://developers.meta.com/horizon/documentation/unreal/unreal-touch-controller/
- An open source gamepad known as the Alpakka controller features a conductive surface area encompassing the entire SEWN button area: https://inputlabs.io/alpakka

Other considerations:
- I have not seen a gamepad featuring a dpad with the capacitive sensing, but I figure it's a better shorthand to deal with the left-hand VR gamepads instead of splitting up SEWN across left/right and making that more messy. 