### PR TITLE
Fix buffer-overflow access in process_testStdinToStdout

### DIFF
--- a/test/testprocess.c
+++ b/test/testprocess.c
@@ -500,7 +500,8 @@ static int process_testStdinToStdout(void *arg)
             total_read += amount_read;
             SDL_WriteIO(stdout_stream, local_buffer, amount_read);
             stdout_stream_buf = SDL_GetPointerProperty(SDL_GetIOProperties(stdout_stream), SDL_PROP_IOSTREAM_DYNAMIC_MEMORY_POINTER, NULL);
-            if (SDL_strstr(stdout_stream_buf, "EOF")) {
+            Sint64 stdout_size = SDL_GetIOSize(stdout_stream);
+            if (SDL_strnstr(stdout_stream_buf, "EOF", (size_t)stdout_size)) {
                 SDLTest_Log("Found EOF in stdout");
                 break;
             }


### PR DESCRIPTION
Backing memory of `SDL_IOFromDynamicMem` is not null-terminated.

- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
Fixes #15685