### PR TITLE
Detect pinch gesture in web target

### DIFF
--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -342,6 +342,21 @@ static EM_BOOL Emscripten_HandleWheel(int eventType, const EmscriptenWheelEvent 
         break;
     }
 
+    if (wheelEvent->mouse.ctrlKey && SDL_EventEnabled(SDL_EVENT_PINCH_UPDATE)) {
+        // Browsers emit "wheel" event with "ctrlKey" flag active when the user does a pinch gesture.
+
+        // makes touch and wheel zoom events match better
+        double scale = SDL_sqrt(deltaY > 0 ? deltaY : -deltaY); 
+        if (deltaY < 0) { scale *= -1.0; }
+        scale = SDL_pow(0.885, scale);
+
+        // We send all events as web target doesn't accumulate scale value like desktop targets.
+        SDL_SendPinch(SDL_EVENT_PINCH_BEGIN, 0, window_data->window, 0);
+        SDL_SendPinch(SDL_EVENT_PINCH_UPDATE, 0, window_data->window, scale);
+        SDL_SendPinch(SDL_EVENT_PINCH_END, 0, window_data->window, 0);
+        return true;
+    }
+
     SDL_SendMouseWheel(0, window_data->window, SDL_DEFAULT_MOUSE_ID, deltaX, -deltaY, SDL_MOUSEWHEEL_NORMAL);
     return SDL_EventEnabled(SDL_EVENT_MOUSE_WHEEL);
 }


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Use event.ctrlKey state to find if the user is doing a pinch gesture.

## Description
Browsers don't have an explicit pinch/zoom gesture event, but they emit wheel events with ctrlKey flag set to true when the user does a pinch/zoom gesture.

I detect this flag, and emit a pinch event instead of wheel event. This has the downside where actual ctrl+wheel actions would look the same.

Doing ctrl+ mouse wheel emits scroll events with huge number values. I made a simple heuristic to make the pinch/zoom feature feel more or less proportional when triggered by either touchpad or ctrl+mousewheel events


## Existing Issue(s)
Related: https://github.com/libsdl-org/SDL/issues/7706
Related: https://github.com/libsdl-org/SDL/pull/9445
Related: https://github.com/libsdl-org/SDL/pull/15092

I worked on this while working also on this other PR, so I consider discussion there also related:
https://github.com/libsdl-org/SDL/pull/15763
