### PR TITLE
SVE2: Improve RGB565 blit performance and accelerate RGB565 Surface Alpha 

### DIFF
--- a/src/video/SDL_blit_A.c
+++ b/src/video/SDL_blit_A.c
@@ -25,7 +25,7 @@
 #include "SDL_pixels_c.h"
 #include "SDL_surface_c.h"
 
-#if defined(SDL_SVE2_INTRINSICS) && (__ARM_ARCH >= 8) && (defined(__aarch64__) || defined(_M_ARM64))
+#ifdef SDL_SVE2_INTRINSICS
 #include "./arm/SDL_sve2_blit_A.h"
 #endif
 
@@ -1481,7 +1481,7 @@ SDL_BlitFunc SDL_CalculateBlitA(SDL_Surface *surface)
             }
 
         case 2:
-#if defined(SDL_SVE2_INTRINSICS) && (__ARM_ARCH >= 8) && (defined(__aarch64__) || defined(_M_ARM64))
+#ifdef SDL_SVE2_INTRINSICS
             if (SDL_HasSVE2()) {
                 if (sf->bytes_per_pixel == 4 &&
                     df->bytes_per_pixel == 2 &&
@@ -1519,11 +1519,11 @@ SDL_BlitFunc SDL_CalculateBlitA(SDL_Surface *surface)
                     return Blit8888to8888PixelAlphaSwizzleLSX;
                 }
 #endif
-#if defined(SDL_SVE2_INTRINSICS) && (__ARM_ARCH >= 8) && (defined(__aarch64__) || defined(_M_ARM64))
+#ifdef SDL_SVE2_INTRINSICS
                 if (SDL_HasSVE2() 
             /* NEON is faster than SVE2 when vector size is 128bit */
             #if defined(SDL_NEON_INTRINSICS)
-                && SDL_GetSVEVectorSize() > 128
+                && (SDL_GetSVEVectorSize() > 128 || !SDL_HasNEON())
             #endif
                 ) {
                     // To prevent "unused function" compiler warnings/errors

--- a/src/video/SDL_blit_A.c
+++ b/src/video/SDL_blit_A.c
@@ -1571,6 +1571,11 @@ SDL_BlitFunc SDL_CalculateBlitA(SDL_Surface *surface)
                             return Blit565to565SurfaceAlphaMMX;
                         } else
 #endif
+#ifdef SDL_SVE2_INTRINSICS
+                        if (SDL_HasSVE2()) {
+                            return Blit565to565SurfaceAlphaSVE2;
+                        } else 
+#endif
                         {
                             return Blit565to565SurfaceAlpha;
                         }

--- a/src/video/SDL_blit_N.c
+++ b/src/video/SDL_blit_N.c
@@ -26,7 +26,7 @@
 #include "SDL_surface_c.h"
 #include "SDL_blit_copy.h"
 
-#if defined(SDL_SVE2_INTRINSICS) && (__ARM_ARCH >= 8) && (defined(__aarch64__) || defined(_M_ARM64))
+#ifdef SDL_SVE2_INTRINSICS
 #include "./arm/SDL_sve2_blit_N.h"
 #endif
 
@@ -3121,7 +3121,7 @@ SDL_BlitFunc SDL_CalculateBlitN(SDL_Surface *surface)
                 return Blit8888to8888PixelSwizzleSSE41;
             }
 #endif
-#if defined(SDL_SVE2_INTRINSICS) && (__ARM_ARCH >= 8) && (defined(__aarch64__) || defined(_M_ARM64))
+#ifdef SDL_SVE2_INTRINSICS
             if (SDL_HasSVE2()) {
                 return Blit8888to8888PixelSwizzleSVE2;
             }
@@ -3132,7 +3132,7 @@ SDL_BlitFunc SDL_CalculateBlitN(SDL_Surface *surface)
             }
 #endif
         }
-#if defined(SDL_SVE2_INTRINSICS) && (__ARM_ARCH >= 8) && (defined(__aarch64__) || defined(_M_ARM64))
+#ifdef SDL_SVE2_INTRINSICS
         if (SDL_HasSVE2()) {
             /* RGBA8888/ARGB8888/XRGB8888 -> RGB565 */
             if (srcfmt->bytes_per_pixel == 4 &&

--- a/src/video/arm/SDL_sve2_blit_A.c
+++ b/src/video/arm/SDL_sve2_blit_A.c
@@ -51,12 +51,12 @@
     }
 
 #undef sdl_sve_rgb32_blend_to_rgb565_op
-#define sdl_sve_rgb32_blend_to_rgb565_op(ma_alpha_chn_idx)               \
-    do {                                                                 \
-        svuint16_t vMask = svget4(sve_source_u16x4, (ma_alpha_chn_idx)); \
-        sve_target_u16 = sdl_sve_chn_blend_with_mask(sve_source_u16,     \
-                                                     sve_target_u16,     \
-                                                     vMask);             \
+#define sdl_sve_rgb32_blend_to_rgb565_op(ma_alpha_chn_idx)                \
+    do {                                                                  \
+        svuint16_t vMask = svget4(sve_source_u16x4, (ma_alpha_chn_idx));  \
+        sve_target_u16 = sdl_sve_chn_blend_with_mask_fast(sve_source_u16, \
+                                                          sve_target_u16, \
+                                                          vMask);         \
     } while (0)
 
 #include "SDL_sve2_swizzle.h"

--- a/src/video/arm/SDL_sve2_blit_A.c
+++ b/src/video/arm/SDL_sve2_blit_A.c
@@ -86,4 +86,101 @@ size_t SDL_GetSVEVectorSize(void)
     return svlen(svundef_u8()) * 8;
 }
 
+/*-----------------------------------------------------------------------------*
+ * RGB565 Blend with Surface Alpha                                             *
+ *-----------------------------------------------------------------------------*/
+SDL_TARGETING("arch=armv8-a+sve2")
+ARM_NONNULL(1, 2)
+static inline void sdl_sve_rgb565_stride_blend_with_opacity(uint16_t *SDL_RESTRICT phwSource,
+                                                            uint16_t *SDL_RESTRICT phwTarget,
+                                                            size_t uStride,
+                                                            uint16_t hwOpacity)
+{
+    sdl_sve_stride_loop_rgb16(uStride, vTailPred)
+    {
+
+        svuint16x3_t vSource16x3 =
+            sdl_sve_rgb565_unpack(svld1_u16(vTailPred, phwSource));
+
+        svuint16x3_t vTarget16x3 =
+            sdl_sve_rgb565_unpack(svld1_u16(vTailPred, phwTarget));
+
+        sdl_sve_pixel_ccc_foreach_chn(
+            vSource16x3,
+            vTarget16x3,
+            {
+                sve_target_u16 = sdl_sve_chn_blend_with_opacity_fast(
+                    sve_source_u16,
+                    sve_target_u16,
+                    hwOpacity);
+            });
+
+        svst1_u16(vTailPred, phwTarget, sdl_sve_rgb565_pack(vTarget16x3));
+
+        phwSource += sve_iteration_advance;
+        phwTarget += sve_iteration_advance;
+    }
+}
+
+SDL_TARGETING("arch=armv8-a+sve2")
+ARM_NONNULL(1, 3)
+static inline void sdl_sve_rgb565_blend_with_opacity(uint8_t *SDL_RESTRICT pchSource,
+                                                     size_t uSourceStride,
+                                                     uint8_t *SDL_RESTRICT pchTarget,
+                                                     size_t uTargetStride,
+                                                     int nWidth,
+                                                     int nHeight,
+                                                     uint16_t hwOpacity)
+{
+    hwOpacity += hwOpacity == 255;
+    assert(0 == ((uintptr_t)pchSource & 0x01));
+    assert(0 == ((uintptr_t)pchTarget & 0x01));
+
+    while (nHeight--) {
+
+        sdl_sve_rgb565_stride_blend_with_opacity((uint16_t *)pchSource,
+                                                 (uint16_t *)pchTarget,
+                                                 nWidth,
+                                                 hwOpacity);
+
+        pchSource += uSourceStride;
+        pchTarget += uTargetStride;
+    }
+}
+
+// fast RGB565->RGB565 blending with surface alpha
+SDL_TARGETING("arch=armv8-a+sve2")
+void Blit565to565SurfaceAlphaSVE2(SDL_BlitInfo *info)
+{
+    uint16_t alpha = info->a;
+
+    int width = info->dst_w;
+    int height = info->dst_h;
+    uint8_t *src = info->src;
+    int srcskip = info->src_skip;
+    uint8_t *dst = info->dst;
+    int dstskip = info->dst_skip;
+
+    const SDL_PixelFormatDetails *srcfmt = info->src_fmt;
+    const SDL_PixelFormatDetails *dstfmt = info->dst_fmt;
+
+    // Set up some basic variables
+    int srcbpp = srcfmt->bytes_per_pixel;
+    int dstbpp = dstfmt->bytes_per_pixel;
+
+    assert(srcbpp == 2);
+    assert(dstbpp == 2);
+
+    int srcstride = srcskip + srcbpp * width;
+    int dststride = dstskip + dstbpp * width;
+
+    sdl_sve_rgb565_blend_with_opacity(src,
+                                      srcstride,
+                                      dst,
+                                      dststride,
+                                      width,
+                                      height,
+                                      alpha);
+}
+
 #endif /* SDL_SVE2_INTRINSICS */

--- a/src/video/arm/SDL_sve2_blit_A.h
+++ b/src/video/arm/SDL_sve2_blit_A.h
@@ -30,6 +30,8 @@
 void Blit8888to8888PixelAlphaSwizzleSVE2(SDL_BlitInfo *info);
 void Blit8888to565PixelAlphaSwizzleSVE2(SDL_BlitInfo *info);
 
+void Blit565to565SurfaceAlphaSVE2(SDL_BlitInfo *info);
+
 size_t SDL_GetSVEVectorSize(void);
 
 #endif /* SDL_SVE2_INTRINSICS */

--- a/src/video/arm/SDL_sve2_extension.h
+++ b/src/video/arm/SDL_sve2_extension.h
@@ -964,6 +964,23 @@ static inline svuint16_t sdl_sve_chn_blend_with_opacity(svuint16_t vSource,
     return svlsr_n_u16_m(svptrue_b16(), vTarget, 8); // vTarget >> 8;
 }
 
+/*! \note the hwOpacity range [0, 0x100]
+ */
+SDL_TARGETING("arch=armv8-a+sve2")
+static inline svuint16_t sdl_sve_chn_blend_with_opacity_fast(svuint16_t vSource,
+                                                        svuint16_t vTarget,
+                                                        uint16_t hwOpacity)
+{
+    // vTarget = vSource * vMask + vTarget * (255 - vMask);
+    svuint16_t vTemp0 = svmul_n_u16_m(svptrue_b16(), vSource, hwOpacity);
+    vTemp0 = svmla_n_u16_m(svptrue_b16(),
+                         vTemp0,
+                         vTarget,
+                         256 - hwOpacity);
+
+    return svlsr_n_u16_m(svptrue_b16(), vTemp0, 8); // vTarget >> 8;
+}
+
 /*! \note the Element range of vMask is [0, 0xFF]
  *  \note the hwOpacity range [0, 0x100]
  */

--- a/src/video/arm/SDL_sve2_extension.h
+++ b/src/video/arm/SDL_sve2_extension.h
@@ -902,7 +902,9 @@ static inline void svst4ub_u16(svbool_t vPredu8,
 /*! \note the Element range of vMask is [0, 0xFF]
  */
 SDL_TARGETING("arch=armv8-a+sve2")
-static inline svuint16_t sdl_sve_chn_blend_with_mask(svuint16_t vSource, svuint16_t vTarget, svuint16_t vMask)
+static inline svuint16_t sdl_sve_chn_blend_with_mask(svuint16_t vSource,
+                                                     svuint16_t vTarget,
+                                                     svuint16_t vMask)
 {
     // vTarget = vSource * vMask + vTarget * (255 - vMask);
     svuint16_t vTemp0 = svmul_u16_m(svptrue_b16(), vSource, vMask);
@@ -920,6 +922,25 @@ static inline svuint16_t sdl_sve_chn_blend_with_mask(svuint16_t vSource, svuint1
     vTemp0 = svadd_u16_m(svptrue_b16(),
                          vTemp0,
                          vTemp1);
+
+    return svlsr_n_u16_m(svptrue_b16(), vTemp0, 8); // vTarget >> 8;
+}
+
+/*! \note the Element range of vMask is [0, 0xFF]
+ */
+SDL_TARGETING("arch=armv8-a+sve2")
+static inline svuint16_t sdl_sve_chn_blend_with_mask_fast(svuint16_t vSource,
+                                                          svuint16_t vTarget,
+                                                          svuint16_t vMask)
+{
+    // vTarget = vSource * vMask + vTarget * (255 - vMask);
+    svuint16_t vTemp0 = svmul_u16_m(svptrue_b16(), vSource, vMask);
+    vTemp0 = svmla_u16_m(svptrue_b16(),
+                         vTemp0,
+                         vTarget,
+                         svsub_u16_m(svptrue_b16(),
+                                     svdup_u16(255),
+                                     vMask));
 
     return svlsr_n_u16_m(svptrue_b16(), vTemp0, 8); // vTarget >> 8;
 }


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

- Apply the changes suggested in #15504 
- Improves the performance of 8888 to 565 pixel alpha blit
- Accelerate RGB565 Surface Alpha

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
