### PR TITLE
Don't use the HIDAPI driver with Backbone One PlayStation Edition Gen 2

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_ps5.c
+++ b/src/joystick/hidapi/SDL_hidapi_ps5.c
@@ -298,6 +298,12 @@ static bool HIDAPI_DriverPS5_IsSupportedDevice(SDL_HIDAPI_Device *device, const 
     Uint8 data[USB_PACKET_LENGTH];
     int size;
 
+    if (vendor_id == USB_VENDOR_BACKBONE &&
+        product_id == USB_PRODUCT_BACKBONE_ONE_PS5_V2) {
+        // This product doesn't appear to use the DualSense protocol
+        return false;
+    }
+
     if (type == SDL_GAMEPAD_TYPE_PS5) {
         return true;
     }

--- a/src/joystick/usb_ids.h
+++ b/src/joystick/usb_ids.h
@@ -79,6 +79,7 @@
 #define USB_PRODUCT_ASTRO_C40_XBOX360                     0x0024
 #define USB_PRODUCT_BACKBONE_ONE_IOS                      0x0103
 #define USB_PRODUCT_BACKBONE_ONE_IOS_PS5                  0x0104
+#define USB_PRODUCT_BACKBONE_ONE_PS5_V2                   0x0304
 #define USB_PRODUCT_BDA_XB1_CLASSIC                       0x581a
 #define USB_PRODUCT_BDA_XB1_FIGHTPAD                      0x791a
 #define USB_PRODUCT_BDA_XB1_SPECTRA_PRO                   0x592a


### PR DESCRIPTION
This product doesn't appear to use the DualSense protocol. On Android this shows up as two interfaces that don't send reports that we can parse.

- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").