### PR TITLE
hints: Add SDL_HINT_CREATE_SURFACE_CLEAR.

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -703,6 +703,29 @@ extern "C" {
 #define SDL_HINT_CPU_FEATURE_MASK "SDL_CPU_FEATURE_MASK"
 
 /**
+ * A variable that decides whether SDL_CreateSurface() clears pixels.
+ *
+ * By default, SDL_CreateSurface() will clear the newly-created surface by
+ * setting all bytes of its `pixels` buffer to zero; for many formats this
+ * clears the surface black, as a reasonable default.
+ *
+ * However, clearing the surface is wasted effort if the app plans to
+ * initialize the entire surface immediately after creation. Disabling this
+ * hint leaves the newly-allocated buffer of pixels uninitialized, and the
+ * app will be responsible for setting every pixel before its first use.
+ *
+ * The variable can be set to the following values:
+ *
+ * - "0": Surface pixels will _not_ be initialized during creation.
+ * - "1": Surface pixels will be zeroed during creation. (default)
+ *
+ * This hint can be set anytime, affecting later calls to SDL_CreateSurface().
+ *
+ * \since This hint is available since SDL 3.6.0.
+ */
+#define SDL_HINT_CREATE_SURFACE_CLEAR "SDL_CREATE_SURFACE_CLEAR"
+
+/**
  * A variable controlling whether DirectInput should be used for controllers.
  *
  * The variable can be set to the following values:

--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -703,10 +703,10 @@ extern "C" {
 #define SDL_HINT_CPU_FEATURE_MASK "SDL_CPU_FEATURE_MASK"
 
 /**
- * A variable that decides whether SDL_CreateSurface() clears pixels.
+ * A variable that decides whether SDL_CreateSurface() zeroes pixels.
  *
  * By default, SDL_CreateSurface() will clear the newly-created surface by
- * setting all bytes of its `pixels` buffer to zero; for many formats this
+ * setting all bytes in its `pixels` buffer to zero; for many formats this
  * clears the surface black, as a reasonable default.
  *
  * However, clearing the surface is wasted effort if the app plans to
@@ -723,7 +723,7 @@ extern "C" {
  *
  * \since This hint is available since SDL 3.6.0.
  */
-#define SDL_HINT_CREATE_SURFACE_CLEAR "SDL_CREATE_SURFACE_CLEAR"
+#define SDL_HINT_CREATE_SURFACE_ZEROED "SDL_CREATE_SURFACE_ZEROED"
 
 /**
  * A variable controlling whether DirectInput should be used for controllers.

--- a/src/video/SDL_surface.c
+++ b/src/video/SDL_surface.c
@@ -46,12 +46,12 @@ static char SDL_surface_magic;
 // Some hint callbacks.
 
 static SDL_InitState create_surface_hints_init;
-static bool create_surface_clear_hint = true;  // tracks SDL_HINT_CREATE_SURFACE_CLEAR state.
+static bool create_surface_zeroed_hint = true;  // tracks SDL_HINT_CREATE_SURFACE_ZEROED state.
 static bool create_surface_malloc_hint = false;  // tracks "SDL_SURFACE_MALLOC" state.
 
 static void SDLCALL SDL_SurfaceClearHintWatcher(void *userdata, const char *name, const char *oldValue, const char *newValue)
 {
-    create_surface_clear_hint = SDL_GetStringBoolean(newValue, true);
+    create_surface_zeroed_hint = SDL_GetStringBoolean(newValue, true);
 }
 
 static void SDLCALL SDL_SurfaceMallocHintWatcher(void *userdata, const char *name, const char *oldValue, const char *newValue)
@@ -64,7 +64,7 @@ static void SDLCALL SDL_SurfaceMallocHintWatcher(void *userdata, const char *nam
 void SDL_QuitSurfaceHints(void)
 {
     if (SDL_ShouldQuit(&create_surface_hints_init)) {
-        SDL_RemoveHintCallback(SDL_HINT_CREATE_SURFACE_CLEAR, SDL_SurfaceClearHintWatcher, NULL);
+        SDL_RemoveHintCallback(SDL_HINT_CREATE_SURFACE_ZEROED, SDL_SurfaceClearHintWatcher, NULL);
         SDL_RemoveHintCallback("SDL_SURFACE_MALLOC", SDL_SurfaceMallocHintWatcher, NULL);
         SDL_SetInitialized(&create_surface_hints_init, false);
     }
@@ -256,12 +256,12 @@ SDL_Surface *SDL_CreateSurface(int width, int height, SDL_PixelFormat format)
 
     if (surface->w && surface->h && format != SDL_PIXELFORMAT_MJPG) {
         if (SDL_ShouldInit(&create_surface_hints_init)) {
-            SDL_AddHintCallback(SDL_HINT_CREATE_SURFACE_CLEAR, SDL_SurfaceClearHintWatcher, NULL);
+            SDL_AddHintCallback(SDL_HINT_CREATE_SURFACE_ZEROED, SDL_SurfaceClearHintWatcher, NULL);
             SDL_AddHintCallback("SDL_SURFACE_MALLOC", SDL_SurfaceMallocHintWatcher, NULL);
             SDL_SetInitialized(&create_surface_hints_init, true);
         }
 
-        bool must_clear = create_surface_clear_hint;  // SDL_HINT_CREATE_SURFACE_CLEAR, tracked by callback.
+        bool must_clear = create_surface_zeroed_hint;  // SDL_HINT_CREATE_SURFACE_ZEROED, tracked by callback.
         surface->flags &= ~SDL_SURFACE_PREALLOCATED;
         if (create_surface_malloc_hint) {  // "SDL_SURFACE_MALLOC" hint, tracked by callback.
             if (must_clear) {

--- a/src/video/SDL_surface.c
+++ b/src/video/SDL_surface.c
@@ -51,22 +51,22 @@ static bool SDL_create_surface_malloc_hint = false;  // tracks "SDL_SURFACE_MALL
 
 static void SDLCALL SDL_CreateSurfaceZeroedChanged(void *userdata, const char *name, const char *oldValue, const char *newValue)
 {
-    create_surface_zeroed_hint = SDL_GetStringBoolean(newValue, true);
+    SDL_create_surface_zeroed_hint = SDL_GetStringBoolean(newValue, true);
 }
 
 static void SDLCALL SDL_SurfaceMallocChanged(void *userdata, const char *name, const char *oldValue, const char *newValue)
 {
-    create_surface_malloc_hint = SDL_GetStringBoolean(newValue, false);
+    SDL_create_surface_malloc_hint = SDL_GetStringBoolean(newValue, false);
 }
 
 // Public routines
 
 void SDL_QuitSurfaceHints(void)
 {
-    if (SDL_ShouldQuit(&create_surface_hints_init)) {
-        SDL_RemoveHintCallback(SDL_HINT_CREATE_SURFACE_ZEROED, SDL_SurfaceClearHintWatcher, NULL);
-        SDL_RemoveHintCallback("SDL_SURFACE_MALLOC", SDL_SurfaceMallocHintWatcher, NULL);
-        SDL_SetInitialized(&create_surface_hints_init, false);
+    if (SDL_ShouldQuit(&SDL_create_surface_hints_init)) {
+        SDL_RemoveHintCallback(SDL_HINT_CREATE_SURFACE_ZEROED, SDL_CreateSurfaceZeroedChanged, NULL);
+        SDL_RemoveHintCallback("SDL_SURFACE_MALLOC", SDL_SurfaceMallocChanged, NULL);
+        SDL_SetInitialized(&SDL_create_surface_hints_init, false);
     }
 }
 
@@ -255,15 +255,15 @@ SDL_Surface *SDL_CreateSurface(int width, int height, SDL_PixelFormat format)
     }
 
     if (surface->w && surface->h && format != SDL_PIXELFORMAT_MJPG) {
-        if (SDL_ShouldInit(&create_surface_hints_init)) {
-            SDL_AddHintCallback(SDL_HINT_CREATE_SURFACE_ZEROED, SDL_SurfaceClearHintWatcher, NULL);
-            SDL_AddHintCallback("SDL_SURFACE_MALLOC", SDL_SurfaceMallocHintWatcher, NULL);
-            SDL_SetInitialized(&create_surface_hints_init, true);
+        if (SDL_ShouldInit(&SDL_create_surface_hints_init)) {
+            SDL_AddHintCallback(SDL_HINT_CREATE_SURFACE_ZEROED, SDL_CreateSurfaceZeroedChanged, NULL);
+            SDL_AddHintCallback("SDL_SURFACE_MALLOC", SDL_SurfaceMallocChanged, NULL);
+            SDL_SetInitialized(&SDL_create_surface_hints_init, true);
         }
 
-        bool clear_surface = create_surface_zeroed_hint;  // SDL_HINT_CREATE_SURFACE_ZEROED, tracked by callback.
+        bool clear_surface = SDL_create_surface_zeroed_hint;  // SDL_HINT_CREATE_SURFACE_ZEROED, tracked by callback.
         surface->flags &= ~SDL_SURFACE_PREALLOCATED;
-        if (create_surface_malloc_hint) {  // "SDL_SURFACE_MALLOC" hint, tracked by callback.
+        if (SDL_create_surface_malloc_hint) {  // "SDL_SURFACE_MALLOC" hint, tracked by callback.
             if (clear_surface) {
                 surface->pixels = SDL_calloc(1, size);
                 clear_surface = false;  // SDL_calloc already did it, don't memset again, below.

--- a/src/video/SDL_surface.c
+++ b/src/video/SDL_surface.c
@@ -261,12 +261,12 @@ SDL_Surface *SDL_CreateSurface(int width, int height, SDL_PixelFormat format)
             SDL_SetInitialized(&create_surface_hints_init, true);
         }
 
-        bool must_clear = create_surface_zeroed_hint;  // SDL_HINT_CREATE_SURFACE_ZEROED, tracked by callback.
+        bool clear_surface = create_surface_zeroed_hint;  // SDL_HINT_CREATE_SURFACE_ZEROED, tracked by callback.
         surface->flags &= ~SDL_SURFACE_PREALLOCATED;
         if (create_surface_malloc_hint) {  // "SDL_SURFACE_MALLOC" hint, tracked by callback.
-            if (must_clear) {
+            if (clear_surface) {
                 surface->pixels = SDL_calloc(1, size);
-                must_clear = false;  // SDL_calloc already did it, don't memset again, below.
+                clear_surface = false;  // SDL_calloc already did it, don't memset again, below.
             } else {
                 surface->pixels = SDL_malloc(size);
             }
@@ -278,7 +278,7 @@ SDL_Surface *SDL_CreateSurface(int width, int height, SDL_PixelFormat format)
             SDL_DestroySurface(surface);
             return NULL;
         }
-        if (must_clear) {
+        if (clear_surface) {
             SDL_memset(surface->pixels, 0, size);
         }
     }

--- a/src/video/SDL_surface.c
+++ b/src/video/SDL_surface.c
@@ -45,16 +45,16 @@ static char SDL_surface_magic;
 
 // Some hint callbacks.
 
-static SDL_InitState create_surface_hints_init;
-static bool create_surface_zeroed_hint = true;  // tracks SDL_HINT_CREATE_SURFACE_ZEROED state.
-static bool create_surface_malloc_hint = false;  // tracks "SDL_SURFACE_MALLOC" state.
+static SDL_InitState SDL_create_surface_hints_init;
+static bool SDL_create_surface_zeroed_hint = true;  // tracks SDL_HINT_CREATE_SURFACE_ZEROED state.
+static bool SDL_create_surface_malloc_hint = false;  // tracks "SDL_SURFACE_MALLOC" state.
 
-static void SDLCALL SDL_SurfaceClearHintWatcher(void *userdata, const char *name, const char *oldValue, const char *newValue)
+static void SDLCALL SDL_CreateSurfaceZeroedChanged(void *userdata, const char *name, const char *oldValue, const char *newValue)
 {
     create_surface_zeroed_hint = SDL_GetStringBoolean(newValue, true);
 }
 
-static void SDLCALL SDL_SurfaceMallocHintWatcher(void *userdata, const char *name, const char *oldValue, const char *newValue)
+static void SDLCALL SDL_SurfaceMallocChanged(void *userdata, const char *name, const char *oldValue, const char *newValue)
 {
     create_surface_malloc_hint = SDL_GetStringBoolean(newValue, false);
 }

--- a/src/video/SDL_surface.c
+++ b/src/video/SDL_surface.c
@@ -228,9 +228,15 @@ SDL_Surface *SDL_CreateSurface(int width, int height, SDL_PixelFormat format)
     }
 
     if (surface->w && surface->h && format != SDL_PIXELFORMAT_MJPG) {
+        bool must_clear = SDL_GetHintBoolean(SDL_HINT_CREATE_SURFACE_CLEAR, true);
         surface->flags &= ~SDL_SURFACE_PREALLOCATED;
         if (SDL_GetHintBoolean("SDL_SURFACE_MALLOC", false)) {
-            surface->pixels = SDL_malloc(size);
+            if (must_clear) {
+                surface->pixels = SDL_calloc(1, size);
+                must_clear = false;  // SDL_calloc already did it, don't memset again, below.
+            } else {
+                surface->pixels = SDL_malloc(size);
+            }
         } else {
             surface->flags |= SDL_SURFACE_SIMD_ALIGNED;
             surface->pixels = SDL_aligned_alloc(SDL_GetSIMDAlignment(), size);
@@ -239,9 +245,9 @@ SDL_Surface *SDL_CreateSurface(int width, int height, SDL_PixelFormat format)
             SDL_DestroySurface(surface);
             return NULL;
         }
-
-        // This is important for bitmaps
-        SDL_memset(surface->pixels, 0, size);
+        if (must_clear) {
+            SDL_memset(surface->pixels, 0, size);
+        }
     }
     return surface;
 }

--- a/src/video/SDL_surface.c
+++ b/src/video/SDL_surface.c
@@ -28,6 +28,7 @@
 #include "SDL_stb_c.h"
 #include "SDL_yuv_c.h"
 #include "../render/SDL_sysrender.h"
+#include "../SDL_hints_c.h"
 
 #include "SDL_surface_c.h"
 
@@ -41,7 +42,33 @@ SDL_COMPILE_TIME_ASSERT(can_indicate_overflow, SDL_SIZE_MAX > SDL_MAX_SINT32);
 // Magic!
 static char SDL_surface_magic;
 
+
+// Some hint callbacks.
+
+static SDL_InitState create_surface_hints_init;
+static bool create_surface_clear_hint = true;  // tracks SDL_HINT_CREATE_SURFACE_CLEAR state.
+static bool create_surface_malloc_hint = false;  // tracks "SDL_SURFACE_MALLOC" state.
+
+static void SDLCALL SDL_SurfaceClearHintWatcher(void *userdata, const char *name, const char *oldValue, const char *newValue)
+{
+    create_surface_clear_hint = SDL_GetStringBoolean(newValue, true);
+}
+
+static void SDLCALL SDL_SurfaceMallocHintWatcher(void *userdata, const char *name, const char *oldValue, const char *newValue)
+{
+    create_surface_malloc_hint = SDL_GetStringBoolean(newValue, false);
+}
+
 // Public routines
+
+void SDL_QuitSurfaceHints(void)
+{
+    if (SDL_ShouldQuit(&create_surface_hints_init)) {
+        SDL_RemoveHintCallback(SDL_HINT_CREATE_SURFACE_CLEAR, SDL_SurfaceClearHintWatcher, NULL);
+        SDL_RemoveHintCallback("SDL_SURFACE_MALLOC", SDL_SurfaceMallocHintWatcher, NULL);
+        SDL_SetInitialized(&create_surface_hints_init, false);
+    }
+}
 
 bool SDL_SurfaceValid(SDL_Surface *surface)
 {
@@ -228,9 +255,15 @@ SDL_Surface *SDL_CreateSurface(int width, int height, SDL_PixelFormat format)
     }
 
     if (surface->w && surface->h && format != SDL_PIXELFORMAT_MJPG) {
-        bool must_clear = SDL_GetHintBoolean(SDL_HINT_CREATE_SURFACE_CLEAR, true);
+        if (SDL_ShouldInit(&create_surface_hints_init)) {
+            SDL_AddHintCallback(SDL_HINT_CREATE_SURFACE_CLEAR, SDL_SurfaceClearHintWatcher, NULL);
+            SDL_AddHintCallback("SDL_SURFACE_MALLOC", SDL_SurfaceMallocHintWatcher, NULL);
+            SDL_SetInitialized(&create_surface_hints_init, true);
+        }
+
+        bool must_clear = create_surface_clear_hint;  // SDL_HINT_CREATE_SURFACE_CLEAR, tracked by callback.
         surface->flags &= ~SDL_SURFACE_PREALLOCATED;
-        if (SDL_GetHintBoolean("SDL_SURFACE_MALLOC", false)) {
+        if (create_surface_malloc_hint) {  // "SDL_SURFACE_MALLOC" hint, tracked by callback.
             if (must_clear) {
                 surface->pixels = SDL_calloc(1, size);
                 must_clear = false;  // SDL_calloc already did it, don't memset again, below.

--- a/src/video/SDL_surface_c.h
+++ b/src/video/SDL_surface_c.h
@@ -96,5 +96,6 @@ extern SDL_Surface *SDL_ConvertSurfaceRect(SDL_Surface *surface, const SDL_Rect 
 extern bool SDL_IsBMP(SDL_IOStream *src);
 extern bool SDL_IsJPG(SDL_IOStream *src);
 extern bool SDL_IsPNG(SDL_IOStream *src);
+extern void SDL_QuitSurfaceHints(void);
 
 #endif // SDL_surface_c_h_

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -4674,6 +4674,7 @@ void SDL_VideoQuit(void)
     SDL_QuitMouse();
     SDL_QuitKeyboard();
     SDL_QuitSubSystem(SDL_INIT_EVENTS);
+    SDL_QuitSurfaceHints();
 
     SDL_EnableScreenSaver();
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

This also tries to use SDL_calloc instead of SDL_malloc in the no-SIMD-align path, in case the system offers a faster way to obtain zero'd bytes through calloc.

Fixes #15715.
Closes #15736.

