### PR TITLE
Backport (some) macOS controller fixes to SDL2

### DIFF
--- a/src/joystick/darwin/SDL_iokitjoystick.c
+++ b/src/joystick/darwin/SDL_iokitjoystick.c
@@ -29,6 +29,7 @@
 #include "SDL_iokitjoystick_c.h"
 #include "../hidapi/SDL_hidapijoystick_c.h"
 #include "../../haptic/darwin/SDL_syshaptic_c.h" /* For haptic hot plugging */
+#include <IOKit/IOKitLib.h>
 
 #define SDL_JOYSTICK_RUNLOOP_MODE CFSTR("SDLJoystick")
 
@@ -420,6 +421,16 @@ static int GetSteamVirtualGamepadSlot(Uint16 vendor_id, Uint16 product_id, const
     return slot;
 }
 
+static SDL_bool IsControlledBy360ControllerDriver(IOHIDDeviceRef hidDevice)
+{
+    bool controlled_by_360controller = false;
+    io_service_t service = IOHIDDeviceGetService(hidDevice);
+    if (service != MACH_PORT_NULL) {
+        controlled_by_360controller = IOObjectConformsTo(service, "Xbox360ControllerClass");
+    }
+    return controlled_by_360controller? SDL_TRUE : SDL_FALSE;
+}
+
 static SDL_bool GetDeviceInfo(IOHIDDeviceRef hidDevice, recDevice *pDevice)
 {
     Sint32 vendor = 0;
@@ -477,8 +488,8 @@ static SDL_bool GetDeviceInfo(IOHIDDeviceRef hidDevice, recDevice *pDevice)
         CFNumberGetValue(refCF, kCFNumberSInt32Type, &version);
     }
 
-    if (SDL_IsJoystickXboxOne(vendor, product)) {
-        /* We can't actually use this API for Xbox controllers */
+    if (!IsControlledBy360ControllerDriver(hidDevice) && SDL_IsJoystickXboxOne(vendor, product)) {
+        // We can't actually use this API for Xbox controllers without the 360Controller driver
         return false;
     }
 
@@ -522,7 +533,7 @@ static SDL_bool JoystickAlreadyKnown(IOHIDDeviceRef ioHIDDeviceObject)
 
 #if defined(SDL_JOYSTICK_MFI)
     extern SDL_bool IOS_SupportedHIDDevice(IOHIDDeviceRef device);
-    if (IOS_SupportedHIDDevice(ioHIDDeviceObject)) {
+    if (!IsControlledBy360ControllerDriver(ioHIDDeviceObject) && IOS_SupportedHIDDevice(ioHIDDeviceObject)) {
         return SDL_TRUE;
     }
 #endif

--- a/src/joystick/hidapi/SDL_hidapi_xbox360.c
+++ b/src/joystick/hidapi/SDL_hidapi_xbox360.c
@@ -36,6 +36,10 @@
 /* Define this if you want to log all packets from the controller */
 /*#define DEBUG_XBOX_PROTOCOL*/
 
+#if defined(__MACOSX__)
+#include <IOKit/IOKitLib.h>
+#endif
+
 typedef struct
 {
     SDL_HIDAPI_Device *device;
@@ -43,6 +47,9 @@ typedef struct
     int player_index;
     SDL_bool player_lights;
     Uint8 last_state[USB_PACKET_LENGTH];
+#if defined(__MACOSX__)
+    SDL_bool controlled_by_360controller;
+#endif
 } SDL_DriverXbox360_Context;
 
 static void HIDAPI_DriverXbox360_RegisterHints(SDL_HintCallback callback, void *userdata)
@@ -62,6 +69,22 @@ static SDL_bool HIDAPI_DriverXbox360_IsEnabled(void)
     return SDL_GetHintBoolean(SDL_HINT_JOYSTICK_HIDAPI_XBOX_360,
                               SDL_GetHintBoolean(SDL_HINT_JOYSTICK_HIDAPI_XBOX, SDL_GetHintBoolean(SDL_HINT_JOYSTICK_HIDAPI, SDL_HIDAPI_DEFAULT)));
 }
+
+#if defined(__MACOSX__)
+static SDL_bool IsControlledBy360ControllerDriverMacOS(SDL_HIDAPI_Device *device)
+{
+    bool controlled_by_360controller = false;
+    if (device && device->path && SDL_strncmp("DevSrvsID:", device->path, 10) == 0) {
+        uint64_t entry_id = SDL_strtoull(device->path + 10, NULL, 10);
+        io_service_t service = IOServiceGetMatchingService(0, IORegistryEntryIDMatching(entry_id));
+        if (service != MACH_PORT_NULL) {
+            controlled_by_360controller = IOObjectConformsTo(service, "Xbox360ControllerClass");
+            IOObjectRelease(service);
+        }
+    }
+    return controlled_by_360controller? SDL_TRUE : SDL_FALSE;
+}
+#endif
 
 static SDL_bool HIDAPI_DriverXbox360_IsSupportedDevice(SDL_HIDAPI_Device *device, const char *name, SDL_GameControllerType type, Uint16 vendor_id, Uint16 product_id, Uint16 version, int interface_number, int interface_class, int interface_subclass, int interface_protocol)
 {
@@ -84,14 +107,22 @@ static SDL_bool HIDAPI_DriverXbox360_IsSupportedDevice(SDL_HIDAPI_Device *device
         /* This is the chatpad or other input interface, not the Xbox 360 interface */
         return SDL_FALSE;
     }
+#if defined(__MACOSX__)
+    if (IsControlledBy360ControllerDriverMacOS(device)) {
+        // Wired Xbox controllers are handled by this driver, when they are
+        // controlled by the 360Controller driver available from:
+        // https://github.com/360Controller/360Controller/releases
+        return SDL_TRUE;
+    }
+#endif
 #if defined(__MACOSX__) && defined(SDL_JOYSTICK_MFI)
     if (SDL_IsJoystickSteamVirtualGamepad(vendor_id, product_id, version)) {
         /* GCController support doesn't work with the Steam Virtual Gamepad */
         return SDL_TRUE;
     } else {
-        /* On macOS you can't write output reports to wired XBox controllers,
-           so we'll just use the GCController support instead.
-        */
+        // On macOS when it isn't controlled by the 360Controller driver and
+        // it doesn't look like a Steam virtual gamepad we should rely on
+        // GCController support instead.
         return SDL_FALSE;
     }
 #else
@@ -143,6 +174,9 @@ static SDL_bool HIDAPI_DriverXbox360_InitDevice(SDL_HIDAPI_Device *device)
         return SDL_FALSE;
     }
     ctx->device = device;
+#if defined(__MACOSX__)
+    ctx->controlled_by_360controller = IsControlledBy360ControllerDriverMacOS(device);
+#endif
 
     device->context = ctx;
 
@@ -203,15 +237,30 @@ static SDL_bool HIDAPI_DriverXbox360_OpenJoystick(SDL_HIDAPI_Device *device, SDL
 
 static int HIDAPI_DriverXbox360_RumbleJoystick(SDL_HIDAPI_Device *device, SDL_Joystick *joystick, Uint16 low_frequency_rumble, Uint16 high_frequency_rumble)
 {
-    Uint8 rumble_packet[] = { 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-
-    rumble_packet[3] = (low_frequency_rumble >> 8);
-    rumble_packet[4] = (high_frequency_rumble >> 8);
-
-    if (SDL_HIDAPI_SendRumble(device, rumble_packet, sizeof(rumble_packet)) != sizeof(rumble_packet)) {
-        return SDL_SetError("Couldn't send rumble packet");
+#if defined(__MACOSX__)
+    if (((SDL_DriverXbox360_Context *)device->context)->controlled_by_360controller) {
+        // On macOS the 360Controller driver uses this short report,
+        // and we need to prefix it with a magic token so hidapi passes it through untouched
+        Uint8 rumble_packet[] = { 'M', 'A', 'G', 'I', 'C', '0', 0x00, 0x04, 0x00, 0x00 };
+        rumble_packet[6 + 2] = (low_frequency_rumble >> 8);
+        rumble_packet[6 + 3] = (high_frequency_rumble >> 8);
+        if (SDL_HIDAPI_SendRumble(device, rumble_packet, sizeof(rumble_packet)) != sizeof(rumble_packet)) {
+            return SDL_SetError("Couldn't send rumble packet");
+        }
+        return 0;
     }
-    return 0;
+#endif
+    {
+        Uint8 rumble_packet[] = { 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+
+        rumble_packet[3] = (low_frequency_rumble >> 8);
+        rumble_packet[4] = (high_frequency_rumble >> 8);
+
+        if (SDL_HIDAPI_SendRumble(device, rumble_packet, sizeof(rumble_packet)) != sizeof(rumble_packet)) {
+            return SDL_SetError("Couldn't send rumble packet");
+        }
+        return 0;
+    }
 }
 
 static int HIDAPI_DriverXbox360_RumbleJoystickTriggers(SDL_HIDAPI_Device *device, SDL_Joystick *joystick, Uint16 left_rumble, Uint16 right_rumble)

--- a/src/joystick/hidapi/SDL_hidapi_xbox360.c
+++ b/src/joystick/hidapi/SDL_hidapi_xbox360.c
@@ -49,6 +49,7 @@ typedef struct
     Uint8 last_state[USB_PACKET_LENGTH];
 #if defined(__MACOSX__)
     SDL_bool controlled_by_360controller;
+    SDL_bool is_steam_virtual_gamepad;
 #endif
 } SDL_DriverXbox360_Context;
 
@@ -177,6 +178,7 @@ static SDL_bool HIDAPI_DriverXbox360_InitDevice(SDL_HIDAPI_Device *device)
     ctx->device = device;
 #if defined(__MACOSX__)
     ctx->controlled_by_360controller = IsControlledBy360ControllerDriverMacOS(device);
+    ctx->is_steam_virtual_gamepad = SDL_IsJoystickSteamVirtualGamepad(device->vendor_id, device->product_id, device->version);
 #endif
 
     device->context = ctx;
@@ -294,7 +296,10 @@ static void HIDAPI_DriverXbox360_HandleStatePacket(SDL_Joystick *joystick, SDL_D
 {
     Sint16 axis;
 #ifdef __MACOSX__
-    const SDL_bool invert_y_axes = SDL_FALSE;
+    // For backwards compatibility reasons, the 360Controller driver and the Steam Virtual
+    // Gamepad require opposite Y axis inversion on macOS
+    const SDL_bool invert_y_axes = (ctx->controlled_by_360controller ||
+                                    ctx->is_steam_virtual_gamepad) ? SDL_FALSE : SDL_TRUE;
 #else
     const SDL_bool invert_y_axes = SDL_TRUE;
 #endif

--- a/src/joystick/hidapi/SDL_hidapi_xbox360.c
+++ b/src/joystick/hidapi/SDL_hidapi_xbox360.c
@@ -116,18 +116,19 @@ static SDL_bool HIDAPI_DriverXbox360_IsSupportedDevice(SDL_HIDAPI_Device *device
     }
 #endif
 #if defined(__MACOSX__) && defined(SDL_JOYSTICK_MFI)
-    if (SDL_IsJoystickSteamVirtualGamepad(vendor_id, product_id, version)) {
-        /* GCController support doesn't work with the Steam Virtual Gamepad */
-        return SDL_TRUE;
-    } else {
-        // On macOS when it isn't controlled by the 360Controller driver and
-        // it doesn't look like a Steam virtual gamepad we should rely on
-        // GCController support instead.
-        return SDL_FALSE;
+    if (SDL_GetHintBoolean(SDL_HINT_JOYSTICK_MFI, SDL_TRUE)) {
+        if (SDL_IsJoystickSteamVirtualGamepad(vendor_id, product_id, version)) {
+            // GCController support doesn't work with the Steam Virtual Gamepad
+            return SDL_TRUE;
+        } else {
+            // On macOS when it isn't controlled by the 360Controller driver and
+            // it doesn't look like a Steam virtual gamepad we should rely on
+            // GCController support instead, if supported.
+            return SDL_FALSE;
+        }
     }
-#else
-    return (type == SDL_CONTROLLER_TYPE_XBOX360) ? SDL_TRUE : SDL_FALSE;
 #endif
+    return (type == SDL_CONTROLLER_TYPE_XBOX360) ? SDL_TRUE : SDL_FALSE;
 }
 
 static SDL_bool SetSlotLED(SDL_hid_device *dev, Uint8 slot, SDL_bool on)

--- a/src/joystick/hidapi/SDL_hidapi_xboxone.c
+++ b/src/joystick/hidapi/SDL_hidapi_xboxone.c
@@ -355,10 +355,11 @@ static SDL_bool HIDAPI_DriverXboxOne_IsEnabled(void)
 static SDL_bool HIDAPI_DriverXboxOne_IsSupportedDevice(SDL_HIDAPI_Device *device, const char *name, SDL_GameControllerType type, Uint16 vendor_id, Uint16 product_id, Uint16 version, int interface_number, int interface_class, int interface_subclass, int interface_protocol)
 {
 #if defined(__MACOSX__) && defined(SDL_JOYSTICK_MFI)
-    if (!SDL_IsJoystickBluetoothXboxOne(vendor_id, product_id)) {
+    if (SDL_GetHintBoolean(SDL_HINT_JOYSTICK_MFI, SDL_TRUE) &&
+        !SDL_IsJoystickBluetoothXboxOne(vendor_id, product_id)) {
         /* On macOS we get a shortened version of the real report and
            you can't write output reports for wired controllers, so
-           we'll just use the GCController support instead.
+           we'll just use the GCController support instead, if available.
         */
         return SDL_FALSE;
     }


### PR DESCRIPTION
SDL2 had https://github.com/libsdl-org/SDL/commit/7da728a642f2acfbba9543a3587363908d7aa1c3 backported, but not https://github.com/libsdl-org/SDL/commit/50d0e2ede2a634a2f41705b85ae65380677ee306, so I backported the latter, then I backported my two PRs (https://github.com/libsdl-org/SDL/pull/15791 and https://github.com/libsdl-org/SDL/pull/15792).

Originally, I just planned to backport my two PRs, but the Y axis inversion fix expected `IsControlledBy360ControllerDriverMacOS(device)`, so backporting the commit that added it seemed like it was probably the best route forward.

I don't have any system running the 360Controller driver, so testing would be appreciated.

I tested 360-class controllers (Logitech F310, PDP Xbox 360 wired) that don't work with macOS's native controller support with `SDL_JOYSTICK_MFI=0 SDL_HIDAPI_LIBUSB_WHITELIST=0 ./build/test/testgamecontroller` and they work as expected.

In a perfect world, I'd like to see https://github.com/libsdl-org/SDL/pull/15794 backported to SDL2, as it makes a ton more controllers work out-of-the-box on macOS, but that is a much more involved change that I don't feel qualified to backport.  At least with these fixes, they can made to work with `SDL_JOYSTICK_MFI=0 SDL_HIDAPI_LIBUSB_WHITELIST=0`.