### PR TITLE
Android: ignore Add/Remove joystick untill SDL is initialized.

### DIFF
--- a/src/joystick/android/SDL_sysjoystick.c
+++ b/src/joystick/android/SDL_sysjoystick.c
@@ -389,6 +389,11 @@ void Android_AddJoystick(int device_id, const char *name, const char *desc, int 
     SDL_GUID guid;
     int i;
 
+    // Ignore Java call before SDL is really initialized
+    if (!SDL_JoysticksInitialized()) {
+        return;
+    }
+
     SDL_LockJoysticks();
 
     if (!SDL_GetHintBoolean(SDL_HINT_TV_REMOTE_AS_JOYSTICK, true)) {
@@ -489,6 +494,11 @@ void Android_RemoveJoystick(int device_id)
 {
     SDL_joylist_item *item = SDL_joylist;
     SDL_joylist_item *prev = NULL;
+
+    // Ignore Java call before SDL is really initialized
+    if (!SDL_JoysticksInitialized()) {
+        return;
+    }
 
     SDL_LockJoysticks();
 


### PR DESCRIPTION

Android: ignore Add/Remove joystick untill SDL is initialized.
( at init, SDL will get the joystick list with Android_JNI_DetectDevices() ) Fixes #15777

- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").
