### PR TITLE
Support PlayStation detection for Red Octane Games devices

### DIFF
--- a/src/joystick/hidapi/SDL_hidapijoystick.c
+++ b/src/joystick/hidapi/SDL_hidapijoystick.c
@@ -216,6 +216,8 @@ bool HIDAPI_SupportsPlaystationDetection(Uint16 vendor, Uint16 product)
          *            https://github.com/libsdl-org/SDL/issues/6799
          */
         return false;
+    case USB_VENDOR_RED_OCTANE_GAMES:
+        return true;
     case USB_VENDOR_SHANWAN:
         return true;
     case USB_VENDOR_SHANWAN_ALT:

--- a/src/joystick/usb_ids.h
+++ b/src/joystick/usb_ids.h
@@ -54,6 +54,7 @@
 #define USB_VENDOR_QANBA        0x2c22
 #define USB_VENDOR_RAZER        0x1532
 #define USB_VENDOR_RED_OCTANE   0x1430
+#define USB_VENDOR_RED_OCTANE_GAMES   0x3958
 #define USB_VENDOR_SAITEK       0x06a3
 #define USB_VENDOR_SCEA         0x12ba
 #define USB_VENDOR_SHANWAN      0x2563


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add the VID for Red Octane Games, and add it to the list of VIDs that support PlayStation detection

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
