### PR TITLE
Fix web joystick vibration (again)

### DIFF
--- a/src/joystick/emscripten/SDL_sysjoystick.c
+++ b/src/joystick/emscripten/SDL_sysjoystick.c
@@ -506,7 +506,7 @@ static bool EMSCRIPTEN_JoystickOpen(SDL_Joystick *joystick, int device_index)
 
     item->rumble_available = MAIN_THREAD_EM_ASM_INT({
         let gamepad = navigator['getGamepads']()[$0];
-        return gamepad && gamepad['vibrationActuator']; // Don't check the vibrationActuator.effects array here, because it's not defined in Safari
+        return gamepad && 'vibrationActuator' in gamepad; // Don't check the vibrationActuator.effects array here, because it's not defined in Safari
         }, item->index);
 
     if (item->rumble_available) {
@@ -516,7 +516,7 @@ static bool EMSCRIPTEN_JoystickOpen(SDL_Joystick *joystick, int device_index)
     item->trigger_rumble_available = MAIN_THREAD_EM_ASM_INT({
         let gamepad = navigator['getGamepads']()[$0];
         // This effect is not supported in Safari, so it's okay for us to check the vibrationActuator.effects array here for the browsers that do support it
-        return gamepad && gamepad['vibrationActuator'] && gamepad['vibrationActuator']['effects'] && gamepad['vibrationActuator']['effects']['includes']('trigger-rumble');
+        return gamepad && 'vibrationActuator' in gamepad && 'effects' in gamepad['vibrationActuator'] && gamepad['vibrationActuator']['effects']['includes']('trigger-rumble');
         }, item->index);
 
     if (item->trigger_rumble_available) {


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
Regression from https://github.com/libsdl-org/SDL/pull/15633
`gamepad && gamepad['vibrationActuator']` returns an object that Emscripten can't turn into an integer, so it always returned `0`.
This PR fixes this issue. :D

(This PR also needs testing on Safari 😅 )

## Existing Issue(s)
None.