### PR TITLE
Fix Xbox One controller detection on the web

### DIFF
--- a/src/joystick/emscripten/SDL_sysjoystick.c
+++ b/src/joystick/emscripten/SDL_sysjoystick.c
@@ -147,20 +147,38 @@ static EM_BOOL Emscripten_JoyStickConnected(int eventType, const EmscriptenGamep
     vendor = SDL_GetEmscriptenJoystickVendor(gamepadEvent->index);
     product = SDL_GetEmscriptenJoystickProduct(gamepadEvent->index);
     is_xinput = SDL_IsEmscriptenJoystickXInput(gamepadEvent->index);
-
-    // Use a generic VID/PID representing an XInput controller
-    if (!vendor && !product && is_xinput) {
-        vendor = USB_VENDOR_MICROSOFT;
-        product = USB_PRODUCT_XBOX360_XUSB_CONTROLLER;
-    }
     
     os_id = SDL_GetEmscriptenOSID();
+
+    item->trigger_rumble_available = MAIN_THREAD_EM_ASM_INT({
+        let gamepad = navigator['getGamepads']()[$0];
+        // This effect is not supported in Safari, so it's okay for us to check the vibrationActuator.effects array here for the browsers that do support it
+        if (!gamepad || !gamepad['vibrationActuator'] || !gamepad['vibrationActuator']['effects'] || !gamepad['vibrationActuator']['effects']['includes']('trigger-rumble')) {
+            return false;
+        }
+        return true;
+        }, item->index);
 
     if (os_id != 0) {
         if (os_id == 1 || os_id == 3) { // Android or iOS (mobile)
             bus = SDL_HARDWARE_BUS_BLUETOOTH;
         } else { // Desktop
             bus = SDL_HARDWARE_BUS_USB;
+        }
+    }
+
+    if (!vendor && !product && is_xinput) {
+        // Use a generic VID/PID representing an XInput controller
+        vendor = USB_VENDOR_MICROSOFT;
+        product = USB_PRODUCT_XBOX360_XUSB_CONTROLLER;
+
+        if (item->trigger_rumble_available) {
+            // Assume Xbox One S Controller
+            if (bus == SDL_HARDWARE_BUS_BLUETOOTH) {
+                product = USB_PRODUCT_XBOX_ONE_S_REV1_BLUETOOTH;
+            } else {
+                product = USB_PRODUCT_XBOX_ONE_S;
+            }            
         }
     }
 
@@ -513,15 +531,7 @@ static bool EMSCRIPTEN_JoystickOpen(SDL_Joystick *joystick, int device_index)
         SDL_SetBooleanProperty(SDL_GetJoystickProperties(joystick), SDL_PROP_JOYSTICK_CAP_RUMBLE_BOOLEAN, true);
     }
 
-    item->trigger_rumble_available = MAIN_THREAD_EM_ASM_INT({
-        let gamepad = navigator['getGamepads']()[$0];
-        // This effect is not supported in Safari, so it's okay for us to check the vibrationActuator.effects array here for the browsers that do support it
-        if (!gamepad || !gamepad['vibrationActuator'] || !gamepad['vibrationActuator']['effects'] || !gamepad['vibrationActuator']['effects']['includes']('trigger-rumble')) {
-            return false;
-        }
-        return true;
-        }, item->index);
-
+    // item->trigger_rumble_available is set in Emscripten_JoyStickConnected
     if (item->trigger_rumble_available) {
         SDL_SetBooleanProperty(SDL_GetJoystickProperties(joystick), SDL_PROP_JOYSTICK_CAP_TRIGGER_RUMBLE_BOOLEAN, true);
     }


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
Requires https://github.com/libsdl-org/SDL/pull/15814 to be merged first.
This PR fixes Xbox One controller detection in Emscripten joystick backend by taking the trigger rumble detection into account.
This PR works in Microsoft Edge and other Chromium browsers, but not Firefox or Safari, because they don't have this vibration effect implemented.
Here's how my Xbox One controller gets detected now:
<img width="1363" height="497" alt="image" src="https://github.com/user-attachments/assets/e62b5592-5346-4c6e-b886-e2327483f0a1" />

PS4 controller in XInput mode via 8BitDo Adapter:
<img width="1358" height="478" alt="image" src="https://github.com/user-attachments/assets/d6b086ef-6e3e-4998-9a99-e989a3c7b25e" />

## Existing Issue(s)
None