### PR TITLE
video: Only ignore modes with a lower color depth in SDL_GetClosestFu…

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -1430,7 +1430,7 @@ bool SDL_GetClosestFullscreenDisplayMode(SDL_DisplayID displayID, int w, int h, 
                      * refresh rate target */
                     continue;
                 }
-                if (SDL_BYTESPERPIXEL(closest->format) >= SDL_BYTESPERPIXEL(mode->format)) {
+                if (SDL_BYTESPERPIXEL(closest->format) > SDL_BYTESPERPIXEL(mode->format)) {
                     // Prefer the highest color depth
                     continue;
                 }


### PR DESCRIPTION
…llscreenDisplayMode()

- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

If a mode with a closer refresh was found, but it had the same color depth as the current best match, it was being dropped. Only ignore the new mode if the color depth is below the current best match.

Fixes #15682
