### PR TITLE
Enable extra player LED sets for PS5 Controllers

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_ps5.c
+++ b/src/joystick/hidapi/SDL_hidapi_ps5.c
@@ -358,7 +358,9 @@ static void SetLightsForPlayerIndex(DS5EffectsState_t *effects, int player_index
         0x0A,
         0x15,
         0x1B,
-        0x1F
+        0x1F,
+        0x11,
+        0x0E
     };
 
     if (player_index >= 0) {


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Adds the 2 missing player LED patterns supported by the PS5 DualSense controller

## Description
I'm running an app using SDL where I support 6 controllers. It'd be nice to give visual feedback to our users using the player LEDs which slot they're in. For Switch controllers, this works as the API switches to a semi binary representation for the 4 LEDs above player index 4. The PS5 controllers stopped at a max of 5 for player index, even though the PS5 controller has 7 supported light patterns. This PR adds the 2 extra light patterns (10001 and 01110) as players 6 and 7. 
