### PR TITLE
GPU: Return early in SDL_WaitForGPUFences if num_fences is 0

### DIFF
--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -3468,7 +3468,11 @@ bool SDL_WaitForGPUFences(
 {
     CHECK_DEVICE_MAGIC(device, false);
 
-    CHECK_PARAM(fences == NULL && num_fences > 0) {
+    if (!num_fences) {
+        return true;
+    }
+
+    CHECK_PARAM(fences == NULL) {
         SDL_InvalidParamError("fences");
         return false;
     }


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

If a user calls SDL_WaitForGPUFences with 0 fences, we should treat it as a no-op and return true immediately.

## Description
Previously, passing 0 fences bypassed the parameter check and reached the underlying driver implementations. On Vulkan backends, this triggered a validation error because vkWaitForFences requires fenceCount > 0.

```
Validation Error: [ VUID-vkWaitForFences-fenceCount-arraylength ] | MessageID = 0x5415e104
vkWaitForFences(): fenceCount must be greater than 0.
The Vulkan spec states: fenceCount must be greater than 0 (https://docs.vulkan.org/spec/latest/chapters/synchronization.html#VUID-vkWaitForFences-fenceCount-arraylength)  
```

Handling this gracefully at the SDL API layer ensures a more coherent and unified API behavior across all graphics backends, preventing backend-specific edge cases from leaking to the application layer.

Fixes Vulkan validation error: VUID-vkWaitForFences-fenceCount-arraylength

Thanks for the consideration :)