### PR TITLE
Respect SDL_HINT_JOYSTICK_MFI 

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_xbox360.c
+++ b/src/joystick/hidapi/SDL_hidapi_xbox360.c
@@ -212,18 +212,19 @@ static bool HIDAPI_DriverXbox360_IsSupportedDevice(SDL_HIDAPI_Device *device, co
     }
 #endif
 #if defined(SDL_PLATFORM_MACOS) && defined(SDL_JOYSTICK_MFI)
-    if (SDL_IsJoystickSteamVirtualGamepad(vendor_id, product_id, version)) {
-        // GCController support doesn't work with the Steam Virtual Gamepad
-        return true;
-    } else {
-        // On macOS when it isn't controlled by the 360Controller driver and
-        // it doesn't look like a Steam virtual gamepad we should rely on
-        // GCController support instead.
-        return false;
+    if (SDL_GetHintBoolean(SDL_HINT_JOYSTICK_MFI, true)) {
+        if (SDL_IsJoystickSteamVirtualGamepad(vendor_id, product_id, version)) {
+            // GCController support doesn't work with the Steam Virtual Gamepad
+            return true;
+        } else {
+            // On macOS when it isn't controlled by the 360Controller driver and
+            // it doesn't look like a Steam virtual gamepad we should rely on
+            // GCController support instead.
+            return false;
+        }
     }
-#else
-    return (type == SDL_GAMEPAD_TYPE_XBOX360);
 #endif
+    return (type == SDL_GAMEPAD_TYPE_XBOX360);
 }
 
 static bool SetSlotLED(SDL_hid_device *dev, Uint8 slot, bool on)

--- a/src/joystick/hidapi/SDL_hidapi_xboxone.c
+++ b/src/joystick/hidapi/SDL_hidapi_xboxone.c
@@ -368,10 +368,11 @@ static bool HIDAPI_DriverXboxOne_IsSupportedDevice(SDL_HIDAPI_Device *device, co
     static const int XBONE_IFACE_PROTOCOL = 208;
 
 #if defined(SDL_PLATFORM_MACOS) && defined(SDL_JOYSTICK_MFI)
-    if (!SDL_IsJoystickBluetoothXboxOne(vendor_id, product_id)) {
+    if (SDL_GetHintBoolean(SDL_HINT_JOYSTICK_MFI, true) &&
+        !SDL_IsJoystickBluetoothXboxOne(vendor_id, product_id)) {
         // On macOS we get a shortened version of the real report and
         // you can't write output reports for wired controllers, so
-        // we'll just use the GCController support instead.
+        // we'll just use the GCController support instead, if available.
         return false;
     }
 #endif


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
In `SDL_hidapi_xbox360.c` and `SDL_hidapi_xboxone.c`, there was logic that checked whether MFI support was compiled in, but not whether it was requested to be disabled via `SDL_HINT_JOYSTICK_MFI`.

## Existing Issue(s)
Found the issue while working on https://github.com/libsdl-org/SDL/issues/15790.  I looked at https://github.com/libsdl-org/SDL/pull/15258 as it seemed to be a similar issue as I was having.  Looking at that change, I spotted the missing check in `SDL_hidapi_xbox360.c`.  After fixing that one, I searched for other uses of `SDL_JOYSTICK_MFI` using GitHub's search, and came across the same type of logic issue in `SDL_hidapi_xboxone.c`, so I changed that as well.