### PR TITLE
Ensure we release exclusive USB access to controllers when backgrounded.

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/HIDDeviceUSB.java
+++ b/android-project/app/src/main/java/org/libsdl/app/HIDDeviceUSB.java
@@ -225,7 +225,6 @@ class HIDDeviceUSB implements HIDDevice {
             if (feature) {
                 return false;
             }
-
             return true;            
         }
 

--- a/android-project/app/src/main/java/org/libsdl/app/HIDDeviceUSB.java
+++ b/android-project/app/src/main/java/org/libsdl/app/HIDDeviceUSB.java
@@ -285,8 +285,7 @@ class HIDDeviceUSB implements HIDDevice {
             UsbInterface iface = mDevice.getInterface(mInterfaceIndex);
             if (frozen) {
                 mConnection.releaseInterface(iface);
-            }
-            else {
+            } else {
                 mConnection.claimInterface(iface, true);
             }
         }

--- a/android-project/app/src/main/java/org/libsdl/app/HIDDeviceUSB.java
+++ b/android-project/app/src/main/java/org/libsdl/app/HIDDeviceUSB.java
@@ -285,9 +285,11 @@ class HIDDeviceUSB implements HIDDevice {
             }
             mInputThread = null;
         }
-        if (mConnection != null && mClaimed) {
-            UsbInterface iface = mDevice.getInterface(mInterfaceIndex);
-            mConnection.releaseInterface(iface);
+        if (mConnection != null) {
+            if (mClaimed) {
+                UsbInterface iface = mDevice.getInterface(mInterfaceIndex);
+                mConnection.releaseInterface(iface);                
+            }
             mConnection.close();
             mConnection = null;
             mClaimed = false;

--- a/android-project/app/src/main/java/org/libsdl/app/HIDDeviceUSB.java
+++ b/android-project/app/src/main/java/org/libsdl/app/HIDDeviceUSB.java
@@ -314,8 +314,7 @@ class HIDDeviceUSB implements HIDDevice {
                 if (mClaimed) {
                     Log.e(TAG, "Tried to release claim on USB device, but failed!");
                 }
-            }
-            else {
+            } else {
                 mClaimed = mConnection.claimInterface(iface, true);
                 if (!mClaimed) {
                     Log.e(TAG, "Tried to regain claim on USB device, but failed!");

--- a/android-project/app/src/main/java/org/libsdl/app/HIDDeviceUSB.java
+++ b/android-project/app/src/main/java/org/libsdl/app/HIDDeviceUSB.java
@@ -137,6 +137,7 @@ class HIDDeviceUSB implements HIDDevice {
         // back to the Android system gamepad functionality (and lose our paddles et al).
         if (mInputEndpoint == null) {
             Log.w(TAG, "Missing required endpoint on USB device " + getDeviceName());
+            mConnection.releaseInterface(iface);
             close();
             return false;
         }
@@ -280,6 +281,15 @@ class HIDDeviceUSB implements HIDDevice {
 
     @Override
     public void setFrozen(boolean frozen) {
+        if (frozen != mFrozen && mConnection != null) {
+            UsbInterface iface = mDevice.getInterface(mInterfaceIndex);
+            if (frozen) {
+                mConnection.releaseInterface(iface);
+            }
+            else {
+                mConnection.claimInterface(iface, true);
+            }
+        }
         mFrozen = frozen;
     }
 

--- a/android-project/app/src/main/java/org/libsdl/app/HIDDeviceUSB.java
+++ b/android-project/app/src/main/java/org/libsdl/app/HIDDeviceUSB.java
@@ -222,15 +222,10 @@ class HIDDeviceUSB implements HIDDevice {
             return false;
         }
         if (!mClaimed) {
-            Log.w(TAG, "readReport() called but some other process currently owns the USB device");
             if (feature) {
                 return false;
             }
 
-            // For non-feature reports, fake that there's no data available if we aren't claimed.
-            // byte[] data;
-            // data = Arrays.copyOfRange(report, 0, res);
-            // mManager.HIDDeviceReportResponse(mDeviceId, data);
             return true;            
         }
 

--- a/android-project/app/src/main/java/org/libsdl/app/HIDDeviceUSB.java
+++ b/android-project/app/src/main/java/org/libsdl/app/HIDDeviceUSB.java
@@ -21,6 +21,7 @@ class HIDDeviceUSB implements HIDDevice {
     protected InputThread mInputThread;
     protected boolean mRunning;
     protected boolean mFrozen;
+    protected boolean mClaimed;
 
     public HIDDeviceUSB(HIDDeviceManager manager, UsbDevice usbDevice, int interface_index) {
         mManager = manager;
@@ -29,6 +30,7 @@ class HIDDeviceUSB implements HIDDevice {
         mInterface = mDevice.getInterface(mInterfaceIndex).getId();
         mDeviceId = manager.getDeviceIDForIdentifier(getIdentifier());
         mRunning = false;
+        mClaimed = false;
     }
 
     String getIdentifier() {
@@ -114,6 +116,7 @@ class HIDDeviceUSB implements HIDDevice {
             close();
             return false;
         }
+        mClaimed = true;
 
         // Find the endpoints
         for (int j = 0; j < iface.getEndpointCount(); j++) {
@@ -154,6 +157,11 @@ class HIDDeviceUSB implements HIDDevice {
     public int writeReport(byte[] report, boolean feature) {
         if (mConnection == null) {
             Log.w(TAG, "writeReport() called with no device connection");
+            return -1;
+        }
+
+        if (!mClaimed) {
+            Log.w(TAG, "writeReport() called but some other process currently owns the USB device");
             return -1;
         }
 
@@ -213,6 +221,18 @@ class HIDDeviceUSB implements HIDDevice {
             Log.w(TAG, "readReport() called with no device connection");
             return false;
         }
+        if (!mClaimed) {
+            Log.w(TAG, "readReport() called but some other process currently owns the USB device");
+            if (feature) {
+                return false;
+            }
+
+            // For non-feature reports, fake that there's no data available if we aren't claimed.
+            // byte[] data;
+            // data = Arrays.copyOfRange(report, 0, res);
+            // mManager.HIDDeviceReportResponse(mDeviceId, data);
+            return true;            
+        }
 
         if (report_number == 0x0) {
             /* Offset the return buffer by 1, so that the report ID
@@ -265,11 +285,12 @@ class HIDDeviceUSB implements HIDDevice {
             }
             mInputThread = null;
         }
-        if (mConnection != null) {
+        if (mConnection != null && mClaimed) {
             UsbInterface iface = mDevice.getInterface(mInterfaceIndex);
             mConnection.releaseInterface(iface);
             mConnection.close();
             mConnection = null;
+            mClaimed = false;
         }
     }
 
@@ -281,15 +302,24 @@ class HIDDeviceUSB implements HIDDevice {
 
     @Override
     public void setFrozen(boolean frozen) {
-        if (frozen != mFrozen && mConnection != null) {
+        mFrozen = frozen;
+
+        /* If we have a valid device connection and the claim state doesn't match what we want, try to correct that. */
+        if (mConnection != null && mClaimed == mFrozen) {
             UsbInterface iface = mDevice.getInterface(mInterfaceIndex);
             if (frozen) {
-                mConnection.releaseInterface(iface);
-            } else {
-                mConnection.claimInterface(iface, true);
+                mClaimed = !mConnection.releaseInterface(iface);
+                if (mClaimed) {
+                    Log.e(TAG, "Tried to release claim on USB device, but failed!");
+                }
+            }
+            else {
+                mClaimed = mConnection.claimInterface(iface, true);
+                if (!mClaimed) {
+                    Log.e(TAG, "Tried to regain claim on USB device, but failed!");
+                }
             }
         }
-        mFrozen = frozen;
     }
 
     protected class InputThread extends Thread {

--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -543,9 +543,6 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
         Log.v(TAG, "onPause()");
         super.onPause();
 
-        if (mHIDDeviceManager != null) {
-            mHIDDeviceManager.setFrozen(true);
-        }
         if (!mHasMultiWindow) {
             pauseNativeThread();
         }
@@ -556,9 +553,6 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
         Log.v(TAG, "onResume()");
         super.onResume();
 
-        if (mHIDDeviceManager != null) {
-            mHIDDeviceManager.setFrozen(false);
-        }
         if (!mHasMultiWindow) {
             resumeNativeThread();
         }
@@ -630,6 +624,10 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     public void onWindowFocusChanged(boolean hasFocus) {
         super.onWindowFocusChanged(hasFocus);
         Log.v(TAG, "onWindowFocusChanged(): " + hasFocus);
+
+        if (mHIDDeviceManager != null) {
+            mHIDDeviceManager.setFrozen(hasFocus);
+        }
 
         if (SDLActivity.mBrokenLibraries) {
            return;

--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -543,6 +543,10 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
         Log.v(TAG, "onPause()");
         super.onPause();
 
+        if (mHIDDeviceManager != null) {
+            mHIDDeviceManager.setFrozen(true);
+        }        
+
         if (!mHasMultiWindow) {
             pauseNativeThread();
         }
@@ -552,6 +556,10 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     protected void onResume() {
         Log.v(TAG, "onResume()");
         super.onResume();
+
+        if (mHIDDeviceManager != null) {
+            mHIDDeviceManager.setFrozen(false);
+        }        
 
         if (!mHasMultiWindow) {
             resumeNativeThread();
@@ -625,8 +633,12 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
         super.onWindowFocusChanged(hasFocus);
         Log.v(TAG, "onWindowFocusChanged(): " + hasFocus);
 
-        if (mHIDDeviceManager != null) {
-            mHIDDeviceManager.setFrozen(hasFocus);
+        // If we are gaining focus, we can always try to restore our USB devices. If we are losing focus,
+        // only try to relinquish them if we don't have background events allowed (for multi-window Android setups).
+        if (hasFocus || !SDLActivity.nativeGetHintBoolean("SDL_JOYSTICK_ALLOW_BACKGROUND_EVENTS", false)) {
+            if (mHIDDeviceManager != null) {
+                mHIDDeviceManager.setFrozen(!hasFocus);
+            }            
         }
 
         if (SDLActivity.mBrokenLibraries) {


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
As we just discovered, we do not release our claimed Android USB interfaces when backgrounded. Aside from this blocking the use of any controller we've claimed while we're running (but in the background), this also can mean that the device *never* recovers the controller if the app gets force-quit.

In addition, if the interface was not found to be valid, we never released it either.

So, make sure we release the interface when it's not valid, and also that we release it when being paused (and reclaim it when resumed).