### PR TITLE
Avoid show candidate list when SDL_HINT_IME_IMPLEMENTED_UI set composition,candidates

### DIFF
--- a/src/video/windows/SDL_windowskeyboard.c
+++ b/src/video/windows/SDL_windowskeyboard.c
@@ -1057,16 +1057,12 @@ bool WIN_HandleIMEMessage(HWND hwnd, UINT msg, WPARAM wParam, LPARAM *lParam, SD
         SDL_DebugIMELog("WM_IME_SETCONTEXT");
 
         LPARAM element_mask;
-        if (videodata->ime_internal_composition && videodata->ime_internal_candidates) {
-            element_mask = 0;
-        } else {
-            element_mask = ISC_SHOWUIALL;
-            if (videodata->ime_internal_composition) {
-                element_mask &= ~ISC_SHOWUICOMPOSITIONWINDOW;
-            }
-            if (videodata->ime_internal_candidates) {
-                element_mask &= ~ISC_SHOWUIALLCANDIDATEWINDOW;
-            }
+        element_mask = ISC_SHOWUIALL;
+        if (videodata->ime_internal_composition) {
+            element_mask &= ~ISC_SHOWUICOMPOSITIONWINDOW;
+        }
+        if (videodata->ime_internal_candidates) {
+            element_mask &= ~ISC_SHOWUIALLCANDIDATEWINDOW;
         }
         *lParam &= element_mask;
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").
## Description
WM_IME_SETCONTEXT lParam not set 0
## Existing Issue(s)
https://github.com/libsdl-org/SDL/issues/15479
