### PR TITLE
ci: ignore artifact upload errors

### DIFF
--- a/.github/workflows/generic.yml
+++ b/.github/workflows/generic.yml
@@ -431,6 +431,7 @@ jobs:
           find ./ -iname '*.so' | xargs -L1 ./build-scripts/check_elf_alignment.sh
       - name: 'Upload binary package'
         uses: actions/upload-artifact@v7
+        continue-on-error: true
         if: ${{ always() && matrix.platform.artifact != '' && (steps.package.outcome == 'success' || steps.cpactions.outcome == 'success') && (matrix.platform.enable-artifacts || steps.tests.outcome == 'failure') }}
         with:
           if-no-files-found: error
@@ -440,6 +441,7 @@ jobs:
             build/include*
       - name: 'Upload minidumps'
         uses: actions/upload-artifact@v7
+        continue-on-error: true
         if: ${{ always() && steps.tests.outcome == 'failure' && (matrix.platform.platform == 'msvc' || matrix.platform.platform == 'msys2') }}
         with:
           if-no-files-found: ignore
@@ -447,6 +449,7 @@ jobs:
           path: build/**/*.dmp
       - name: "Upload Android test apk's"
         uses: actions/upload-artifact@v7
+        continue-on-error: true
         if: ${{ matrix.platform.enable-artifacts && always() && matrix.platform.artifact != '' && steps.apks.outcome == 'success' }}
         with:
           if-no-files-found: error


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
It saves us from checking the ci logs when GitHub actions experiences a transient error.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
