### PR TITLE
examples: Fix float division

### DIFF
--- a/examples/demo/02-woodeneye-008/woodeneye-008.c
+++ b/examples/demo/02-woodeneye-008/woodeneye-008.c
@@ -206,7 +206,7 @@ static void draw(SDL_Renderer *renderer, const float (*edges)[6], const Player p
         for (i = 0; i < players_len; i++) {
             const Player *player = &players[i];
             float mod_x = (float)(i % part_hor);
-            float mod_y = (float)(i / part_hor);
+            float mod_y = (float)i / part_hor;
             float hor_origin = (mod_x + 0.5f) * size_hor;
             float ver_origin = (mod_y + 0.5f) * size_ver;
             float cam_origin = (float)(0.5 * SDL_sqrt(size_hor * size_hor + size_ver * size_ver));

--- a/examples/renderer/05-rectangles/rectangles.c
+++ b/examples/renderer/05-rectangles/rectangles.c
@@ -90,7 +90,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
 
     /* ...and also fill a bunch of rectangles at once... */
     for (i = 0; i < SDL_arraysize(rects); i++) {
-        const float w = (float) (WINDOW_WIDTH / SDL_arraysize(rects));
+        const float w = ((float) WINDOW_WIDTH / SDL_arraysize(rects));
         const float h = i * 8.0f;
         rects[i].x = i * w;
         rects[i].y = WINDOW_HEIGHT - h;

--- a/examples/renderer/18-debug-text/debug-text.c
+++ b/examples/renderer/18-debug-text/debug-text.c
@@ -66,7 +66,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
     SDL_SetRenderScale(renderer, 1.0f, 1.0f);
     SDL_RenderDebugText(renderer, 64, 350, "This only does ASCII chars. So this laughing emoji won't draw: 🤣");
 
-    SDL_RenderDebugTextFormat(renderer, (float) ((WINDOW_WIDTH - (charsize * 46)) / 2), 400, "(This program has been running for %" SDL_PRIu64 " seconds.)", SDL_GetTicks() / 1000);
+    SDL_RenderDebugTextFormat(renderer, ((float) (WINDOW_WIDTH - (charsize * 46)) / 2), 400, "(This program has been running for %" SDL_PRIu64 " seconds.)", SDL_GetTicks() / 1000);
 
     SDL_RenderPresent(renderer);  /* put it all on the screen! */
 


### PR DESCRIPTION
Avoid integer division before conversion to float in the examples to prevent precision loss warnings.