### PR TITLE
Fix web crash for joystick without vibration

### DIFF
--- a/src/joystick/emscripten/SDL_sysjoystick.c
+++ b/src/joystick/emscripten/SDL_sysjoystick.c
@@ -506,7 +506,11 @@ static bool EMSCRIPTEN_JoystickOpen(SDL_Joystick *joystick, int device_index)
 
     item->rumble_available = MAIN_THREAD_EM_ASM_INT({
         let gamepad = navigator['getGamepads']()[$0];
-        return gamepad && 'vibrationActuator' in gamepad; // Don't check the vibrationActuator.effects array here, because it's not defined in Safari
+        // Don't check the vibrationActuator.effects array here, because it's not defined in Safari
+        if (!gamepad || !gamepad['vibrationActuator']) {
+            return false;
+        }
+        return true;
         }, item->index);
 
     if (item->rumble_available) {
@@ -516,7 +520,10 @@ static bool EMSCRIPTEN_JoystickOpen(SDL_Joystick *joystick, int device_index)
     item->trigger_rumble_available = MAIN_THREAD_EM_ASM_INT({
         let gamepad = navigator['getGamepads']()[$0];
         // This effect is not supported in Safari, so it's okay for us to check the vibrationActuator.effects array here for the browsers that do support it
-        return gamepad && 'vibrationActuator' in gamepad && 'effects' in gamepad['vibrationActuator'] && gamepad['vibrationActuator']['effects']['includes']('trigger-rumble');
+        if (!gamepad || !gamepad['vibrationActuator'] || !gamepad['vibrationActuator']['effects'] || !gamepad['vibrationActuator']['effects']['includes']('trigger-rumble')) {
+            return false;
+        }
+        return true;
         }, item->index);
 
     if (item->trigger_rumble_available) {


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
One more PR to fix the web joystick vibration 😅 
This time the crash was happening because `vibrationActuator` property is defined in the gamepad object, but it's null for controllers with no vibration, so the code was accessing the vibration properties on `null` object.

## Existing Issue(s)
None.
