### PR TITLE
Added support for Xbox controllers via libusb on macOS

### DIFF
--- a/cmake/sdlchecks.cmake
+++ b/cmake/sdlchecks.cmake
@@ -1272,7 +1272,7 @@ macro(CheckHIDAPI)
           #include <stddef.h>
           #include <libusb.h>
           int main(int argc, char **argv) {
-            libusb_close(NULL);
+            libusb_interrupt_event_handler(NULL);
             return 0;
           }" HAVE_LIBUSB_H)
         cmake_pop_check_state()

--- a/src/hidapi/SDL_hidapi.c
+++ b/src/hidapi/SDL_hidapi.c
@@ -543,8 +543,8 @@ static void HIDAPI_ShutdownDiscovery(void)
 // Platform HIDAPI Implementation
 
 #define HIDAPI_USING_SDL_RUNTIME
-#define HIDAPI_IGNORE_DEVICE(BUS, VID, PID, USAGE_PAGE, USAGE, LIBUSB) \
-        SDL_HIDAPI_ShouldIgnoreDevice(BUS, VID, PID, USAGE_PAGE, USAGE, LIBUSB)
+#define HIDAPI_IGNORE_DEVICE(BUS, VID, PID, USAGE_PAGE, USAGE, LIBUSB, LIBUSB_XBOX) \
+        SDL_HIDAPI_ShouldIgnoreDevice(BUS, VID, PID, USAGE_PAGE, USAGE, LIBUSB, LIBUSB_XBOX)
 
 struct PLATFORM_hid_device_;
 typedef struct PLATFORM_hid_device_ PLATFORM_hid_device;
@@ -859,7 +859,7 @@ static const struct {
     { USB_VENDOR_NINTENDO, USB_PRODUCT_NINTENDO_SWITCH2_PRO },
 };
 
-static bool RequiresLibUSB(Uint16 vendor, Uint16 product)
+static bool RequiresLibUSB(Uint16 vendor, Uint16 product, bool libusb_xbox)
 {
     for (int i = 0; i < SDL_arraysize(SDL_libusb_required); ++i) {
         if (vendor == SDL_libusb_required[i].vendor &&
@@ -867,6 +867,17 @@ static bool RequiresLibUSB(Uint16 vendor, Uint16 product)
             return true;
         }
     }
+
+#ifdef SDL_PLATFORM_MACOS
+    // On macOS we want to use libusb if possible for Xbox controllers
+    // that are not supported by the OS. Opening the device via libusb
+    // will fail if the device is supported (and opened) by the OS, so
+    // any devices we return here and can open are fair game.
+    if (libusb_xbox) {
+        return true;
+    }
+#endif // SDL_PLATFORM_MACOS
+
     return false;
 }
 
@@ -1054,10 +1065,10 @@ static void SDLCALL IgnoredDevicesChanged(void *userdata, const char *name, cons
     }
 }
 
-bool SDL_HIDAPI_ShouldIgnoreDevice(int bus, Uint16 vendor_id, Uint16 product_id, Uint16 usage_page, Uint16 usage, bool libusb)
+bool SDL_HIDAPI_ShouldIgnoreDevice(int bus, Uint16 vendor_id, Uint16 product_id, Uint16 usage_page, Uint16 usage, bool libusb, bool libusb_xbox)
 {
     if (libusb) {
-        if (use_libusb_whitelist && !RequiresLibUSB(vendor_id, product_id)) {
+        if (use_libusb_whitelist && !RequiresLibUSB(vendor_id, product_id, libusb_xbox)) {
             return true;
         }
         if (!use_libusb_gamecube &&
@@ -1065,7 +1076,7 @@ bool SDL_HIDAPI_ShouldIgnoreDevice(int bus, Uint16 vendor_id, Uint16 product_id,
             return true;
         }
     } else {
-        if (RequiresLibUSB(vendor_id, product_id)) {
+        if (RequiresLibUSB(vendor_id, product_id, libusb_xbox)) {
             return true;
         }
     }

--- a/src/hidapi/SDL_hidapi.c
+++ b/src/hidapi/SDL_hidapi.c
@@ -734,6 +734,10 @@ static SDL_LibUSBContext *libusb_ctx;
 #define libusb_bulk_transfer                libusb_ctx->bulk_transfer
 #define libusb_handle_events                libusb_ctx->handle_events
 #define libusb_handle_events_completed      libusb_ctx->handle_events_completed
+#define libusb_interrupt_event_handler      libusb_ctx->interrupt_event_handler
+#define libusb_has_capability               libusb_ctx->has_capability
+#define libusb_hotplug_register_callback    libusb_ctx->hotplug_register_callback
+#define libusb_hotplug_deregister_callback  libusb_ctx->hotplug_deregister_callback
 #define libusb_error_name                   libusb_ctx->error_name
 
 struct LIBUSB_hid_device_;

--- a/src/hidapi/SDL_hidapi_c.h
+++ b/src/hidapi/SDL_hidapi_c.h
@@ -22,5 +22,5 @@
 
 
 /* Return true if the HIDAPI should ignore a device during enumeration */
-extern bool SDL_HIDAPI_ShouldIgnoreDevice(int bus_type, Uint16 vendor_id, Uint16 product_id, Uint16 usage_page, Uint16 usage, bool libusb);
+extern bool SDL_HIDAPI_ShouldIgnoreDevice(int bus_type, Uint16 vendor_id, Uint16 product_id, Uint16 usage_page, Uint16 usage, bool libusb, bool is_xbox);
 

--- a/src/hidapi/android/hid.cpp
+++ b/src/hidapi/android/hid.cpp
@@ -1114,7 +1114,7 @@ struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned shor
 		const hid_device_info *info = pDevice->GetDeviceInfo();
 
 		/* See if there are any devices we should skip in enumeration */
-		if (SDL_HIDAPI_ShouldIgnoreDevice(HID_API_BUS_UNKNOWN, info->vendor_id, info->product_id, 0, 0, false)) {
+		if (SDL_HIDAPI_ShouldIgnoreDevice(HID_API_BUS_UNKNOWN, info->vendor_id, info->product_id, 0, 0, false, false)) {
 			continue;
 		}
 

--- a/src/hidapi/ios/hid.m
+++ b/src/hidapi/ios/hid.m
@@ -995,7 +995,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
         }
 
         /* See if there are any devices we should skip in enumeration */
-        if (SDL_HIDAPI_ShouldIgnoreDevice(HID_API_BUS_BLUETOOTH, VALVE_USB_VID, device.pid, 0, 0, false)) {
+        if (SDL_HIDAPI_ShouldIgnoreDevice(HID_API_BUS_BLUETOOTH, VALVE_USB_VID, device.pid, 0, 0, false, false)) {
             continue;
         }
 

--- a/src/hidapi/libusb/hid.c
+++ b/src/hidapi/libusb/hid.c
@@ -911,21 +911,27 @@ static int is_xboxone(unsigned short vendor_id, const struct libusb_interface_de
 	return 0;
 }
 
-static int should_enumerate_interface(unsigned short vendor_id, const struct libusb_interface_descriptor *intf_desc)
+static int should_enumerate_interface(unsigned short vendor_id, unsigned short product_id, const struct libusb_interface_descriptor *intf_desc)
 {
+	int is_xbox = (is_xbox360(vendor_id, intf_desc) ||
+	               is_xboxone(vendor_id, intf_desc));
+
 #if 0
 	printf("Checking interface 0x%x %d/%d/%d/%d\n", vendor_id, intf_desc->bInterfaceNumber, intf_desc->bInterfaceClass, intf_desc->bInterfaceSubClass, intf_desc->bInterfaceProtocol);
 #endif
 
+#ifdef HIDAPI_IGNORE_DEVICE
+	/* See if there are any devices we should skip in enumeration */
+	if (HIDAPI_IGNORE_DEVICE(HID_API_BUS_USB, vendor_id, product_id, 0, 0, true, is_xbox)) {
+		return 0;
+	}
+#endif
+
+	/* Enumerate Xbox 360 and Xbox One controllers */
+	if (is_xbox)
+		return 1;
+
 	if (intf_desc->bInterfaceClass == LIBUSB_CLASS_HID)
-		return 1;
-
-	/* Also enumerate Xbox 360 controllers */
-	if (is_xbox360(vendor_id, intf_desc))
-		return 1;
-
-	/* Also enumerate Xbox One controllers */
-	if (is_xboxone(vendor_id, intf_desc))
 		return 1;
 
 	return 0;
@@ -982,13 +988,6 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 			continue;
 		}
 
-#ifdef HIDAPI_IGNORE_DEVICE
-		/* See if there are any devices we should skip in enumeration */
-		if (HIDAPI_IGNORE_DEVICE(HID_API_BUS_USB, dev_vid, dev_pid, 0, 0, true)) {
-			continue;
-		}
-#endif
-
 		res = libusb_get_active_config_descriptor(dev, &conf_desc);
 		if (res < 0)
 			libusb_get_config_descriptor(dev, 0, &conf_desc);
@@ -998,7 +997,7 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 				for (k = 0; k < intf->num_altsetting; k++) {
 					const struct libusb_interface_descriptor *intf_desc;
 					intf_desc = &intf->altsetting[k];
-					if (should_enumerate_interface(dev_vid, intf_desc)) {
+					if (should_enumerate_interface(dev_vid, dev_pid, intf_desc)) {
 						struct hid_device_info *tmp;
 
 						res = libusb_open(dev, &handle);
@@ -1485,7 +1484,7 @@ HID_API_EXPORT hid_device *hid_open_path(const char *path)
 			const struct libusb_interface *intf = &conf_desc->interface[j];
 			for (k = 0; k < intf->num_altsetting && !good_open; k++) {
 				const struct libusb_interface_descriptor *intf_desc = &intf->altsetting[k];
-				if (should_enumerate_interface(desc.idVendor, intf_desc)) {
+				if (should_enumerate_interface(desc.idVendor, desc.idProduct, intf_desc)) {
 					char dev_path[64];
 					get_path(&dev_path, usb_dev, conf_desc->bConfigurationValue, intf_desc->bInterfaceNumber);
 					if (!strcmp(dev_path, path)) {

--- a/src/hidapi/libusb/hid.c
+++ b/src/hidapi/libusb/hid.c
@@ -600,6 +600,66 @@ HID_API_EXPORT const char* HID_API_CALL hid_version_str(void)
 	return HID_API_VERSION_STR;
 }
 
+#ifdef HIDAPI_USING_SDL_RUNTIME
+static libusb_hotplug_callback_handle hotplug_callback_handle;
+static int shutdown_event_thread;
+static hidapi_thread_state event_thread_state;
+
+static int hotplug_callback(struct libusb_context *ctx, struct libusb_device *dev, libusb_hotplug_event event, void *user_data)
+{
+	switch (event) {
+	case LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED:
+		++SDL_HIDAPI_discovery.m_unDeviceChangeCounter;
+		break;
+	case LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT:
+		++SDL_HIDAPI_discovery.m_unDeviceChangeCounter;
+		break;
+	default:
+		break;
+	}
+	return 0;
+}
+
+
+static void *event_thread(void *param)
+{
+	while (!shutdown_event_thread) {
+		int res = libusb_handle_events(usb_context);
+		if (res < 0) {
+			/* There was an error. */
+			LOG("event_thread(): (%d) %s\n", res, libusb_error_name(res));
+		}
+	}
+	return NULL;
+}
+
+static void start_event_thread()
+{
+	if (libusb_has_capability(LIBUSB_CAP_HAS_HOTPLUG)) {
+		int res = libusb_hotplug_register_callback(usb_context, LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED | LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT, 0, LIBUSB_HOTPLUG_MATCH_ANY, LIBUSB_HOTPLUG_MATCH_ANY, LIBUSB_HOTPLUG_MATCH_ANY, hotplug_callback, NULL, &hotplug_callback_handle);
+		if (res < 0) {
+			LOG("Couldn't register hotplug: (%d) %s\n", res, libusb_error_name(res));
+		}
+	}
+
+	hidapi_thread_create(&event_thread_state, event_thread, NULL);
+}
+
+static void stop_event_thread()
+{
+	shutdown_event_thread = 1;
+	libusb_interrupt_event_handler(usb_context);
+	hidapi_thread_join(&event_thread_state);
+	shutdown_event_thread = 0;
+
+	if (hotplug_callback_handle) {
+		libusb_hotplug_deregister_callback(usb_context, hotplug_callback_handle);
+		hotplug_callback_handle = 0;
+	}
+}
+#endif /* HIDAPI_USING_SDL_RUNTIME */
+
+
 int HID_API_EXPORT hid_init(void)
 {
 	if (!usb_context) {
@@ -613,6 +673,10 @@ int HID_API_EXPORT hid_init(void)
 		locale = setlocale(LC_CTYPE, NULL);
 		if (!locale)
 			(void) setlocale(LC_CTYPE, "");
+
+#ifdef HIDAPI_USING_SDL_RUNTIME
+		start_event_thread();
+#endif
 	}
 
 	return 0;
@@ -621,6 +685,10 @@ int HID_API_EXPORT hid_init(void)
 int HID_API_EXPORT hid_exit(void)
 {
 	usb_string_cache_destroy();
+
+#ifdef HIDAPI_USING_SDL_RUNTIME
+	stop_event_thread();
+#endif
 
 	if (usb_context) {
 		libusb_exit(usb_context);
@@ -1186,10 +1254,9 @@ static void LIBUSB_CALL read_callback(struct libusb_transfer *transfer)
 }
 
 
-static void *read_thread(void *param)
+static void start_read_operations(hid_device *dev)
 {
 	int res;
-	hid_device *dev = param;
 	uint8_t *buf;
 	const size_t length = dev->input_ep_max_packet_size;
 
@@ -1209,10 +1276,37 @@ static void *read_thread(void *param)
 	   from inside read_callback() */
 	res = libusb_submit_transfer(dev->transfer);
 	if(res < 0) {
-                LOG("libusb_submit_transfer failed: %d %s. Stopping read_thread from running\n", res, libusb_error_name(res));
-                dev->shutdown_thread = 1;
-                dev->transfer_loop_finished = 1;
+		LOG("libusb_submit_transfer failed: %d %s. Stopping read_thread from running\n", res, libusb_error_name(res));
+		dev->shutdown_thread = 1;
+		dev->transfer_loop_finished = 1;
 	}
+}
+
+
+static void stop_read_operations(hid_device *dev)
+{
+	while (!dev->transfer_loop_finished)
+		libusb_handle_events_completed(usb_context, &dev->transfer_loop_finished);
+
+	/* Now that the read operations are stopping, Wake any threads which are
+	   waiting on data (in hid_read_timeout()). Do this under a mutex to
+	   make sure that a thread which is about to go to sleep waiting on
+	   the condition actually will go to sleep before the condition is
+	   signaled. */
+	hidapi_thread_mutex_lock(&dev->thread_state);
+	hidapi_thread_cond_broadcast(&dev->thread_state);
+	hidapi_thread_mutex_unlock(&dev->thread_state);
+}
+
+
+#ifdef HIDAPI_USING_SDL_RUNTIME
+/* We have a separate thread handling all the events */
+#else
+static void *read_thread(void *param)
+{
+	hid_device *dev = param;
+
+	start_read_operations(dev);
 
 	/* Notify the main thread that the read thread is up and running. */
 	hidapi_thread_barrier_wait(&dev->thread_state);
@@ -1239,17 +1333,7 @@ static void *read_thread(void *param)
 	   if no transfers are pending, but that's OK. */
 	libusb_cancel_transfer(dev->transfer);
 
-	while (!dev->transfer_loop_finished)
-		libusb_handle_events_completed(usb_context, &dev->transfer_loop_finished);
-
-	/* Now that the read thread is stopping, Wake any threads which are
-	   waiting on data (in hid_read_timeout()). Do this under a mutex to
-	   make sure that a thread which is about to go to sleep waiting on
-	   the condition actually will go to sleep before the condition is
-	   signaled. */
-	hidapi_thread_mutex_lock(&dev->thread_state);
-	hidapi_thread_cond_broadcast(&dev->thread_state);
-	hidapi_thread_mutex_unlock(&dev->thread_state);
+	stop_read_operations(dev);
 
 	/* The dev->transfer->buffer and dev->transfer objects are cleaned up
 	   in hid_close(). They are not cleaned up here because this thread
@@ -1261,6 +1345,7 @@ static void *read_thread(void *param)
 
 	return NULL;
 }
+#endif /* HIDAPI_USING_SDL_RUNTIME */
 
 static void init_xbox360(libusb_device_handle *device_handle, unsigned short idVendor, unsigned short idProduct, const struct libusb_config_descriptor *conf_desc)
 {
@@ -1441,10 +1526,14 @@ static int hidapi_initialize_device(hid_device *dev, const struct libusb_interfa
 
 	calculate_device_quirks(dev, desc.idVendor, desc.idProduct);
 
+#ifdef HIDAPI_USING_SDL_RUNTIME
+	start_read_operations(dev);
+#else
 	hidapi_thread_create(&dev->thread_state, read_thread, dev);
 
 	/* Wait here for the read thread to be initialized. */
 	hidapi_thread_barrier_wait(&dev->thread_state);
+#endif
 	return 1;
 }
 
@@ -1868,8 +1957,12 @@ void HID_API_EXPORT hid_close(hid_device *dev)
 	dev->shutdown_thread = 1;
 	libusb_cancel_transfer(dev->transfer);
 
+#ifdef HIDAPI_USING_SDL_RUNTIME
+	stop_read_operations(dev);
+#else
 	/* Wait for read_thread() to end. */
 	hidapi_thread_join(&dev->thread_state);
+#endif
 
 	/* Clean up the Transfer objects allocated in read_thread(). */
 	free(dev->transfer->buffer);

--- a/src/hidapi/libusb/hidapi_thread_sdl.h
+++ b/src/hidapi/libusb/hidapi_thread_sdl.h
@@ -53,10 +53,17 @@ static int SDL_CreateThreadBarrier(SDL_ThreadBarrier *barrier, Uint32 count)
 
 static void SDL_DestroyThreadBarrier(SDL_ThreadBarrier *barrier)
 {
-    SDL_DestroyCondition(barrier->cond);
-    SDL_DestroyMutex(barrier->mutex);
+    if (barrier->cond) {
+        SDL_DestroyCondition(barrier->cond);
+        barrier->cond = NULL;
+    }
+    if (barrier->mutex) {
+        SDL_DestroyMutex(barrier->mutex);
+        barrier->mutex = NULL;
+    }
 }
 
+#if 0 // Not used
 static int SDL_WaitThreadBarrier(SDL_ThreadBarrier *barrier)
 {
     SDL_LockMutex(barrier->mutex);
@@ -71,6 +78,7 @@ static int SDL_WaitThreadBarrier(SDL_ThreadBarrier *barrier)
     SDL_UnlockMutex(barrier->mutex);
     return 0;
 }
+#endif
 
 #include "../../thread/SDL_systhread.h"
 
@@ -97,8 +105,14 @@ static void hidapi_thread_state_init(hidapi_thread_state *state)
 static void hidapi_thread_state_destroy(hidapi_thread_state *state)
 {
     SDL_DestroyThreadBarrier(&state->barrier);
-    SDL_DestroyCondition(state->condition);
-    SDL_DestroyMutex(state->mutex);
+    if (state->condition) {
+        SDL_DestroyCondition(state->condition);
+        state->condition = NULL;
+    }
+    if (state->mutex) {
+        SDL_DestroyMutex(state->mutex);
+        state->mutex = NULL;
+    }
 }
 
 static void hidapi_thread_cleanup_push(void (*routine)(void *), void *arg)
@@ -153,10 +167,12 @@ static void hidapi_thread_cond_broadcast(hidapi_thread_state *state)
     SDL_BroadcastCondition(state->condition);
 }
 
+#if 0 // Not used
 static void hidapi_thread_barrier_wait(hidapi_thread_state *state)
 {
     SDL_WaitThreadBarrier(&state->barrier);
 }
+#endif
 
 typedef struct
 {

--- a/src/hidapi/linux/hid.c
+++ b/src/hidapi/linux/hid.c
@@ -906,7 +906,7 @@ static struct hid_device_info * create_device_info_for_device(struct udev_device
 
 		cur_dev = root;
 		while (cur_dev) {
-			if (HIDAPI_IGNORE_DEVICE(cur_dev->bus_type, cur_dev->vendor_id, cur_dev->product_id, cur_dev->usage_page, cur_dev->usage, false)) {
+			if (HIDAPI_IGNORE_DEVICE(cur_dev->bus_type, cur_dev->vendor_id, cur_dev->product_id, cur_dev->usage_page, cur_dev->usage, false, false)) {
 				struct hid_device_info *tmp = cur_dev;
 
 				cur_dev = tmp->next;

--- a/src/hidapi/mac/hid.c
+++ b/src/hidapi/mac/hid.c
@@ -598,7 +598,7 @@ static struct hid_device_info *create_device_info_with_usage(IOHIDDeviceRef dev,
 
 #ifdef HIDAPI_IGNORE_DEVICE
 	/* See if there are any devices we should skip in enumeration */
-	if (HIDAPI_IGNORE_DEVICE(get_bus_type(dev), dev_vid, dev_pid, usage_page, usage, false)) {
+	if (HIDAPI_IGNORE_DEVICE(get_bus_type(dev), dev_vid, dev_pid, usage_page, usage, false, false)) {
 		free(cur_dev);
 		return NULL;
 	}

--- a/src/hidapi/windows/hid.c
+++ b/src/hidapi/windows/hid.c
@@ -1046,7 +1046,7 @@ struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned shor
 			HidP_GetCaps(pp_data, &caps);
 			HidD_FreePreparsedData(pp_data);
 		}
-		if (HIDAPI_IGNORE_DEVICE(bus_type, attrib.VendorID, attrib.ProductID, caps.UsagePage, caps.Usage, false)) {
+		if (HIDAPI_IGNORE_DEVICE(bus_type, attrib.VendorID, attrib.ProductID, caps.UsagePage, caps.Usage, false, false)) {
 			goto cont_close;
 		}
 #endif

--- a/src/joystick/hidapi/SDL_hidapi_xbox360.c
+++ b/src/joystick/hidapi/SDL_hidapi_xbox360.c
@@ -112,8 +112,8 @@ static void FetchXInputCapabilities(SDL_HIDAPI_Device *device)
         const struct libusb_interface *intf = &conf_desc->interface[device->interface_number];
         intf_desc = &intf->altsetting[0];
         if (intf_desc->extra_length == 17 && intf_desc->extra[1] == 0x21) {
-			ctx->capabilities.type = intf_desc->extra[3];
-			ctx->capabilities.subType = intf_desc->extra[4];
+            ctx->capabilities.type = intf_desc->extra[3];
+            ctx->capabilities.subType = intf_desc->extra[4];
             switch (ctx->capabilities.subType) {
                 case 0x01: // XINPUT_DEVSUBTYPE_GAMEPAD
                     device->joystick_type = SDL_JOYSTICK_TYPE_GAMEPAD;
@@ -177,7 +177,7 @@ static void FetchXInputCapabilities(SDL_HIDAPI_Device *device)
             SDL_Log("   wLeftMotorSpeed: %02x", ctx->capabilities.vibration.wLeftMotorSpeed);
             SDL_Log("   wRightMotorSpeed: %02x", ctx->capabilities.vibration.wRightMotorSpeed);
 #endif
-		}
+        }
         SDL_QuitLibUSB();
     }
 }
@@ -217,10 +217,11 @@ static bool HIDAPI_DriverXbox360_IsSupportedDevice(SDL_HIDAPI_Device *device, co
         if (SDL_IsJoystickSteamVirtualGamepad(vendor_id, product_id, version)) {
             // GCController support doesn't work with the Steam Virtual Gamepad
             return true;
-        } else {
+        }
+        if (device && SDL_strncmp(device->path, "DevSrvsID", 9) == 0) {
             // On macOS when it isn't controlled by the 360Controller driver and
-            // it doesn't look like a Steam virtual gamepad we should rely on
-            // GCController support instead.
+            // it doesn't look like a Steam virtual gamepad and it's not
+            // available via libusb we should rely on GCController support.
             return false;
         }
     }

--- a/src/joystick/hidapi/SDL_hidapi_xboxone.c
+++ b/src/joystick/hidapi/SDL_hidapi_xboxone.c
@@ -369,7 +369,8 @@ static bool HIDAPI_DriverXboxOne_IsSupportedDevice(SDL_HIDAPI_Device *device, co
 
 #if defined(SDL_PLATFORM_MACOS) && defined(SDL_JOYSTICK_MFI)
     if (SDL_GetHintBoolean(SDL_HINT_JOYSTICK_MFI, true) &&
-        !SDL_IsJoystickBluetoothXboxOne(vendor_id, product_id)) {
+        !SDL_IsJoystickBluetoothXboxOne(vendor_id, product_id) &&
+        (device && SDL_strncmp(device->path, "DevSrvsID", 9) == 0)) {
         // On macOS we get a shortened version of the real report and
         // you can't write output reports for wired controllers, so
         // we'll just use the GCController support instead, if available.

--- a/src/misc/SDL_libusb.c
+++ b/src/misc/SDL_libusb.c
@@ -90,6 +90,10 @@ bool SDL_InitLibUSB(SDL_LibUSBContext **ctx)
             LOAD_LIBUSB_SYMBOL(int (LIBUSB_CALL *)(libusb_device_handle *, unsigned char, unsigned char *, int, int *, unsigned int), bulk_transfer)
             LOAD_LIBUSB_SYMBOL(int (LIBUSB_CALL *)(libusb_context *), handle_events)
             LOAD_LIBUSB_SYMBOL(int (LIBUSB_CALL *)(libusb_context *, int *), handle_events_completed)
+            LOAD_LIBUSB_SYMBOL(void (LIBUSB_CALL *)(libusb_context *ctx), interrupt_event_handler)
+            LOAD_LIBUSB_SYMBOL(int (LIBUSB_CALL *)(uint32_t), has_capability)
+            LOAD_LIBUSB_SYMBOL(int (LIBUSB_CALL *)(libusb_context *, int, int, int, int, int, libusb_hotplug_callback_fn, void *, libusb_hotplug_callback_handle *), hotplug_register_callback)
+            LOAD_LIBUSB_SYMBOL(void (LIBUSB_CALL *)(libusb_context *, libusb_hotplug_callback_handle), hotplug_deregister_callback)
             LOAD_LIBUSB_SYMBOL(const char * (LIBUSB_CALL *)(int), error_name)
 #undef LOAD_LIBUSB_SYMBOL
         }

--- a/src/misc/SDL_libusb.h
+++ b/src/misc/SDL_libusb.h
@@ -91,6 +91,10 @@ typedef struct SDL_LibUSBContext
     );
     int (LIBUSB_CALL *handle_events)(libusb_context *ctx);
     int (LIBUSB_CALL *handle_events_completed)(libusb_context *ctx, int *completed);
+    void (LIBUSB_CALL *interrupt_event_handler)(libusb_context *ctx);
+    int (LIBUSB_CALL *has_capability)(uint32_t capability);
+    int (LIBUSB_CALL *hotplug_register_callback)(libusb_context *ctx, int events, int flags, int vendor_id, int product_id, int dev_class, libusb_hotplug_callback_fn cb_fn, void *user_data, libusb_hotplug_callback_handle *callback_handle);
+    void (LIBUSB_CALL *hotplug_deregister_callback)(libusb_context *ctx, libusb_hotplug_callback_handle callback_handle);
     const char * (LIBUSB_CALL *error_name)(int errcode);
 /* *INDENT-ON* */ // clang-format on
 


### PR DESCRIPTION
A number of third party Xbox controllers are not supported by macOS, but work with libusb and the SDL HIDAPI driver.

Closes https://github.com/libsdl-org/SDL/pull/15258

- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").
