### PR TITLE
Remove CenterPad and RightStick from Steam Controller (2015) internal state struct

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_steam.c
+++ b/src/joystick/hidapi/SDL_hidapi_steam.c
@@ -75,17 +75,9 @@ typedef struct SteamControllerStateInternal_t
     short sRightPadX;
     short sRightPadY;
 
-    // Center pad coordinates
-    short sCenterPadX;
-    short sCenterPadY;
-
     // Left analog stick coordinates
     short sLeftStickX;
     short sLeftStickY;
-
-    // Right analog stick coordinates
-    short sRightStickX;
-    short sRightStickY;
 
     unsigned short sTriggerL;
     unsigned short sTriggerR;


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
These values are never used for the Steam Controller (2015), as it does not physically have these inputs.
The values for sCenterPadX/Y are never referenced outside these two lines, the sRightStickX/Y does not apply to the Steam Controller (2015).
I have tested the Steam Controller 2015 and Steam Controller 2026 with this change, they both function without issues.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
None