### PR TITLE
Android: prevent removing joystick if SDL hasn't been initialized yet

### DIFF
--- a/src/joystick/android/SDL_sysjoystick.c
+++ b/src/joystick/android/SDL_sysjoystick.c
@@ -497,6 +497,12 @@ void Android_RemoveJoystick(int device_id)
     SDL_joylist_item *item = SDL_joylist;
     SDL_joylist_item *prev = NULL;
 
+    // Java might notify us about joysticks being removed before joysticks have
+    // been initialized.
+    if (!SDL_JoysticksInitialized()) {
+        return;
+    }
+
     SDL_LockJoysticks();
 
     // Don't call JoystickByDeviceId here or there'll be an infinite loop!


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Android: prevent removing joystick if SDL hasn't been initialized yet

@slouken maybe same kind of issue could also occurs if deviceRemove occurs before SDL starts


  

following
Fixes https://github.com/libsdl-org/SDL/issues/15777