### PR TITLE
Add support for the 8BitDo Ultimate 2 Bluetooth in DInput mode

### DIFF
--- a/src/joystick/SDL_gamepad.c
+++ b/src/joystick/SDL_gamepad.c
@@ -714,7 +714,7 @@ static GamepadMapping_t *SDL_CreateMappingForAndroidGamepad(SDL_GUID guid)
     int button_mask;
     int axis_mask;
     Uint16 vendor, product;
-    
+
     SDL_strlcpy(mapping_string, "none,", sizeof(mapping_string));
 
     SDL_GetJoystickGUIDInfo(guid, &vendor, &product, NULL, NULL);
@@ -1223,11 +1223,12 @@ static GamepadMapping_t *SDL_CreateMappingForHIDAPIGamepad(SDL_GUID guid)
                 product == USB_PRODUCT_8BITDO_SN30_PRO_BT ||
                 product == USB_PRODUCT_8BITDO_PRO_2 ||
                 product == USB_PRODUCT_8BITDO_PRO_2_BT ||
+                product == USB_PRODUCT_8BITDO_ULTIMATE2_BT ||
                 product == USB_PRODUCT_8BITDO_PRO_3)) {
             SDL_strlcat(mapping_string, "a:b1,b:b0,back:b4,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b5,leftshoulder:b9,leftstick:b7,lefttrigger:a4,leftx:a0,lefty:a1,rightshoulder:b10,rightstick:b8,righttrigger:a5,rightx:a2,righty:a3,start:b6,x:b3,y:b2,hint:!SDL_GAMECONTROLLER_USE_BUTTON_LABELS:=1,", sizeof(mapping_string));
             if (product == USB_PRODUCT_8BITDO_PRO_2 || product == USB_PRODUCT_8BITDO_PRO_2_BT) {
                 SDL_strlcat(mapping_string, "paddle1:b14,paddle2:b13,", sizeof(mapping_string));
-            } else if (product == USB_PRODUCT_8BITDO_PRO_3) {
+            } else if (product == USB_PRODUCT_8BITDO_PRO_3 || product == USB_PRODUCT_8BITDO_ULTIMATE2_BT) {
                 SDL_strlcat(mapping_string, "paddle1:b12,paddle2:b11,paddle3:b14,paddle4:b13,", sizeof(mapping_string));
             }
     } else if (vendor == USB_VENDOR_8BITDO &&

--- a/src/joystick/hidapi/SDL_hidapi_8bitdo.c
+++ b/src/joystick/hidapi/SDL_hidapi_8bitdo.c
@@ -146,6 +146,7 @@ static bool HIDAPI_Driver8BitDo_IsSupportedDevice(SDL_HIDAPI_Device *device, con
         case USB_PRODUCT_8BITDO_PRO_2:
         case USB_PRODUCT_8BITDO_PRO_2_BT:
         case USB_PRODUCT_8BITDO_PRO_3:
+        case USB_PRODUCT_8BITDO_ULTIMATE2_BT:
         case USB_PRODUCT_8BITDO_ULTIMATE2_WIRELESS:
             return true;
         default:
@@ -163,7 +164,7 @@ static bool HIDAPI_Driver8BitDo_InitDevice(SDL_HIDAPI_Device *device)
     }
     device->context = ctx;
 
-    if (device->product_id == USB_PRODUCT_8BITDO_ULTIMATE2_WIRELESS) {
+    if (device->product_id == USB_PRODUCT_8BITDO_ULTIMATE2_WIRELESS || device->product_id == USB_PRODUCT_8BITDO_ULTIMATE2_BT) {
         // The Ultimate 2 Wireless v1.02 firmware has 12 byte reports, v1.03 firmware has 34 byte reports
         const int ULTIMATE2_WIRELESS_V103_REPORT_SIZE = 34;
         const int MAX_ATTEMPTS = 3;
@@ -269,6 +270,7 @@ static Uint64 HIDAPI_Driver8BitDo_GetIMURateForProductID(SDL_HIDAPI_Device *devi
             // This firmware appears to update at 100 Hz over USB
             return 100;
         }
+    case USB_PRODUCT_8BITDO_ULTIMATE2_BT:
     case USB_PRODUCT_8BITDO_ULTIMATE2_WIRELESS:
         if (device->is_bluetooth) {
             // Note, This is estimated by observation of Bluetooth packets received in the testcontroller tool
@@ -298,6 +300,7 @@ static bool HIDAPI_Driver8BitDo_OpenJoystick(SDL_HIDAPI_Device *device, SDL_Joys
     if (device->product_id == USB_PRODUCT_8BITDO_PRO_2 ||
         device->product_id == USB_PRODUCT_8BITDO_PRO_2_BT ||
         device->product_id == USB_PRODUCT_8BITDO_PRO_3 ||
+        device->product_id == USB_PRODUCT_8BITDO_ULTIMATE2_BT ||
         device->product_id == USB_PRODUCT_8BITDO_ULTIMATE2_WIRELESS) {
         // This controller has additional buttons
         joystick->nbuttons = SDL_GAMEPAD_NUM_8BITDO_BUTTONS;

--- a/src/joystick/usb_ids.h
+++ b/src/joystick/usb_ids.h
@@ -74,6 +74,7 @@
 #define USB_PRODUCT_8BITDO_PRO_2                          0x6003    // mode switch to D
 #define USB_PRODUCT_8BITDO_PRO_2_BT                       0x6006    // mode switch to D
 #define USB_PRODUCT_8BITDO_PRO_3                          0x6009    // mode switch to D
+#define USB_PRODUCT_8BITDO_ULTIMATE2_BT                   0x6011    // mode switch to D
 #define USB_PRODUCT_8BITDO_ULTIMATE2_WIRELESS             0x6012    // mode switch to BT
 #define USB_PRODUCT_AMAZON_LUNA_CONTROLLER                0x0419
 #define USB_PRODUCT_ASTRO_C40_XBOX360                     0x0024


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds support for the DInput mode of the 8BitDo Ultimate 2 Bluetooth controller, not to be confused with the already-supported Ultimate 2 Wireless.

This controller is nearly identical to the Wireless variant, but has functionality for connecting to the Switch and Switch 2 over Bluetooth which the Wireless variant lacks. It also accordingly has the Nintendo-style face button layout.

The Bluetooth variant normally lacks a DInput mode, but there's a beta firmware for its 2.4G receiver which adds it and seems to make it behave identically to the Wireless version. I don't know if there's anywhere this firmware version can be downloaded outside of contacting 8BitDo's support, and whether there's a newer version than what I have. Rumble and motion sensors are not working, just like the code seems to imply it doesn't for older firmware versions of the Wireless variant, but one could hope that if a non-beta version of this firmware were ever to materialize, these features would be supported in it.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
