### PR TITLE
Fix no static method found on Android

### DIFF
--- a/android-project/app/proguard-rules.pro
+++ b/android-project/app/proguard-rules.pro
@@ -45,6 +45,7 @@
     boolean setSystemCursor(int);
     void setWindowStyle(boolean);
     boolean shouldMinimizeOnFocusLoss();
+    boolean showFileDialog(java.lang.String[], boolean, boolean, int);
     boolean showTextInput(int, int, int, int, int);
     boolean supportsRelativeMouse();
     int openFileDescriptor(java.lang.String, java.lang.String);


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

This PR fixes java.lang.NoSuchMethodError: no static method "Lorg/libsdl/app/SDLActivity;.showFileDialog([Ljava/lang/String;ZZI)Z" error on release build for Android.
