### PR TITLE
Properly fix cursor position in Korean IME

### DIFF
--- a/src/video/windows/SDL_windowskeyboard.c
+++ b/src/video/windows/SDL_windowskeyboard.c
@@ -828,6 +828,11 @@ static void IME_GetCompositionString(SDL_VideoData *videodata, HIMC himc, LPARAM
     }
     length /= sizeof(WCHAR);
 
+    if (!(*lParam & GCS_CURSORPOS)) {
+        // If the IME doesn't support GCS_CURSORPOS, default the cursor to the end of the composition.
+        videodata->ime_cursor = length;
+    }
+
     if ((dwLang == LANG_CHT || dwLang == LANG_CHS) &&
         videodata->ime_cursor > 0 &&
         videodata->ime_cursor < (int)(videodata->ime_composition_length / sizeof(WCHAR)) &&
@@ -889,7 +894,7 @@ static void IME_SendInputEvent(SDL_VideoData *videodata)
 
     videodata->ime_composition[0] = 0;
     videodata->ime_readingstring[0] = 0;
-    videodata->ime_cursor = 1; // Korean IME cursor
+    videodata->ime_cursor = 0;
 }
 
 static void IME_SendEditingEvent(SDL_VideoData *videodata)
@@ -1072,7 +1077,7 @@ bool WIN_HandleIMEMessage(HWND hwnd, UINT msg, WPARAM wParam, LPARAM *lParam, SD
     } else if (msg == WM_IME_STARTCOMPOSITION) {
         SDL_DebugIMELog("WM_IME_STARTCOMPOSITION");
         if (videodata->ime_internal_composition) {
-            videodata->ime_cursor = 1; // Korean IME cursor
+            videodata->ime_cursor = 0;
             // Windows may still display a composition dialog even with
             // ISC_SHOWUICOMPOSITIONWINDOW cleared, so trap the message
             // here to prevent that (even when the IME is disabled).


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- This PR improves on and fixes issues in https://github.com/libsdl-org/SDL/pull/15643

If an IME doesn't provide a cursor position via GCS_CURSORPOS, the cursor position will now default to the end of the composition. This is what other programs on Windows do for Korean IME. (Sidenote: we could theoretically report the position as not set, as allowed by https://wiki.libsdl.org/SDL3/SDL_TextEditingEvent, but that can be done in another PR).

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
- Closes https://github.com/libsdl-org/SDL/issues/15589