### PR TITLE
OpenVR: Actually quit correctly if we get a close/quit message.

### DIFF
--- a/src/video/openvr/SDL_openvrvideo.c
+++ b/src/video/openvr/SDL_openvrvideo.c
@@ -1487,7 +1487,7 @@ static void OPENVR_PumpEvents(SDL_VideoDevice *_this)
                 break;
             case EVREventType_VREvent_OverlayClosed:
             case EVREventType_VREvent_Quit:
-                SDL_Quit();
+                SDL_SendQuit();
                 break;
             }
         }


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
Hilariously, this PR is considerably longer than the change. However, for posterity:

`EVREventType_VREvent_OverlayClosed` and `EVREventType_VREvent_Quit` were being handled by calling `SDL_Quit`, which caused SDL to go away from underneath the application, but did not actually quit. Change it to call `SDL_SendQuit` instead.