### PR TITLE
SDL_GetRenderOutputSize -> SDL_GetCurrentRenderOutputSIze

### DIFF
--- a/docs/hello.c
+++ b/docs/hello.c
@@ -46,7 +46,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
     const float scale = 4.0f;
 
     /* Center the message and scale it up */
-    SDL_GetRenderOutputSize(renderer, &w, &h);
+    SDL_GetCurrentRenderOutputSize(renderer, &w, &h);
     SDL_SetRenderScale(renderer, scale, scale);
     x = ((w / scale) - SDL_DEBUG_TEXT_FONT_CHARACTER_SIZE * SDL_strlen(message)) / 2;
     y = ((h / scale) - SDL_DEBUG_TEXT_FONT_CHARACTER_SIZE) / 2;


### PR DESCRIPTION
SDL_GetRenderOutput size is old

- [ ] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
