### PR TITLE
Fix touchpad finger detection on Steam Deck

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_steamdeck.c
+++ b/src/joystick/hidapi/SDL_hidapi_steamdeck.c
@@ -65,6 +65,8 @@ typedef enum
     STEAMDECK_LBUTTON_R5            = 0x00010000,
     STEAMDECK_LBUTTON_LEFT_PAD      = 0x00020000,
     STEAMDECK_LBUTTON_RIGHT_PAD     = 0x00040000,
+    STEAMDECK_LBUTTON_LEFT_TOUCHPAD_TOUCH      = 0x00080000,
+    STEAMDECK_LBUTTON_RIGHT_TOUCHPAD_TOUCH     = 0x00100000,
     STEAMDECK_LBUTTON_L3            = 0x00400000,
     STEAMDECK_LBUTTON_R3            = 0x04000000,
 
@@ -81,6 +83,13 @@ typedef struct
     Uint64 sensor_timestamp_ns;
     Uint64 last_button_state;
     Uint8 watchdog_counter;
+
+    bool left_touch_down;
+    float left_touch_x;
+    float left_touch_y;
+    bool right_touch_down;
+    float right_touch_x;
+    float right_touch_y;
 } SDL_DriverSteamDeck_Context;
 
 static bool DisableDeckLizardMode(SDL_hid_device *dev)
@@ -248,17 +257,33 @@ static void HIDAPI_DriverSteamDeck_HandleState(SDL_HIDAPI_Device *device,
     values[2] = (-pInReport->payload.deckState.sAccelY / 32768.0f) * 2.0f * SDL_STANDARD_GRAVITY;
     SDL_SendJoystickSensor(timestamp, joystick, SDL_SENSOR_ACCEL, ctx->sensor_timestamp_ns, values, 3);
 
-    SDL_SendJoystickTouchpad(timestamp, joystick, 0, 0,
-            pInReport->payload.deckState.sPressurePadLeft > 0,
-            pInReport->payload.deckState.sLeftPadX        / 65536.0f + 0.5f,
-            pInReport->payload.deckState.sLeftPadY        / 65536.0f + 0.5f,
-            pInReport->payload.deckState.sPressurePadLeft / 32768.0f);
+    bool left_touch_down = (pInReport->payload.deckState.ulButtonsL & STEAMDECK_LBUTTON_LEFT_TOUCHPAD_TOUCH) ? true : false;
+    bool right_touch_down = (pInReport->payload.deckState.ulButtonsL & STEAMDECK_LBUTTON_RIGHT_TOUCHPAD_TOUCH) ? true : false;
+    if (left_touch_down || ctx->left_touch_down) {
+        if (left_touch_down) {
+            ctx->left_touch_x = pInReport->payload.deckState.sLeftPadX / 65536.0f + 0.5f;
+            ctx->left_touch_y = -(float)pInReport->payload.deckState.sLeftPadY / 65536.0f + 0.5f;
 
-    SDL_SendJoystickTouchpad(timestamp, joystick, 1, 0,
-            pInReport->payload.deckState.sPressurePadRight > 0,
-            pInReport->payload.deckState.sRightPadX        / 65536.0f + 0.5f,
-            pInReport->payload.deckState.sRightPadY        / 65536.0f + 0.5f,
-            pInReport->payload.deckState.sPressurePadRight / 32768.0f);
+        }
+        SDL_SendJoystickTouchpad(timestamp, joystick, 0, 0,
+                left_touch_down,
+                ctx->left_touch_x,
+                ctx->left_touch_y,
+                pInReport->payload.deckState.sPressurePadLeft / 32768.0f);
+        ctx->left_touch_down = left_touch_down;
+    }
+    if (right_touch_down || ctx->right_touch_down) {
+        if (right_touch_down) {
+            ctx->right_touch_x = pInReport->payload.deckState.sRightPadX / 65536.0f + 0.5f;
+            ctx->right_touch_y = -(float)pInReport->payload.deckState.sRightPadY / 65536.0f + 0.5f;
+        }
+        SDL_SendJoystickTouchpad(timestamp, joystick, 1, 0,
+                right_touch_down,
+                ctx->right_touch_x,
+                ctx->right_touch_y,
+                pInReport->payload.deckState.sPressurePadRight / 32768.0f);
+        ctx->right_touch_down = right_touch_down;
+    }
 }
 
 /*****************************************************************************************************/


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").



## Description
The Steam Deck driver code has the same bug as the one that was fixed in https://github.com/libsdl-org/SDL/pull/15644 .
In addition the touchpad's y-axis isn't reported in the same way as on the Steam controllers.
You actually don't get any events at all with light touches, so I suspect the person who made https://github.com/libsdl-org/SDL/pull/12888 never actually tested on hardware, as the difference in behavior to the Steam client is immediately obvious.

## Existing Issue(s)
Relates to #12855  and  #15638 .
