### PR TITLE
SDL_hidapi_xbox360.c: Fix Y axis inversion on macOS

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_xbox360.c
+++ b/src/joystick/hidapi/SDL_hidapi_xbox360.c
@@ -48,7 +48,7 @@ typedef struct
     Uint8 last_state[USB_PACKET_LENGTH];
 #ifdef SDL_PLATFORM_MACOS
     bool controlled_by_360controller;
-    bool is_joystick_steam_virtual_gamepad;
+    bool is_steam_virtual_gamepad;
 #endif
 } SDL_DriverXbox360_Context;
 
@@ -399,7 +399,7 @@ static void HIDAPI_DriverXbox360_HandleStatePacket(SDL_Joystick *joystick, SDL_D
     // For backwards compatibility reasons, the 360Controller driver and the Steam Virtual
     // Gamepad require opposite Y axis inversion on macOS
     const bool invert_y_axes = (ctx->controlled_by_360controller ||
-                                ctx->is_joystick_steam_virtual_gamepad) ? false : true;
+                                ctx->is_steam_virtual_gamepad) ? false : true;
 #else
     const bool invert_y_axes = true;
 #endif

--- a/src/joystick/hidapi/SDL_hidapi_xbox360.c
+++ b/src/joystick/hidapi/SDL_hidapi_xbox360.c
@@ -398,8 +398,8 @@ static void HIDAPI_DriverXbox360_HandleStatePacket(SDL_Joystick *joystick, SDL_D
 #ifdef SDL_PLATFORM_MACOS
     // For backwards compatibility reasons, the 360Controller driver and the Steam Virtual
     // Gamepad require opposite Y axis inversion on macOS
-    const bool invert_y_axes = (!ctx->controlled_by_360controller &&
-                                !ctx->is_joystick_steam_virtual_gamepad);
+    const bool invert_y_axes = (ctx->controlled_by_360controller ||
+                                ctx->is_joystick_steam_virtual_gamepad) ? false : true;
 #else
     const bool invert_y_axes = true;
 #endif

--- a/src/joystick/hidapi/SDL_hidapi_xbox360.c
+++ b/src/joystick/hidapi/SDL_hidapi_xbox360.c
@@ -48,6 +48,7 @@ typedef struct
     Uint8 last_state[USB_PACKET_LENGTH];
 #ifdef SDL_PLATFORM_MACOS
     bool controlled_by_360controller;
+    bool is_joystick_steam_virtual_gamepad;
 #endif
 } SDL_DriverXbox360_Context;
 
@@ -272,6 +273,7 @@ static bool HIDAPI_DriverXbox360_InitDevice(SDL_HIDAPI_Device *device)
     ctx->device = device;
 #ifdef SDL_PLATFORM_MACOS
     ctx->controlled_by_360controller = IsControlledBy360ControllerDriverMacOS(device);
+    ctx->is_joystick_steam_virtual_gamepad = SDL_IsJoystickSteamVirtualGamepad(device->vendor_id, device->product_id, device->version);
 #endif
 
     device->context = ctx;
@@ -394,7 +396,10 @@ static void HIDAPI_DriverXbox360_HandleStatePacket(SDL_Joystick *joystick, SDL_D
 {
     Sint16 axis;
 #ifdef SDL_PLATFORM_MACOS
-    const bool invert_y_axes = false;
+    // For backwards compatibility reasons, the 360Controller driver and the Steam Virtual
+    // Gamepad require opposite Y axis inversion on macOS
+    const bool invert_y_axes = (!ctx->controlled_by_360controller &&
+                                !ctx->is_joystick_steam_virtual_gamepad);
 #else
     const bool invert_y_axes = true;
 #endif

--- a/src/joystick/hidapi/SDL_hidapi_xbox360.c
+++ b/src/joystick/hidapi/SDL_hidapi_xbox360.c
@@ -273,7 +273,7 @@ static bool HIDAPI_DriverXbox360_InitDevice(SDL_HIDAPI_Device *device)
     ctx->device = device;
 #ifdef SDL_PLATFORM_MACOS
     ctx->controlled_by_360controller = IsControlledBy360ControllerDriverMacOS(device);
-    ctx->is_joystick_steam_virtual_gamepad = SDL_IsJoystickSteamVirtualGamepad(device->vendor_id, device->product_id, device->version);
+    ctx->is_steam_virtual_gamepad = SDL_IsJoystickSteamVirtualGamepad(device->vendor_id, device->product_id, device->version);
 #endif
 
     device->context = ctx;


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
Originally, macOS had opposite Y axis inversion as every other platform, likely to correct for an issue with the virtual gamepad reported by the old 360Controller driver.

Wired Xbox 360 controllers using native macOS drivers were first reported to be broken in https://github.com/libsdl-org/SDL/issues/11002.  The inversion was removed in https://github.com/libsdl-org/SDL/commit/7da728a642f2acfbba9543a3587363908d7aa1c3, presumably breaking 360Controller usage, but fixing wired 360 controllers using the new native support in macOS 15 and above.  However, this change was reverted without explanation in https://github.com/libsdl-org/SDL/commit/d7b1ba1bfca7c9bf4f57075258ccfa0e0c6b2051 which added explicit support for the Steam Virtual Gamepad.  Presumably, Steam on macOS reports inverted Y axes to match what SDL expected on the platform.  However, this reversion broke the native macOS controller support.  The incorrect inversion also breaks using off-brand 360-class gamepads via the libusb backend of HIDRAW.

I tested with both an off-brand Xbox 360 controller (Gamestop branded) and a Logitech F310, both using the libusb backend for HIDRAW; both these controllers had improper Y axis inversion before, and work as expected with this code.

Unfortunately, I do not have an OEM wired Xbox 360 controller to test the native macOS HIDRAW gamepad support, but given the continued activity on issue #11002, I believe the current code was incorrect and this code should be correct.

I also do not current have Steam set up on this machine to test the virtual gamepad driver, but given this change specifically keeps the existing behavior for the Steam Virtual Gamepad, there should be no issue here.  Similarly, I didn't test with the old 360Controller driver, as it would require me pull out and set up a very old, very large iMac from the closet, as 360Controller supports macOS 10.15 at the very latest.

Additional testing from anyone with an OEM wired Xbox 360 controller would be appreciated, as well as testing with the Steam Virtual Gamepad just to me sure, and perhaps even 360Controller if someone has a very old system easily accessible.

## Existing Issue(s)
https://github.com/libsdl-org/SDL/issues/11002
