### PR TITLE
docs: bump minimum required Android ndk version

### DIFF
--- a/docs/README-android.md
+++ b/docs/README-android.md
@@ -13,7 +13,7 @@ Requirements
 Android SDK (version 35 or later)
 https://developer.android.com/sdk/index.html
 
-Android NDK r15c or later
+Android NDK r28c or later
 https://developer.android.com/tools/sdk/ndk/index.html
 
 Minimum API level supported by SDL: 21 (Android 5.0)


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- The current minimum required ndk version cannot build SDL3 with aaudio and camera support
- sve2 support is incomplete in older ndk
- elf alignment is not properly configured out-of-the-box for older ndk versions

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #15697
Closes #15703