### PR TITLE
Add docstring to Swift test shim header for clarity

### DIFF
--- a/cmake/test/swift/shim.h
+++ b/cmake/test/swift/shim.h
@@ -1,3 +1,4 @@
+/* This file provides a shim for Swift testing in SDL. */
 /* Contributed by Piotr Usewicz (https://github.com/pusewicz) */
 
 #include <SDL3/SDL.h>


### PR DESCRIPTION
## Problem Background
The header file `cmake/test/swift/shim.h` previously lacked a descriptive comment about its purpose, only containing contributor information. This made it difficult for other developers to understand the file's role in the project.

## Changes
Added a documentation comment at the top of the file: `/* This file provides a shim for Swift testing in SDL. */`. This provides clear context about the file's function while preserving the existing contributor credit.

## Verification
- Reviewed the comment to ensure it accurately reflects the file's purpose as a Swift testing shim.
- Verified that the change does not affect the build process or code functionality through standard compilation tests.
- Confirmed adherence to the repository's existing comment style and conventions.