### PR TITLE
x11: Explicitly specify EGL platform

### DIFF
--- a/src/video/x11/SDL_x11opengles.c
+++ b/src/video/x11/SDL_x11opengles.c
@@ -53,7 +53,8 @@ int X11_GLES_LoadLibrary(_THIS, const char *path)
 #endif
     }
 
-    return SDL_EGL_LoadLibrary(_this, path, (NativeDisplayType) data->display, 0);
+    return SDL_EGL_LoadLibrary(_this, path, (NativeDisplayType) data->display,
+                               EGL_PLATFORM_X11_KHR);
 }
 
 XVisualInfo *X11_GLES_GetVisual(_THIS, Display *display, int screen)


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description

Mesa's eglGetDisplay() chooses the native EGL platform from EGL_PLATFORM, limited autodetection, or the build-time default. If that selects Wayland while SDL is using the X11 video backend, Mesa can treat the X11 Display pointer as a wl_display and crash during eglInitialize().

See: https://gitlab.com/qemu-project/qemu/-/work_items/3540

## Existing Issue(s)

None