### PR TITLE
ci: add permissions and pin action SHAs (3 workflows)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   controller:
     name: 'Create test plan'
@@ -14,10 +16,10 @@ jobs:
       platforms-level1: ${{ steps.plan.outputs.platforms-level1 }}
       platforms-others: ${{ steps.plan.outputs.platforms-others }}
     steps:
-      - uses: actions/setup-python@main
+      - uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48  # main
         with:
           python-version: 3.x
-      - uses: actions/checkout@main
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # main
         with:
           sparse-checkout: '.github/workflows/create-test-plan.py'
       - name: 'Create plan'

--- a/.github/workflows/generic.yml
+++ b/.github/workflows/generic.yml
@@ -9,6 +9,8 @@ on:
         type: string
         required: true
 
+permissions: read-all
+
 jobs:
   build:
     name: ${{ matrix.platform.name }}
@@ -24,13 +26,13 @@ jobs:
     steps:
       - name: 'Set up MSYS2'
         if: ${{ matrix.platform.platform == 'msys2' }}
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c  # v2
         with:
           msystem: ${{ matrix.platform.msys2-msystem }}
           install: ${{ matrix.platform.msys2-packages }}
       - name: 'Set up Cygwin'
         if: ${{ matrix.platform.platform == 'cygwin' }}
-        uses: cygwin/cygwin-install-action@master
+        uses: cygwin/cygwin-install-action@781ea34f8c7c28e794b807fb7120e93bfdac3089  # master
         with:
           packages: ${{ matrix.platform.cygwin-packages }}
       - name: 'About this job'
@@ -40,7 +42,7 @@ jobs:
           echo "os=${{ matrix.platform.os }}"
           echo ""
           echo "Add [sdl-ci-filter ${{ matrix.platform.key }}] to your commit message to reduce the number of jobs."
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - name: 'Set up ninja'
         if: ${{ matrix.platform.setup-ninja }}
         uses: ./.github/actions/setup-ninja
@@ -49,11 +51,11 @@ jobs:
         uses: ./.github/actions/setup-msvc-libusb
         with:
           arch: ${{ matrix.platform.setup-libusb-arch }}
-      - uses: mymindstorm/setup-emsdk@v15
+      - uses: mymindstorm/setup-emsdk@667eb33f24e84e7f362c16d8d7fff0629a73e15e  # v15
         if: ${{ matrix.platform.platform == 'emscripten' }}
         with:
           version: 3.1.35
-      - uses: browser-actions/setup-chrome@v2
+      - uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd  # v2
         id: setup-chrome
         if: ${{ matrix.platform.platform == 'emscripten' }}
         with:
@@ -69,7 +71,7 @@ jobs:
           echo "chromedriver_dir=${chromedriver_dir}"
           echo "${chrome_dir}" >>${GITHUB_PATH}
           echo "${chromedriver_dir}" >>${GITHUB_PATH}
-      - uses: nttld/setup-ndk@v1
+      - uses: nttld/setup-ndk@ed92fe6cadad69be94a966a7ee3271275e62f779  # v1
         if: ${{ matrix.platform.android-ndk }}
         id: setup-ndk
         with:
@@ -81,12 +83,12 @@ jobs:
         run: |
           # We cannot use GitHub expressions in the controller job
           echo "ANDROID_NDK_HOME=${{ steps.setup-ndk.outputs.ndk-path }}" >>$GITHUB_ENV
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5
         if: ${{ matrix.platform.java }}
         with:
           distribution: 'temurin'
           java-version: '17'
-      - uses: TheMrMilchmann/setup-msvc-dev@v4
+      - uses: TheMrMilchmann/setup-msvc-dev@79dac248aac9d0059f86eae9d8b5bfab4e95e97c  # v4
         if: ${{ matrix.platform.platform == 'msvc' }}
         with:
           arch: ${{ matrix.platform.msvc-vcvars-arch }}
@@ -186,7 +188,7 @@ jobs:
           echo "timestamp=$(date -u "+%Y%m%d%H%M_%S")" >> "$GITHUB_OUTPUT"
       - name: 'Restore ccache'
         if: ${{ matrix.platform.ccache }}
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         id: restore-ccache
         with:
           path: ${{ runner.temp }}/ccache
@@ -334,7 +336,7 @@ jobs:
       - name: 'Build (cross-platform-actions, BSD)'
         id: cpactions
         if: ${{ matrix.platform.cpactions }}
-        uses: cross-platform-actions/action@v1
+        uses: cross-platform-actions/action@be3d7e9ff5c8770b9c51b1a8c8c5446e1cad7cf9  # v1
         with:
           operating_system: '${{ matrix.platform.cpactions-os }}'
           architecture: '${{ matrix.platform.cpactions-arch }}'
@@ -364,7 +366,7 @@ jobs:
       - name: Add msbuild to PATH
         id: setup-msbuild
         if: ${{ matrix.platform.msvc-project != '' }}
-        uses: microsoft/setup-msbuild@v3
+        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57  # v3
       - name: Build msbuild
         if: ${{ matrix.platform.msvc-project != '' }}
         run: |
@@ -408,7 +410,7 @@ jobs:
           ccache -s
       - name: 'Save ccache'
         if: ${{ matrix.platform.ccache }}
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ${{ runner.temp }}/ccache
           key: ${{ steps.restore-ccache.outputs.cache-primary-key }}
@@ -428,7 +430,7 @@ jobs:
         run: |
           find ./ -iname '*.so' | xargs -L1 ./build-scripts/check_elf_alignment.sh
       - name: 'Upload binary package'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         continue-on-error: true
         if: ${{ always() && matrix.platform.artifact != '' && (steps.package.outcome == 'success' || steps.cpactions.outcome == 'success') && (matrix.platform.enable-artifacts || steps.tests.outcome == 'failure') }}
         with:
@@ -439,7 +441,7 @@ jobs:
             build/include*
             build/CMakeFiles/CMakeConfigureLog.yaml
       - name: 'Upload minidumps'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         continue-on-error: true
         if: ${{ always() && steps.tests.outcome == 'failure' && (matrix.platform.platform == 'msvc' || matrix.platform.platform == 'msys2') }}
         with:
@@ -447,7 +449,7 @@ jobs:
           name: '${{ matrix.platform.artifact }}-minidumps'
           path: build/**/*.dmp
       - name: "Upload Android test apk's"
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         continue-on-error: true
         if: ${{ matrix.platform.enable-artifacts && always() && matrix.platform.artifact != '' && steps.apks.outcome == 'success' }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
         description: 'Commit of SDL'
         required: true
 
+permissions: read-all
+
 jobs:
 
   src:
@@ -20,15 +22,15 @@ jobs:
       src-zip: ${{ steps.releaser.outputs.src-zip }}
     steps:
       - name: 'Set up Python'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: '3.11'
       - name: 'Fetch build-release.py'
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           sparse-checkout: 'build-scripts/build-release.py'
       - name: 'Set up SDL sources'
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           path: 'SDL'
           fetch-depth: 0
@@ -43,7 +45,7 @@ jobs:
             --github \
             --debug
       - name: 'Store source archives'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: sources
           path: '${{ github.workspace}}/dist'
@@ -61,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Download source archives'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: sources
           path: '${{ github.workspace }}'
@@ -114,15 +116,15 @@ jobs:
       dmg: ${{ steps.releaser.outputs.dmg }}
     steps:
       - name: 'Set up Python'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: '3.11'
       - name: 'Fetch build-release.py'
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           sparse-checkout: 'build-scripts/build-release.py'
       - name: 'Download source archives'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: sources
           path: '${{ github.workspace }}'
@@ -143,7 +145,7 @@ jobs:
             --github \
             --debug
       - name: 'Store DMG image file'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: dmg
           path: '${{ github.workspace }}/dist'
@@ -153,12 +155,12 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: 'Download source archives'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: sources
           path: '${{ github.workspace }}'
       - name: 'Download ${{ needs.dmg.outputs.dmg }}'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: dmg
           path: '${{ github.workspace }}'
@@ -322,15 +324,15 @@ jobs:
       VC-devel: ${{ steps.releaser.outputs.VC-devel }}
     steps:
       - name: 'Set up Python'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: '3.11'
       - name: 'Fetch build-release.py'
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           sparse-checkout: 'build-scripts/build-release.py'
       - name: 'Download source archives'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: sources
           path: '${{ github.workspace }}'
@@ -351,7 +353,7 @@ jobs:
             --github `
             --debug
       - name: 'Store MSVC archives'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: win32
           path: '${{ github.workspace }}/dist'
@@ -361,16 +363,16 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: 'Fetch .github/actions/setup-ninja/action.yml'
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           sparse-checkout: '.github/actions/setup-ninja/action.yml'
       - name: 'Download source archives'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: sources
           path: '${{ github.workspace }}'
       - name: 'Download MSVC binaries'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: win32
           path: '${{ github.workspace }}'
@@ -391,7 +393,7 @@ jobs:
       - name: Set up ninja
         uses: ./.github/actions/setup-ninja
       - name: 'Configure vcvars x86'
-        uses: TheMrMilchmann/setup-msvc-dev@v4
+        uses: TheMrMilchmann/setup-msvc-dev@79dac248aac9d0059f86eae9d8b5bfab4e95e97c  # v4
         with:
           arch: x64_x86
       - name: 'CMake (configure + build + tests) x86'
@@ -411,7 +413,7 @@ jobs:
           cmake --build build_x86 --config Release --verbose
           ctest --test-dir build_x86 --no-tests=error -C Release --output-on-failure
       - name: 'Configure vcvars x64'
-        uses: TheMrMilchmann/setup-msvc-dev@v4
+        uses: TheMrMilchmann/setup-msvc-dev@79dac248aac9d0059f86eae9d8b5bfab4e95e97c  # v4
         with:
           arch: x64
       - name: 'CMake (configure + build + tests) x64'
@@ -431,7 +433,7 @@ jobs:
           cmake --build build_x64 --config Release --verbose
           ctest --test-dir build_x64 --no-tests=error -C Release --output-on-failure
       - name: 'Configure vcvars arm64'
-        uses: TheMrMilchmann/setup-msvc-dev@v4
+        uses: TheMrMilchmann/setup-msvc-dev@79dac248aac9d0059f86eae9d8b5bfab4e95e97c  # v4
         with:
           arch: x64_arm64
       - name: 'CMake (configure + build) arm64'
@@ -481,11 +483,11 @@ jobs:
       mingw-devel-tar-xz: ${{ steps.releaser.outputs.mingw-devel-tar-xz }}
     steps:
       - name: 'Set up Python'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: '3.11'
       - name: 'Fetch build-release.py'
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           sparse-checkout: 'build-scripts/build-release.py'
       - name: 'Install Mingw toolchain'
@@ -493,7 +495,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y gcc-mingw-w64 g++-mingw-w64 ninja-build
       - name: 'Download source archives'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: sources
           path: '${{ github.workspace }}'
@@ -513,7 +515,7 @@ jobs:
             --github \
             --debug
       - name: 'Store MinGW archives'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: mingw
           path: '${{ github.workspace }}/dist'
@@ -527,12 +529,12 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y gcc-mingw-w64 g++-mingw-w64 ninja-build
       - name: 'Download source archives'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: sources
           path: '${{ github.workspace }}'
       - name: 'Download MinGW binaries'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: mingw
           path: '${{ github.workspace }}'
@@ -582,21 +584,21 @@ jobs:
       android-aar: ${{ steps.releaser.outputs.android-aar }}
     steps:
       - name: 'Set up Python'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: '3.11'
       - name: 'Fetch build-release.py'
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
           sparse-checkout: 'build-scripts/build-release.py'
       - name: 'Setup Android NDK'
         id: setup-ndk
-        uses: nttld/setup-ndk@v1
+        uses: nttld/setup-ndk@ed92fe6cadad69be94a966a7ee3271275e62f779  # v1
         with:
           local-cache: false
           ndk-version: r28c
       - name: 'Setup Java JDK'
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5
         with:
           distribution: 'temurin'
           java-version: '11'
@@ -605,7 +607,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y ninja-build
       - name: 'Download source archives'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: sources
           path: '${{ github.workspace }}'
@@ -627,7 +629,7 @@ jobs:
             --github \
             --debug
       - name: 'Store Android archive(s)'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: android
           path: '${{ github.workspace }}/dist'
@@ -637,20 +639,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Set up Python'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: '3.11'
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5
         with:
           distribution: 'temurin'
           java-version: '17'
       - name: 'Download source archives'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: sources
           path: '${{ github.workspace }}'
       - name: 'Download Android .aar archive'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: android
           path: '${{ github.workspace }}'


### PR DESCRIPTION
## Summary

Three CI workflows are missing top-level `permissions` declarations and reference several actions by mutable tags or branch names.

**Highest-risk references fixed:**
- `actions/checkout@main` → pinned to commit SHA (any push to `actions/checkout`'s main branch would immediately execute in your CI)
- `actions/setup-python@main` → pinned to commit SHA (same risk)
- `cygwin/cygwin-install-action@master` → pinned to commit SHA

**All mutable tags pinned:**
`actions/checkout@v6`, `actions/setup-python@v6`, `actions/download-artifact@v8`, `actions/setup-java@v5`, `actions/upload-artifact@v7`, `actions/cache/restore@v5`, `actions/cache/save@v5`, `browser-actions/setup-chrome@v2`, `cross-platform-actions/action@v1`, `microsoft/setup-msbuild@v3`, `msys2/setup-msys2@v2`, `mymindstorm/setup-emsdk@v15`, `nttld/setup-ndk@v1`, `TheMrMilchmann/setup-msvc-dev@v4`

Pinning to a full commit SHA ensures only the audited version of each action runs, regardless of upstream changes or a compromised tag/branch.