### PR TITLE
stdinc: only use _Countof for SDL_arraysize when using a C standard > C23

### DIFF
--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -256,7 +256,8 @@ void *alloca(size_t);
 #define SDL_arraysize(array) (sizeof(array)/sizeof(array[0]))  /* or `_Countof(array)` on recent gcc and clang */
 
 #else
-#if !defined(__cplusplus) && ((defined(__GNUC__) && __GNUC__ >= 16) || SDL_HAS_EXTENSION(c_countof))
+#if !defined(__cplusplus) && ((defined(__GNUC__) && __GNUC__ >= 16) || SDL_HAS_EXTENSION(c_countof)) \
+    && (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202500L)
 #define SDL_arraysize(array) _Countof(array)
 #else
 #define SDL_arraysize(array) (sizeof(array)/sizeof(array[0]))


### PR DESCRIPTION
Building with `-pedantic` caused a warning to be emitted:
```
/home/maarten/projects/SDL/include/SDL3/SDL_stdinc.h:260:30: warning: ISO C does not support ‘_Countof’ before C2Y [-Wpedantic]
  260 | #define SDL_arraysize(array) _Countof(array)
      |                              ^~~~~~~~
```
Building with `-std=gnu2y` made the warning disappear, so require a higher `__STDC_VERSION__`.


- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
