### PR TITLE
EGL: Always pass the platform type when available

### DIFF
--- a/src/video/kmsdrm/SDL_kmsdrmopengles.c
+++ b/src/video/kmsdrm/SDL_kmsdrmopengles.c
@@ -30,8 +30,8 @@
 
 #define VOID2U64(x) ((uint64_t)(size_t)(x))
 
-#ifndef EGL_PLATFORM_GBM_MESA
-#define EGL_PLATFORM_GBM_MESA 0x31D7
+#ifndef EGL_PLATFORM_GBM_KHR
+#define EGL_PLATFORM_GBM_KHR 0x31D7
 #endif
 
 #ifndef EGL_SYNC_NATIVE_FENCE_ANDROID
@@ -60,7 +60,7 @@ void KMSDRM_GLES_SetDefaultProfileConfig(SDL_VideoDevice *_this)
     _this->gl_config.minor_version = 0;
 #endif
 
-    _this->gl_config.egl_platform = EGL_PLATFORM_GBM_MESA;
+    _this->gl_config.egl_platform = EGL_PLATFORM_GBM_KHR;
 }
 
 bool KMSDRM_GLES_LoadLibrary(SDL_VideoDevice *_this, const char *path)

--- a/src/video/wayland/SDL_waylandopengles.c
+++ b/src/video/wayland/SDL_waylandopengles.c
@@ -32,22 +32,22 @@
 
 #include "xdg-shell-client-protocol.h"
 
+#ifndef EGL_PLATFORM_WAYLAND_KHR
+#define EGL_PLATFORM_WAYLAND_KHR 0x31D8
+#endif
+
 // EGL implementation of SDL OpenGL ES support
 
 void Wayland_GLES_SetDefaultProfileConfig(SDL_VideoDevice *_this)
 {
-#if defined(SDL_PLATFORM_QNXNTO)
-    // QNX defaults to EGL_PLATFORM_SCREEN_QNX unless this is explicitly specified
-    _this->gl_config.egl_platform = EGL_PLATFORM_WAYLAND_EXT;
-#endif
+    _this->gl_config.egl_platform = EGL_PLATFORM_WAYLAND_KHR;
 }
 
 bool Wayland_GLES_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 {
-    bool result;
     SDL_VideoData *data = _this->internal;
 
-    result = SDL_EGL_LoadLibrary(_this, path, (NativeDisplayType)data->display);
+    const bool result = SDL_EGL_LoadLibrary(_this, path, (NativeDisplayType)data->display);
 
     Wayland_PumpEvents(_this);
     WAYLAND_wl_display_flush(data->display);

--- a/src/video/x11/SDL_x11opengles.c
+++ b/src/video/x11/SDL_x11opengles.c
@@ -27,7 +27,16 @@
 #include "SDL_x11opengl.h"
 #include "SDL_x11xsync.h"
 
+#ifndef EGL_PLATFORM_X11_KHR
+#define EGL_PLATFORM_X11_KHR 0x31D5
+#endif
+
 // EGL implementation of SDL OpenGL support
+
+void X11_GLES_SetDefaultProfileConfig(SDL_VideoDevice *_this)
+{
+    _this->gl_config.egl_platform = EGL_PLATFORM_X11_KHR;
+}
 
 bool X11_GLES_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 {

--- a/src/video/x11/SDL_x11opengles.h
+++ b/src/video/x11/SDL_x11opengles.h
@@ -49,6 +49,7 @@ extern SDL_GLContext X11_GLES_CreateContext(SDL_VideoDevice *_this, SDL_Window *
 extern bool X11_GLES_SwapWindow(SDL_VideoDevice *_this, SDL_Window *window);
 extern bool X11_GLES_MakeCurrent(SDL_VideoDevice *_this, SDL_Window *window, SDL_GLContext context);
 extern SDL_EGLSurface X11_GLES_GetEGLSurface(SDL_VideoDevice *_this, SDL_Window *window);
+extern void X11_GLES_SetDefaultProfileConfig(SDL_VideoDevice *_this);
 
 #endif // SDL_VIDEO_OPENGL_EGL
 

--- a/src/video/x11/SDL_x11video.c
+++ b/src/video/x11/SDL_x11video.c
@@ -238,6 +238,7 @@ static SDL_VideoDevice *X11_CreateDevice(void)
         device->GL_SwapWindow = X11_GLES_SwapWindow;
         device->GL_DestroyContext = X11_GLES_DestroyContext;
         device->GL_GetEGLSurface = X11_GLES_GetEGLSurface;
+        device->GL_SetDefaultProfileConfig = X11_GLES_SetDefaultProfileConfig;
 #ifdef SDL_VIDEO_OPENGL_GLX
     }
 #endif


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Always pass the EGL platform type for Wayland and X11, or the driver could potentially select the wrong backend if certain envvars are misconfigured.

SDL3 version of #15806