### PR TITLE
ci: use cpactions cpa.sh shell + bump FreeBSD and OpenBSD

### DIFF
--- a/.github/workflows/create-test-plan.py
+++ b/.github/workflows/create-test-plan.py
@@ -813,7 +813,7 @@ def spec_to_job(spec: JobSpec, key: str, trackmem_symbol_names: bool, ctest_args
             job.static_lib = StaticLibType.A
         case SdlPlatform.FreeBSD | SdlPlatform.NetBSD | SdlPlatform.OpenBSD:
             job.cpactions = True
-            job.no_cmake = True
+            job.shell = "cpa.sh {0}"
             job.run_tests = False
             job.apt_packages = []
             job.shared_lib = SharedLibType.SO_0
@@ -821,7 +821,7 @@ def spec_to_job(spec: JobSpec, key: str, trackmem_symbol_names: bool, ctest_args
             match spec.platform:
                 case SdlPlatform.FreeBSD:
                     job.cpactions_os = "freebsd"
-                    job.cpactions_version = "14.3"
+                    job.cpactions_version = "15.0"
                     job.cpactions_arch = "x86-64"
                     job.cpactions_setup_cmd = "sudo pkg update"
                     job.cpactions_install_cmd = "sudo pkg install -y cmake ninja pkgconf libXcursor libXext libXinerama libXi libXfixes libXrandr libXScrnSaver libXxf86vm wayland wayland-protocols libxkbcommon mesa-libs libglvnd evdev-proto libinotify alsa-lib jackit pipewire pulseaudio sndio dbus zh-fcitx ibus libudev-devd"
@@ -829,6 +829,7 @@ def spec_to_job(spec: JobSpec, key: str, trackmem_symbol_names: bool, ctest_args
                         "-DSDL_CHECK_REQUIRED_INCLUDES=/usr/local/include",
                         "-DSDL_CHECK_REQUIRED_LINK_OPTIONS=-L/usr/local/lib",
                     ))
+                    fpic = True
                 case SdlPlatform.NetBSD:
                     job.cpactions_os = "netbsd"
                     job.cpactions_version = "10.1"
@@ -837,7 +838,7 @@ def spec_to_job(spec: JobSpec, key: str, trackmem_symbol_names: bool, ctest_args
                     job.cpactions_install_cmd = "sudo -E pkgin -y install cmake dbus pkgconf ninja-build pulseaudio libxkbcommon wayland wayland-protocols libinotify libusb1"
                 case SdlPlatform.OpenBSD:
                     job.cpactions_os = "openbsd"
-                    job.cpactions_version = "7.7"
+                    job.cpactions_version = "7.9"
                     job.cpactions_arch = "x86-64"
                     job.cpactions_setup_cmd = "sudo pkg_add -u"
                     job.cpactions_install_cmd = "sudo pkg_add cmake ninja pkgconf wayland wayland-protocols libxkbcommon libinotify pulseaudio dbus ibus"

--- a/.github/workflows/create-test-plan.py
+++ b/.github/workflows/create-test-plan.py
@@ -829,7 +829,6 @@ def spec_to_job(spec: JobSpec, key: str, trackmem_symbol_names: bool, ctest_args
                         "-DSDL_CHECK_REQUIRED_INCLUDES=/usr/local/include",
                         "-DSDL_CHECK_REQUIRED_LINK_OPTIONS=-L/usr/local/lib",
                     ))
-                    fpic = True
                 case SdlPlatform.NetBSD:
                     job.cpactions_os = "netbsd"
                     job.cpactions_version = "10.1"
@@ -842,6 +841,7 @@ def spec_to_job(spec: JobSpec, key: str, trackmem_symbol_names: bool, ctest_args
                     job.cpactions_arch = "x86-64"
                     job.cpactions_setup_cmd = "sudo pkg_add -u"
                     job.cpactions_install_cmd = "sudo pkg_add cmake ninja pkgconf wayland wayland-protocols libxkbcommon libinotify pulseaudio dbus ibus"
+                    fpic = True
         case SdlPlatform.NGage:
             build_parallel = False
             job.cmake_build_type = "Release"

--- a/.github/workflows/create-test-plan.py
+++ b/.github/workflows/create-test-plan.py
@@ -879,6 +879,7 @@ def spec_to_job(spec: JobSpec, key: str, trackmem_symbol_names: bool, ctest_args
                     job.cpactions_arch = "x86-64"
                     job.cpactions_setup_cmd = "sudo pkg_add -u"
                     job.cpactions_install_cmd = "sudo pkg_add cmake ninja pkgconf wayland wayland-protocols libxkbcommon libinotify pulseaudio dbus ibus"
+                    fpic = True
         case SdlPlatform.NGage:
             build_parallel = False
             job.cmake_build_type = "Release"

--- a/.github/workflows/create-test-plan.py
+++ b/.github/workflows/create-test-plan.py
@@ -851,7 +851,7 @@ def spec_to_job(spec: JobSpec, key: str, trackmem_symbol_names: bool, ctest_args
             job.static_lib = StaticLibType.A
         case SdlPlatform.FreeBSD | SdlPlatform.NetBSD | SdlPlatform.OpenBSD:
             job.cpactions = True
-            job.no_cmake = True
+            job.shell = "cpa.sh {0}"
             job.run_tests = False
             job.apt_packages = []
             job.shared_lib = SharedLibType.SO_0
@@ -859,7 +859,7 @@ def spec_to_job(spec: JobSpec, key: str, trackmem_symbol_names: bool, ctest_args
             match spec.platform:
                 case SdlPlatform.FreeBSD:
                     job.cpactions_os = "freebsd"
-                    job.cpactions_version = "14.4"
+                    job.cpactions_version = "15.0"
                     job.cpactions_arch = "x86-64"
                     job.cpactions_setup_cmd = "sudo pkg update"
                     job.cpactions_install_cmd = "sudo pkg install -y cmake ninja pkgconf libXcursor libXext libXinerama libXi libXfixes libXrandr libXScrnSaver libXxf86vm wayland wayland-protocols libxkbcommon mesa-libs libglvnd evdev-proto libinotify alsa-lib jackit pipewire pulseaudio sndio dbus zh-fcitx ibus libudev-devd"
@@ -867,6 +867,7 @@ def spec_to_job(spec: JobSpec, key: str, trackmem_symbol_names: bool, ctest_args
                         "-DSDL_CHECK_REQUIRED_INCLUDES=/usr/local/include",
                         "-DSDL_CHECK_REQUIRED_LINK_OPTIONS=-L/usr/local/lib",
                     ))
+                    fpic = True
                 case SdlPlatform.NetBSD:
                     job.cpactions_os = "netbsd"
                     job.cpactions_version = "10.1"
@@ -875,7 +876,7 @@ def spec_to_job(spec: JobSpec, key: str, trackmem_symbol_names: bool, ctest_args
                     job.cpactions_install_cmd = "sudo -E pkgin -y install cmake dbus pkgconf ninja-build pulseaudio libxkbcommon wayland wayland-protocols libinotify libusb1"
                 case SdlPlatform.OpenBSD:
                     job.cpactions_os = "openbsd"
-                    job.cpactions_version = "7.7"
+                    job.cpactions_version = "7.9"
                     job.cpactions_arch = "x86-64"
                     job.cpactions_setup_cmd = "sudo pkg_add -u"
                     job.cpactions_install_cmd = "sudo pkg_add cmake ninja pkgconf wayland wayland-protocols libxkbcommon libinotify pulseaudio dbus ibus"

--- a/.github/workflows/generic.yml
+++ b/.github/workflows/generic.yml
@@ -33,6 +33,13 @@ jobs:
         uses: cygwin/cygwin-install-action@master
         with:
           packages: ${{ matrix.platform.cygwin-packages }}
+      - name: 'Set up BSD (cross-platform-actions)'
+        if: ${{ matrix.platform.cpactions != '' }}
+        uses: cross-platform-actions/action@v1
+        with:
+          operating_system: '${{ matrix.platform.cpactions-os }}'
+          architecture: '${{ matrix.platform.cpactions-arch }}'
+          version: '${{ matrix.platform.cpactions-version }}'
       - name: 'About this job'
         run: |
           echo "key=${{ matrix.platform.key }}"
@@ -141,6 +148,11 @@ jobs:
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
           brew update
           brew install ${{ matrix.platform.brew-packages }}
+      - name: 'Install BSD packages'
+        if: ${{ matrix.platform.cpactions != '' }}
+        run: |
+          ${{ matrix.platform.cpactions-setup-cmd }}
+          ${{ matrix.platform.cpactions-install-cmd }}
       - name: 'Setup Python'
         uses: 'actions/setup-python@main'
         if: ${{ matrix.platform.setup-python }}
@@ -333,36 +345,6 @@ jobs:
           ${{ matrix.platform.ldflags && format('export LDFLAGS="{0}"', matrix.platform.ldflags) || '' }}
           export PKG_CONFIG_PATH=${{ steps.install.outputs.prefix }}/lib/pkgconfig
           cmake/test/test_pkgconfig.sh
-      - name: 'Build (cross-platform-actions, BSD)'
-        id: cpactions
-        if: ${{ matrix.platform.cpactions }}
-        uses: cross-platform-actions/action@v1
-        with:
-          operating_system: '${{ matrix.platform.cpactions-os }}'
-          architecture: '${{ matrix.platform.cpactions-arch }}'
-          version: '${{ matrix.platform.cpactions-version }}'
-          run: |
-            ${{ matrix.platform.cpactions-setup-cmd }}
-            ${{ matrix.platform.cpactions-install-cmd }}
-            cmake -S . -B build -GNinja  \
-              ${{ matrix.platform.cmake-toolchain-file != '' && format('-DCMAKE_TOOLCHAIN_FILE={0}', matrix.platform.cmake-toolchain-file) || '' }} \
-              -Wdeprecated -Wdev -Werror \
-              -DSDL_WERROR=${{ matrix.platform.werror }} \
-              -DSDL_INSTALL_DOCS=ON \
-              ${{ matrix.platform.cmake-arguments }} \
-              -DSDL_SHARED=${{ matrix.platform.shared }} \
-              -DSDL_STATIC=${{ matrix.platform.static  }} \
-              -DSDL_VENDOR_INFO="Github Workflow" \
-              -DCMAKE_INSTALL_PREFIX=prefix \
-              -DCMAKE_INSTALL_LIBDIR=lib \
-              -DCMAKE_BUILD_TYPE=${{ matrix.platform.cmake-build-type }}
-            cmake --build build/ --config ${{ matrix.platform.cmake-build-type }} --verbose
-            cmake --build build/ --config ${{ matrix.platform.cmake-build-type }} --target package
-
-            cmake --build build/ --config ${{ matrix.platform.cmake-build-type }} --target clean
-            rm -rf build/dist/_CPack_Packages
-            rm -rf build/CMakeFiles
-            rm -rf build/docs
       - name: Add msbuild to PATH
         id: setup-msbuild
         if: ${{ matrix.platform.msvc-project != '' }}
@@ -432,7 +414,7 @@ jobs:
       - name: 'Upload binary package'
         uses: actions/upload-artifact@v7
         continue-on-error: true
-        if: ${{ always() && matrix.platform.artifact != '' && (steps.package.outcome == 'success' || steps.cpactions.outcome == 'success') && (matrix.platform.enable-artifacts || steps.tests.outcome == 'failure') }}
+        if: ${{ always() && matrix.platform.artifact != '' && steps.package.outcome == 'success' && (matrix.platform.enable-artifacts || steps.tests.outcome == 'failure') }}
         with:
           if-no-files-found: error
           name: '${{ matrix.platform.artifact }}'

--- a/.github/workflows/generic.yml
+++ b/.github/workflows/generic.yml
@@ -33,6 +33,13 @@ jobs:
         uses: cygwin/cygwin-install-action@master
         with:
           packages: ${{ matrix.platform.cygwin-packages }}
+      - name: 'Set up BSD (cross-platform-actions)'
+        if: ${{ matrix.platform.cpactions != '' }}
+        uses: cross-platform-actions/action@v1
+        with:
+          operating_system: '${{ matrix.platform.cpactions-os }}'
+          architecture: '${{ matrix.platform.cpactions-arch }}'
+          version: '${{ matrix.platform.cpactions-version }}'
       - name: 'About this job'
         run: |
           echo "key=${{ matrix.platform.key }}"
@@ -145,6 +152,11 @@ jobs:
 
           brew update --auto-update
           brew install --quiet ${{ matrix.platform.brew-packages }}
+      - name: 'Install BSD packages'
+        if: ${{ matrix.platform.cpactions != '' }}
+        run: |
+          ${{ matrix.platform.cpactions-setup-cmd }}
+          ${{ matrix.platform.cpactions-install-cmd }}
       - name: 'Setup Python'
         uses: 'actions/setup-python@main'
         if: ${{ matrix.platform.setup-python }}
@@ -328,36 +340,6 @@ jobs:
           ${{ matrix.platform.ldflags && format('export LDFLAGS="{0}"', matrix.platform.ldflags) || '' }}
           export PKG_CONFIG_PATH=${{ steps.install.outputs.prefix }}/lib/pkgconfig
           cmake/test/test_pkgconfig.sh
-      - name: 'Build (cross-platform-actions, BSD)'
-        id: cpactions
-        if: ${{ matrix.platform.cpactions }}
-        uses: cross-platform-actions/action@v1
-        with:
-          operating_system: '${{ matrix.platform.cpactions-os }}'
-          architecture: '${{ matrix.platform.cpactions-arch }}'
-          version: '${{ matrix.platform.cpactions-version }}'
-          run: |
-            ${{ matrix.platform.cpactions-setup-cmd }}
-            ${{ matrix.platform.cpactions-install-cmd }}
-            cmake -S . -B build -GNinja  \
-              ${{ matrix.platform.cmake-toolchain-file != '' && format('-DCMAKE_TOOLCHAIN_FILE={0}', matrix.platform.cmake-toolchain-file) || '' }} \
-              -Wdeprecated -Wdev -Werror \
-              -DSDL_WERROR=${{ matrix.platform.werror }} \
-              -DSDL_INSTALL_DOCS=ON \
-              ${{ matrix.platform.cmake-arguments }} \
-              -DSDL_SHARED=${{ matrix.platform.shared }} \
-              -DSDL_STATIC=${{ matrix.platform.static  }} \
-              -DSDL_VENDOR_INFO="Github Workflow" \
-              -DCMAKE_INSTALL_PREFIX=prefix \
-              -DCMAKE_INSTALL_LIBDIR=lib \
-              -DCMAKE_BUILD_TYPE=${{ matrix.platform.cmake-build-type }}
-            cmake --build build/ --config ${{ matrix.platform.cmake-build-type }} --verbose
-            cmake --build build/ --config ${{ matrix.platform.cmake-build-type }} --target package
-
-            cmake --build build/ --config ${{ matrix.platform.cmake-build-type }} --target clean
-            rm -rf build/dist/_CPack_Packages
-            rm -rf build/CMakeFiles
-            rm -rf build/docs
       - name: Add msbuild to PATH
         id: setup-msbuild
         if: ${{ matrix.platform.msvc-project != '' }}
@@ -427,7 +409,7 @@ jobs:
       - name: 'Upload binary package'
         uses: actions/upload-artifact@v7
         continue-on-error: true
-        if: ${{ always() && matrix.platform.artifact != '' && (steps.package.outcome == 'success' || steps.cpactions.outcome == 'success') && (matrix.platform.enable-artifacts || steps.tests.outcome == 'failure') }}
+        if: ${{ always() && matrix.platform.artifact != '' && steps.package.outcome == 'success' && (matrix.platform.enable-artifacts || steps.tests.outcome == 'failure') }}
         with:
           if-no-files-found: error
           name: '${{ matrix.platform.artifact }}'


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description

Using the `run:` option of cpactions is deprecated, so switch over to using the `cpa.sh` shell script.
This integrates rather well with the already-existing steps.

This also bumps OpenBSD and FreeBSD ci versions.

There are some build errors with FreeBSD and NetBSD for which I need help.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
