### PR TITLE
Report SDL_TOUCH_MOUSEID when events come from trackpad in Wayland

### DIFF
--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -1046,7 +1046,7 @@ void SDL_SendMouseWheel(Uint64 timestamp, SDL_Window *window, SDL_MouseID mouseI
     if (SDL_EventEnabled(SDL_EVENT_MOUSE_WHEEL)) {
         float integer_x, integer_y;
 
-        if (!mouse->relative_mode || mouse->warp_emulation_active) {
+        if ((!mouse->relative_mode || mouse->warp_emulation_active) && mouseID != SDL_TOUCH_MOUSEID && mouseID != SDL_PEN_MOUSEID) {
             // We're not in relative mode, so all mouse events are global mouse events
             mouseID = SDL_GLOBAL_MOUSE_ID;
         }

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -1288,8 +1288,13 @@ static void pointer_dispatch_axis(SDL_WaylandSeat *seat)
         break;
     }
 
+    SDL_MouseID pointer_id = seat->pointer.sdl_id;
+    if (seat->pointer.pending_frame.axis.source == SDL_WAYLAND_AXIS_SOURCE_FINGER) {
+        pointer_id = SDL_TOUCH_MOUSEID;
+    }
+
     SDL_SendMouseWheel(seat->pointer.pending_frame.timestamp_ns,
-                       seat->pointer.focus->sdlwindow, seat->pointer.sdl_id, x, y, direction);
+                       seat->pointer.focus->sdlwindow, pointer_id, x, y, direction);
 }
 
 static void pointer_handle_frame(void *data, struct wl_pointer *pointer)
@@ -1352,13 +1357,17 @@ static void pointer_handle_frame(void *data, struct wl_pointer *pointer)
 static void pointer_handle_axis_source(void *data, struct wl_pointer *pointer,
                                        uint32_t axis_source)
 {
-    // unimplemented
+    SDL_WaylandSeat *seat = data;
+    seat->pointer.pending_frame.have_axis = true;
+    seat->pointer.pending_frame.axis.source = axis_source;
 }
 
 static void pointer_handle_axis_stop(void *data, struct wl_pointer *pointer,
                                      uint32_t time, uint32_t axis)
 {
-    // unimplemented
+    SDL_WaylandSeat *seat = data;
+    seat->pointer.pending_frame.have_axis = true;
+    seat->pointer.pending_frame.axis.released = true;
 }
 
 static void pointer_handle_axis_discrete(void *data, struct wl_pointer *pointer,

--- a/src/video/wayland/SDL_waylandevents_c.h
+++ b/src/video/wayland/SDL_waylandevents_c.h
@@ -39,6 +39,14 @@ enum SDL_WaylandAxisEvent
     SDL_WAYLAND_AXIS_EVENT_VALUE120
 };
 
+enum SDL_WaylandAxisSource
+{
+    SDL_WAYLAND_AXIS_SOURCE_WHEEL = 0,
+    SDL_WAYLAND_AXIS_SOURCE_FINGER = 1,
+    SDL_WAYLAND_AXIS_SOURCE_CONTINUOUS = 2,
+    SDL_WAYLAND_AXIS_SOURCE_WHEEL_TILT = 3,
+};
+
 typedef struct
 {
     Sint32 repeat_rate;     // Repeat rate in range of [1, 1000] character(s) per second
@@ -235,6 +243,8 @@ typedef struct SDL_WaylandSeat
                 float y;
 
                 SDL_MouseWheelDirection direction;
+                enum SDL_WaylandAxisSource source;
+                bool released;
             } axis;
 
             struct wl_surface *enter_surface;


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Implemented Wayland callbacks to track when a scroll event happened from a touch device.

## Description
When a developer can tell if the scroll event comes from a touch device, she can move the zoom feature  to happen with the pinch gesture, and use the scroll event for panning the view.

When events look the same, the developer needs to choose between:
- Using scroll event for scroll/panning the view, but in this case the mouse experience would be much inferior.
- Using scroll event for zoom, which would be best for mouse, and would also work well for the touchpad, but wouldn't profit as much from the touchpad capabilities.

## Existing Issue(s)

Maybe related: https://github.com/libsdl-org/SDL/issues/5066
Maybe related: https://github.com/libsdl-org/SDL/issues/7690

These commits had some related changes, but weren't intended as a feature at the time. It was a workaround for a separate issue in macOS, so may be relevant: 
- https://github.com/libsdl-org/SDL/commit/d2d06f444393c8e35fc8b7d20c4931620236556b
- https://github.com/libsdl-org/SDL/commit/e841b066fd76aa1eb7cf2be9a46cc82798ab3c33
- https://github.com/libsdl-org/SDL/issues/3303
Maybe it makes sense to bring a fraction of those changes.

