### PR TITLE
wayland: unified error message for SDL_SetWindowIcon

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -3263,7 +3263,7 @@ bool Wayland_SetWindowIcon(SDL_VideoDevice *_this, SDL_Window *window, SDL_Surfa
     struct xdg_toplevel *toplevel = NULL;
 
     if (!_this->internal->xdg_toplevel_icon_manager_v1) {
-        return SDL_SetError("wayland: cannot set icon; required xdg_toplevel_icon_v1 protocol not supported");
+        return SDL_Unsupported();
     }
 
     int image_count = 0;


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Changed the error message on wayland if xdg_toplevel_icon_v1 is not supported from `wayland: cannot set icon; required xdg_toplevel_icon_v1 protocol not supported` to `That operation is not supported`.

## Description
Recently, an issue came up in my Wayland window manager: when I try to change the window icon, it throws an error, but the error message does not follow a standard format. On Android, however, in the same case, a standard error message is displayed, which helps me handle the “error” (which is not actually an error, just an unsupported feature). I think it would be good if different platforms indicated in a consistent way when a feature is not supported.

```cpp
if (!SDL_SetWindowIcon(window, icon) && static_cast<bool>(std::strcmp(SDL_GetError(), "That operation is not supported"))) {
	throw std::runtime_error{SDL_GetError()};
}
```

On the other hand, I think it would be good if error handling were extended with constant error strings, since there is already one like (“That operation is not supported”). This could be extracted into a macro so there is something to compare against.

Thanks for the consideration :)