### PR TITLE
render: an empty clip rect should clip all drawing

### DIFF
--- a/src/render/metal/SDL_render_metal.m
+++ b/src/render/metal/SDL_render_metal.m
@@ -1553,14 +1553,14 @@ static bool SetDrawState(SDL_Renderer *renderer, const SDL_RenderCommand *cmd, c
             METAL_GetOutputSize(renderer, &output.w, &output.h);
         }
 
-        if (SDL_GetRectIntersection(&output, &clip, &clip)) {
-            MTLScissorRect mtlrect;
-            mtlrect.x = clip.x;
-            mtlrect.y = clip.y;
-            mtlrect.width = clip.w;
-            mtlrect.height = clip.h;
-            [data.mtlcmdencoder setScissorRect:mtlrect];
-        }
+        SDL_GetRectIntersection(&output, &clip, &clip);
+
+        MTLScissorRect mtlrect;
+        mtlrect.x = clip.x;
+        mtlrect.y = clip.y;
+        mtlrect.width = clip.w;
+        mtlrect.height = clip.h;
+        [data.mtlcmdencoder setScissorRect:mtlrect];
 
         statecache->cliprect_dirty = false;
     }

--- a/test/testautomation_render.c
+++ b/test/testautomation_render.c
@@ -1362,6 +1362,20 @@ static int SDLCALL render_testClipRect(void *arg)
     compare(referenceSurface, ALLOWABLE_ERROR_OPAQUE);
 
     /*
+     * Verify that empty cliprect clips all drawing
+     */
+
+    /* Set the cliprect and do a fill operation */
+    cliprect.h = 0;
+    CHECK_FUNC(SDL_SetRenderClipRect, (renderer, &cliprect))
+    CHECK_FUNC(SDL_SetRenderDrawColor, (renderer, 255, 0, 0, SDL_ALPHA_OPAQUE))
+    CHECK_FUNC(SDL_RenderFillRect, (renderer, NULL))
+    CHECK_FUNC(SDL_SetRenderClipRect, (renderer, NULL))
+
+    /* Check to see if final image matches. */
+    compare(referenceSurface, ALLOWABLE_ERROR_OPAQUE);
+
+    /*
      * Verify that clear ignores the cliprect
      */
 


### PR DESCRIPTION
Added a test to validate this and fixed the Metal renderer

Fixes https://github.com/libsdl-org/SDL/issues/15434

- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").