### PR TITLE
android.mk: introduce SDL3_sve2 static library adding -armv8-a+sve2

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,5 +1,45 @@
 LOCAL_PATH := $(call my-dir)
 
+SDL_PRIVATE_CFLAGS := \
+	-DGL_GLEXT_PROTOTYPES \
+	-Wall -Wextra \
+	-Wmissing-prototypes \
+	-Wunreachable-code-break \
+	-Wunneeded-internal-declaration \
+	-Wmissing-variable-declarations \
+	-Wfloat-conversion \
+	-Wshorten-64-to-32 \
+	-Wunreachable-code-return \
+	-Wshift-sign-overflow \
+	-Wstrict-prototypes \
+	-Wkeyword-macro \
+
+
+ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
+
+###########################
+#
+# SVE2 simd code (arm64-v8a only)
+#
+###########################
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := SDL3_sve2
+
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/include $(LOCAL_PATH)/include/build_config $(LOCAL_PATH)/src
+
+LOCAL_SRC_FILES := \
+	$(wildcard $(LOCAL_PATH)/src/video/arm/*.c)
+
+LOCAL_CFLAGS += \
+	$(SDL_PRIVATE_CFLAGS) \
+	-march=armv8-a+sve2 \
+
+include $(BUILD_STATIC_LIBRARY)
+
+endif
+
 ###########################
 #
 # SDL shared library
@@ -84,22 +124,10 @@ LOCAL_SRC_FILES := \
 	$(wildcard $(LOCAL_PATH)/src/tray/*.c) \
 	$(wildcard $(LOCAL_PATH)/src/video/*.c) \
 	$(wildcard $(LOCAL_PATH)/src/video/android/*.c) \
-	$(wildcard $(LOCAL_PATH)/src/video/arm/*.c) \
 	$(wildcard $(LOCAL_PATH)/src/video/yuv2rgb/*.c))
 
-LOCAL_CFLAGS += -DGL_GLEXT_PROTOTYPES
 LOCAL_CFLAGS += \
-	-Wall -Wextra \
-	-Wmissing-prototypes \
-	-Wunreachable-code-break \
-	-Wunneeded-internal-declaration \
-	-Wmissing-variable-declarations \
-	-Wfloat-conversion \
-	-Wshorten-64-to-32 \
-	-Wunreachable-code-return \
-	-Wshift-sign-overflow \
-	-Wstrict-prototypes \
-	-Wkeyword-macro \
+	$(SDL_PRIVATE_CFLAGS) \
 
 # Warnings we haven't fixed (yet)
 LOCAL_CFLAGS += -Wno-unused-parameter -Wno-sign-compare
@@ -112,6 +140,10 @@ LOCAL_LDFLAGS := -Wl,--no-undefined -Wl,--no-undefined-version -Wl,--version-scr
 
 ifeq ($(NDK_DEBUG),1)
     cmd-strip :=
+endif
+
+ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
+LOCAL_STATIC_LIBRARIES += SDL3_sve2
 endif
 
 include $(BUILD_SHARED_LIBRARY)

--- a/src/video/arm/SDL_sve2_extension.h
+++ b/src/video/arm/SDL_sve2_extension.h
@@ -22,30 +22,14 @@
 /*
  * IMPORTANT: Please do NOT include this header file directly or indirectly
  *            outside the src/video/arm folder.
- * 
+ *
  */
 
-#if !defined(SDL_SVE2_EXTENSION_H) //&& (defined(__ARM_FEATURE_SVE2) && __ARM_FEATURE_SVE2)
+#ifndef SDL_SVE2_EXTENSION_H
 #define SDL_SVE2_EXTENSION_H
 
 #include "SDL_sve2_util.h"
 
-/*
- * NOTE: Some Android builds didn't attach '-march=armv8-a+sve2' to 
- *       SDL_sve2_*.c and hence the macro __ARM_FEATURE_SVE is not
- *       defined by the compiler. This might not be a problem as the 
- *       SDL_TARGETING("arch=armv8-a+sve2") enables the feature for
- *       individual functions, until some version of compilers
- *       provides arm_sve.h raising errors then __ARM_FEATURE_SVE 
- *       is not defined. Although it should be avoided, as a 
- *       workaround, we have to define the __ARM_FEATURE_SVE here as 
- *       an ugly hack. 
- */
-#ifdef SDL_PLATFORM_ANDROID
-#ifndef __ARM_FEATURE_SVE
-#define __ARM_FEATURE_SVE 1
-#endif
-#endif
 #include <arm_sve.h>
 #include <stdint.h>
 

--- a/src/video/arm/SDL_sve2_swizzle.h
+++ b/src/video/arm/SDL_sve2_swizzle.h
@@ -22,10 +22,10 @@
 /*
  * IMPORTANT: Please do NOT include this header file directly or indirectly
  *            outside the src/video/arm folder.
- * 
+ *
  */
 
-#if !defined(SD_SVE2_SWIZZLE_H) //&& (defined(__ARM_FEATURE_SVE2) && __ARM_FEATURE_SVE2)
+#ifndef SD_SVE2_SWIZZLE_H
 #define SD_SVE2_SWIZZLE_H
 
 #include "SDL_sve2_extension.h"


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
The only purpose of SDL3_sve2 is to add the `-armv8-a+sve2` compile option.

I think we need to bump the required ndk version seriously.
I cannot build SDL3 using the CMake build system with ndk <=19 because of missing aaudio and camera types/macros/defines/...
I can build SDL3 using ndk 20 using the CMake build system, with disabled sve2 simd.
android.mk fails to build with ndk 20 because the compiler does not support `-march=armv8-a+sve2`.

ndk 21e builds fine.


## Existing Issue(s)
Fixes #15697
