### PR TITLE
Add Corsair as valid PlayStation controller

### DIFF
--- a/src/joystick/hidapi/SDL_hidapijoystick.c
+++ b/src/joystick/hidapi/SDL_hidapijoystick.c
@@ -178,6 +178,8 @@ bool HIDAPI_SupportsPlaystationDetection(Uint16 vendor, Uint16 product)
         return true;
     case USB_VENDOR_DRAGONRISE:
         return true;
+    case USB_VENDOR_CORSAIR:
+        return true;
     case USB_VENDOR_HORI:
         return true;
     case USB_VENDOR_LOGITECH:

--- a/src/joystick/usb_ids.h
+++ b/src/joystick/usb_ids.h
@@ -31,6 +31,7 @@
 #define USB_VENDOR_ASUS         0x0b05
 #define USB_VENDOR_BACKBONE     0x358a
 #define USB_VENDOR_CRKD         0x3651
+#define USB_VENDOR_CORSAIR      0x1b1c
 #define USB_VENDOR_GAMESIR      0x3537
 #define USB_VENDOR_DRAGONRISE   0x0079
 #define USB_VENDOR_FLYDIGI_V1   0x04b4


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
This change add Corsair as a valid vendor of PlayStation controllers. This adds support for the [Corsair NOVABLADE PRO](https://www.corsair.com/us/en/explorer/gamer/leverless-controllers/) under Linux.

The problem was that on PlayStation 4/5 modes the controller was not correctly identified and the default profile does not correctly maps the buttons. After adding the vendor under `HIDAPI_SupportsPlaystationDetection` fixed this issue. I was able to see the new correct mapping and identification when running `testcontroller` binary after compiling:

```
Using udev for HIDAPI joystick device discovery
Added HIDAPI device 'Corsair Novablade PRO Wireless Hall Effect Leverless Controller' VID 0x1b1c, PID 0x2b27, bluetooth 0, version 256, serial NONE, interface 0, interface_class 0, interface_subclass 0, interface_protocol 0, usage page 0x0001, usage 0x0005, path = /dev/hidraw9, driver = SDL_JOYSTICK_HIDAPI_PS5 (ENABLED)
Using udev for joystick device discovery
Gamepad 5 added
Opened gamepad Corsair Novablade PRO Wireless Hall Effect Leverless Controller, guid 0300c9141c1b0000272b000000016800, /dev/hidraw9
Has player LED
Player index: 0
Controller is an arcade stick
Mapping: 0300c9141c1b0000272b000000016800,*,a:b0,b:b1,back:b4,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b5,leftshoulder:b9,leftstick:b7,lefttrigger:a4,leftx:a0,lefty:a1,rightshoulder:b10,rightstick:b8,righttrigger:a5,rightx:a2,righty:a3,start:b6,x:b2,y:b3,touchpad:b11,misc1:b12,crc:14c9,platform:Linux,
Gamepad 5 removed
Removing HIDAPI device 'Corsair Novablade PRO Wireless Hall Effect Leverless Controller' VID 0x1b1c, PID 0x2b27, bluetooth 0, version 256, serial NONE, interface 0, interface_class 0, interface_subclass 0, interface_protocol 0, usage page 0x0001, usage 0x0005, path = /dev/hidraw9, driver = SDL_JOYSTICK_HIDAPI_PS5 (ENABLED)
```

This fix the issue for PS4/5 modes wired and wireless modes. However, here are some caveats: 

- I do not own any other Corsair device to be able to test with them.
- The controller does not work at all on PC mode. It is not recognized as a controller under Linux. But that may be a different issue.

My testing was done under Arch Linux kernel 7.0.11 and sdl3 3.4.10-1

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
There is no existing issue open.