### PR TITLE
Fix Steam Controller 2 touchpad finger detection

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_steam_triton.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam_triton.c
@@ -250,10 +250,10 @@ static void HIDAPI_DriverSteamTriton_HandleState(SDL_HIDAPI_Device *device,
         ctx->last_sensor_tick = pTritonReport->imu.timestamp;
     }
 
-    bool downLeft = pTritonReport->buttons & TRITON_LEFT_TOUCHPAD_TOUCH ? true : false;
-    bool downRight = pTritonReport->buttons & TRITON_RIGHT_TOUCHPAD_TOUCH ? true : false;
-    if (downLeft || ctx->left_touch_down){
-        if (downLeft){
+    bool left_touch_down = (pTritonReport->buttons & TRITON_LEFT_TOUCHPAD_TOUCH) ? true : false;
+    bool right_touch_down = (pTritonReport->buttons & TRITON_RIGHT_TOUCHPAD_TOUCH) ? true : false;
+    if (left_touch_down || ctx->left_touch_down) {
+        if (left_touch_down) {
             ctx->left_touch_x = pTritonReport->sLeftPadX / 65536.0f + 0.5f;
             ctx->left_touch_y = -(float)pTritonReport->sLeftPadY / 65536.0f + 0.5f;
 

--- a/src/joystick/hidapi/SDL_hidapi_steam_triton.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam_triton.c
@@ -103,8 +103,13 @@ typedef struct
     Uint16 low_frequency_rumble;
     Uint16 high_frequency_rumble;
     Uint64 last_rumble_time;
+
     bool left_touch_down;
+    float left_touch_x;
+    float left_touch_y;
     bool right_touch_down;
+    float right_touch_x;
+    float right_touch_y;
 } SDL_DriverSteamTriton_Context;
 
 static bool IsProteusDongle(Uint16 product_id)
@@ -248,18 +253,27 @@ static void HIDAPI_DriverSteamTriton_HandleState(SDL_HIDAPI_Device *device,
     bool downLeft = pTritonReport->buttons & TRITON_LEFT_TOUCHPAD_TOUCH ? true : false;
     bool downRight = pTritonReport->buttons & TRITON_RIGHT_TOUCHPAD_TOUCH ? true : false;
     if (downLeft || ctx->left_touch_down){
+        if (downLeft){
+            ctx->left_touch_x=pTritonReport->sLeftPadX / 65536.0f + 0.5f;
+            ctx->left_touch_y=-(float)pTritonReport->sLeftPadY / 65536.0f + 0.5f;
+
+        }
         SDL_SendJoystickTouchpad(timestamp, joystick, 0, 0,
                                  downLeft,
-                                 pTritonReport->sLeftPadX / 65536.0f + 0.5f,
-                                 -(float)pTritonReport->sLeftPadY / 65536.0f + 0.5f,
+                                 ctx->left_touch_x,
+                                 ctx->left_touch_y,
                                  pTritonReport->sPressureLeft / 32768.0f);
         ctx->left_touch_down=downLeft;
     }
     if (downRight || ctx->right_touch_down){
+        if (downRight){
+            ctx->right_touch_x=pTritonReport->sRightPadX / 65536.0f + 0.5f;
+            ctx->right_touch_y=-(float)pTritonReport->sRightPadY / 65536.0f + 0.5f;
+        }
         SDL_SendJoystickTouchpad(timestamp, joystick, 1, 0,
                                  downRight,
-                                 pTritonReport->sRightPadX / 65536.0f + 0.5f,
-                                 -(float)pTritonReport->sRightPadY / 65536.0f + 0.5f,
+                                 ctx->right_touch_x,
+                                 ctx->right_touch_y,
                                  pTritonReport->sPressureRight / 32768.0f);
         ctx->right_touch_down=downRight;
     }

--- a/src/joystick/hidapi/SDL_hidapi_steam_triton.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam_triton.c
@@ -263,7 +263,7 @@ static void HIDAPI_DriverSteamTriton_HandleState(SDL_HIDAPI_Device *device,
                                  ctx->left_touch_x,
                                  ctx->left_touch_y,
                                  pTritonReport->sPressureLeft / 32768.0f);
-        ctx->left_touch_down=downLeft;
+        ctx->left_touch_down = left_touch_down;
     }
     if (downRight || ctx->right_touch_down){
         if (downRight){

--- a/src/joystick/hidapi/SDL_hidapi_steam_triton.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam_triton.c
@@ -254,8 +254,8 @@ static void HIDAPI_DriverSteamTriton_HandleState(SDL_HIDAPI_Device *device,
     bool downRight = pTritonReport->buttons & TRITON_RIGHT_TOUCHPAD_TOUCH ? true : false;
     if (downLeft || ctx->left_touch_down){
         if (downLeft){
-            ctx->left_touch_x=pTritonReport->sLeftPadX / 65536.0f + 0.5f;
-            ctx->left_touch_y=-(float)pTritonReport->sLeftPadY / 65536.0f + 0.5f;
+            ctx->left_touch_x = pTritonReport->sLeftPadX / 65536.0f + 0.5f;
+            ctx->left_touch_y = -(float)pTritonReport->sLeftPadY / 65536.0f + 0.5f;
 
         }
         SDL_SendJoystickTouchpad(timestamp, joystick, 0, 0,

--- a/src/joystick/hidapi/SDL_hidapi_steam_triton.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam_triton.c
@@ -103,6 +103,8 @@ typedef struct
     Uint16 low_frequency_rumble;
     Uint16 high_frequency_rumble;
     Uint64 last_rumble_time;
+    bool left_touch_down;
+    bool right_touch_down;
 } SDL_DriverSteamTriton_Context;
 
 static bool IsProteusDongle(Uint16 product_id)
@@ -243,17 +245,24 @@ static void HIDAPI_DriverSteamTriton_HandleState(SDL_HIDAPI_Device *device,
         ctx->last_sensor_tick = pTritonReport->imu.timestamp;
     }
 
-    SDL_SendJoystickTouchpad(timestamp, joystick, 0, 0,
-                             pTritonReport->sPressureLeft > 0,
-                             pTritonReport->sLeftPadX / 65536.0f + 0.5f,
-                             -(float)pTritonReport->sLeftPadY / 65536.0f + 0.5f,
-                             pTritonReport->sPressureLeft / 32768.0f);
-
-    SDL_SendJoystickTouchpad(timestamp, joystick, 1, 0,
-                             pTritonReport->sPressureRight > 0,
-                             pTritonReport->sRightPadX / 65536.0f + 0.5f,
-                             -(float)pTritonReport->sRightPadY / 65536.0f + 0.5f,
-                             pTritonReport->sPressureRight / 32768.0f);
+    bool downLeft = pTritonReport->buttons & TRITON_LEFT_TOUCHPAD_TOUCH ? true : false;
+    bool downRight = pTritonReport->buttons & TRITON_RIGHT_TOUCHPAD_TOUCH ? true : false;
+    if (downLeft || ctx->left_touch_down){
+        SDL_SendJoystickTouchpad(timestamp, joystick, 0, 0,
+                                 downLeft,
+                                 pTritonReport->sLeftPadX / 65536.0f + 0.5f,
+                                 -(float)pTritonReport->sLeftPadY / 65536.0f + 0.5f,
+                                 pTritonReport->sPressureLeft / 32768.0f);
+        ctx->left_touch_down=downLeft;
+    }
+    if (downRight || ctx->right_touch_down){
+        SDL_SendJoystickTouchpad(timestamp, joystick, 1, 0,
+                                 downRight,
+                                 pTritonReport->sRightPadX / 65536.0f + 0.5f,
+                                 -(float)pTritonReport->sRightPadY / 65536.0f + 0.5f,
+                                 pTritonReport->sPressureRight / 32768.0f);
+        ctx->right_touch_down=downRight;
+    }
 }
 
 static void HIDAPI_DriverSteamTriton_HandleBatteryStatus(SDL_HIDAPI_Device *device,

--- a/src/joystick/hidapi/SDL_hidapi_steam_triton.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam_triton.c
@@ -259,7 +259,7 @@ static void HIDAPI_DriverSteamTriton_HandleState(SDL_HIDAPI_Device *device,
 
         }
         SDL_SendJoystickTouchpad(timestamp, joystick, 0, 0,
-                                 downLeft,
+                                 left_touch_down,
                                  ctx->left_touch_x,
                                  ctx->left_touch_y,
                                  pTritonReport->sPressureLeft / 32768.0f);

--- a/src/joystick/hidapi/SDL_hidapi_steam_triton.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam_triton.c
@@ -265,17 +265,17 @@ static void HIDAPI_DriverSteamTriton_HandleState(SDL_HIDAPI_Device *device,
                                  pTritonReport->sPressureLeft / 32768.0f);
         ctx->left_touch_down = left_touch_down;
     }
-    if (downRight || ctx->right_touch_down){
-        if (downRight){
-            ctx->right_touch_x=pTritonReport->sRightPadX / 65536.0f + 0.5f;
-            ctx->right_touch_y=-(float)pTritonReport->sRightPadY / 65536.0f + 0.5f;
+    if (right_touch_down || ctx->right_touch_down) {
+        if (right_touch_down) {
+            ctx->right_touch_x = pTritonReport->sRightPadX / 65536.0f + 0.5f;
+            ctx->right_touch_y = -(float)pTritonReport->sRightPadY / 65536.0f + 0.5f;
         }
         SDL_SendJoystickTouchpad(timestamp, joystick, 1, 0,
-                                 downRight,
+                                 right_touch_down,
                                  ctx->right_touch_x,
                                  ctx->right_touch_y,
                                  pTritonReport->sPressureRight / 32768.0f);
-        ctx->right_touch_down=downRight;
+        ctx->right_touch_down = right_touch_down;
     }
 }
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").



## Description
The Steam Controller 2 driver detects touchpads via the pressure sensor. This is unreliable and can cause missed touch events. A better way is to use the touch flags of the buttons.

## Existing Issue(s)
Improves #15638 .

