### PR TITLE
ime: ibus: Remove the need of ibus headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2012,16 +2012,13 @@ elseif(UNIX AND NOT (APPLE OR RISCOS OR HAIKU OR CYGWIN))
       endif()
 
       if(SDL_IBUS)
-        pkg_search_module(IBUS ibus-1.0 ibus)
         find_path(HAVE_SYS_INOTIFY_H NAMES sys/inotify.h)
-        if(IBUS_FOUND AND HAVE_SYS_INOTIFY_H)
-          set(HAVE_IBUS_IBUS_H TRUE)
-          sdl_include_directories(PRIVATE SYSTEM ${IBUS_INCLUDE_DIRS})
+        if(HAVE_DBUS AND HAVE_SYS_INOTIFY_H)
           set(HAVE_IBUS TRUE)
         endif()
       endif()
 
-      if (HAVE_IBUS_IBUS_H OR HAVE_FCITX)
+      if (HAVE_IBUS OR HAVE_FCITX)
         set(SDL_USE_IME 1)
       endif()
 
@@ -2064,7 +2061,7 @@ elseif(UNIX AND NOT (APPLE OR RISCOS OR HAIKU OR CYGWIN))
       )
     endif()
 
-    if(HAVE_IBUS_IBUS_H)
+    if(HAVE_IBUS)
       sdl_sources(
         "${SDL3_SOURCE_DIR}/src/core/linux/SDL_ibus.c"
         "${SDL3_SOURCE_DIR}/src/core/linux/SDL_ibus.h"

--- a/include/build_config/SDL_build_config.h.cmake
+++ b/include/build_config/SDL_build_config.h.cmake
@@ -207,7 +207,7 @@
 
 #cmakedefine HAVE_DBUS_DBUS_H 1
 #cmakedefine HAVE_FCITX 1
-#cmakedefine HAVE_IBUS_IBUS_H 1
+#cmakedefine HAVE_IBUS 1
 #cmakedefine HAVE_INOTIFY_INIT1 1
 #cmakedefine HAVE_INOTIFY 1
 #cmakedefine HAVE_LIBUSB 1

--- a/src/core/linux/SDL_ibus.c
+++ b/src/core/linux/SDL_ibus.c
@@ -20,11 +20,8 @@
 */
 #include "SDL_internal.h"
 
-#ifdef HAVE_IBUS_IBUS_H
 #include "SDL_ibus.h"
 #include "SDL_dbus.h"
-
-#ifdef SDL_USE_LIBDBUS
 
 #include "../../video/SDL_sysvideo.h"
 #include "../../events/SDL_keyboard_c.h"
@@ -36,6 +33,7 @@
 #include <sys/inotify.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <limits.h>
 
 static const char IBUS_PATH[] = "/org/freedesktop/IBus";
 
@@ -737,7 +735,3 @@ void SDL_IBus_PumpEvents(void)
         }
     }
 }
-
-#endif // SDL_USE_LIBDBUS
-
-#endif

--- a/src/core/linux/SDL_ibus.h
+++ b/src/core/linux/SDL_ibus.h
@@ -24,9 +24,52 @@
 #ifndef SDL_ibus_h_
 #define SDL_ibus_h_
 
-#ifdef HAVE_IBUS_IBUS_H
+#ifdef HAVE_IBUS
 #define SDL_USE_IBUS 1
-#include <ibus.h>
+
+/* IBusModifierType and IBusCapabilite have been copied from ibustypes.h */
+
+typedef enum
+{
+    IBUS_SHIFT_MASK    = 1 << 0,
+    IBUS_LOCK_MASK     = 1 << 1,
+    IBUS_CONTROL_MASK  = 1 << 2,
+    IBUS_MOD1_MASK     = 1 << 3,
+    IBUS_MOD2_MASK     = 1 << 4,
+    IBUS_MOD3_MASK     = 1 << 5,
+    IBUS_MOD4_MASK     = 1 << 6,
+    IBUS_MOD5_MASK     = 1 << 7,
+    IBUS_BUTTON1_MASK  = 1 << 8,
+    IBUS_BUTTON2_MASK  = 1 << 9,
+    IBUS_BUTTON3_MASK  = 1 << 10,
+    IBUS_BUTTON4_MASK  = 1 << 11,
+    IBUS_BUTTON5_MASK  = 1 << 12,
+
+    /* ibus mask */
+    IBUS_HANDLED_MASK  = 1 << 24,
+    IBUS_FORWARD_MASK  = 1 << 25,
+    IBUS_IGNORED_MASK  = IBUS_FORWARD_MASK,
+
+    IBUS_SUPER_MASK    = 1 << 26,
+    IBUS_HYPER_MASK    = 1 << 27,
+    IBUS_META_MASK     = 1 << 28,
+
+    IBUS_RELEASE_MASK  = 1 << 30,
+
+    IBUS_MODIFIER_MASK = 0x5f001fff
+} IBusModifierType;
+
+typedef enum {
+    IBUS_CAP_PREEDIT_TEXT       = 1 << 0,
+    IBUS_CAP_AUXILIARY_TEXT     = 1 << 1,
+    IBUS_CAP_LOOKUP_TABLE       = 1 << 2,
+    IBUS_CAP_FOCUS              = 1 << 3,
+    IBUS_CAP_PROPERTY           = 1 << 4,
+    IBUS_CAP_SURROUNDING_TEXT   = 1 << 5,
+    IBUS_CAP_OSK                = 1 << 6,
+    IBUS_CAP_SYNC_PROCESS_KEY   = 1 << 7,
+    IBUS_CAP_SYNC_PROCESS_KEY_V2 = IBUS_CAP_SYNC_PROCESS_KEY,
+} IBusCapabilite;
 
 extern bool SDL_IBus_Init(void);
 extern void SDL_IBus_Quit(void);
@@ -50,6 +93,6 @@ extern void SDL_IBus_UpdateTextInputArea(SDL_Window *window);
    SDL_SendEditingText for each event it finds */
 extern void SDL_IBus_PumpEvents(void);
 
-#endif // HAVE_IBUS_IBUS_H
+#endif // HAVE_IBUS
 
 #endif // SDL_ibus_h_

--- a/src/core/linux/SDL_ime.c
+++ b/src/core/linux/SDL_ime.c
@@ -70,7 +70,7 @@ static void InitIME(void)
 #endif // HAVE_FCITX
 
     // default to IBus
-#ifdef HAVE_IBUS_IBUS_H
+#ifdef HAVE_IBUS
     if (!SDL_IME_Init_Real) {
         SDL_IME_Init_Real = SDL_IBus_Init;
         SDL_IME_Quit_Real = SDL_IBus_Quit;
@@ -80,7 +80,7 @@ static void InitIME(void)
         SDL_IME_UpdateTextInputArea_Real = SDL_IBus_UpdateTextInputArea;
         SDL_IME_PumpEvents_Real = SDL_IBus_PumpEvents;
     }
-#endif // HAVE_IBUS_IBUS_H
+#endif // HAVE_IBUS
 }
 
 bool SDL_IME_Init(void)


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
Hello, SDL only uses some defines from IBusModifierType and IBusCapabilite, make a copy of them so that distros can build with SDL_IBUS=ON without ibus installed.
