### PR TITLE
Fix JoyCon triggers on the web

### DIFF
--- a/src/joystick/emscripten/SDL_sysjoystick.c
+++ b/src/joystick/emscripten/SDL_sysjoystick.c
@@ -196,6 +196,7 @@ static EM_BOOL Emscripten_JoyStickConnected(int eventType, const EmscriptenGamep
     const int real_button_count = gamepadEvent->numButtons;
     const int real_axis_count = gamepadEvent->numAxes;
     int first_trigger_button = -1;
+    int first_trigger_axis = real_axis_count;
     int first_hat_button = -1;
     int num_buttons = gamepadEvent->numButtons;
     int num_axes = gamepadEvent->numAxes;
@@ -206,6 +207,10 @@ static EM_BOOL Emscripten_JoyStickConnected(int eventType, const EmscriptenGamep
 
         if (num_axes == 4) {  // Chrome gives the triggers analog button values, Firefox exposes them as extra axes. Both have the digital buttons.
             num_axes += 2;  // the two trigger "buttons"
+            triggers_are_buttons = true;
+        } else if (num_axes == 2) { // JoyCon controllers separately have 2 axes each
+            num_axes += 4;  // the two trigger "buttons" and 2 dummy axes for the right stick
+            first_trigger_axis = 4;
             triggers_are_buttons = true;
         }
 
@@ -240,8 +245,8 @@ static EM_BOOL Emscripten_JoyStickConnected(int eventType, const EmscriptenGamep
     }
 
     if (item->triggers_are_buttons) {
-        item->axis[real_axis_count] = (gamepadEvent->analogButton[first_trigger_button] * 2.0f) - 1.0f;
-        item->axis[real_axis_count+1] = (gamepadEvent->analogButton[first_trigger_button+1] * 2.0f) - 1.0f;
+        item->axis[first_trigger_axis] = (gamepadEvent->analogButton[first_trigger_button] * 2.0f) - 1.0f;
+        item->axis[first_trigger_axis+1] = (gamepadEvent->analogButton[first_trigger_button+1] * 2.0f) - 1.0f;
     }
 
     SDL_assert(item->nhats <= 1);  // there is (currently) only ever one of these, faked from the d-pad buttons.
@@ -548,6 +553,11 @@ static void EMSCRIPTEN_JoystickUpdate(SDL_Joystick *joystick)
                 const int first_trigger_button = item->first_trigger_button;
                 const int real_button_count = gamepadState.numButtons;
                 const int real_axis_count = gamepadState.numAxes;
+                int first_trigger_axis = real_axis_count;
+                
+                if (real_axis_count == 2) {
+                    first_trigger_axis = 4;
+                }
 
                 int buttonidx = 0;
                 for (i = 0; i < real_button_count; i++, buttonidx++) {
@@ -575,9 +585,9 @@ static void EMSCRIPTEN_JoystickUpdate(SDL_Joystick *joystick)
 
                 if (item->triggers_are_buttons) {
                     for (i = 0; i < 2; i++) {
-                        if (item->axis[real_axis_count+i] != gamepadState.analogButton[first_trigger_button+i]) {
-                            SDL_SendJoystickAxis(timestamp, item->joystick, real_axis_count+i, (Sint16)(32767.0f * ((gamepadState.analogButton[first_trigger_button+i] * 2.0f) - 1.0f)));
-                            item->axis[real_axis_count+i] = gamepadState.analogButton[first_trigger_button+i];
+                        if (item->axis[first_trigger_axis+i] != gamepadState.analogButton[first_trigger_button+i]) {
+                            SDL_SendJoystickAxis(timestamp, item->joystick, first_trigger_axis+i, (Sint16)(32767.0f * ((gamepadState.analogButton[first_trigger_button+i] * 2.0f) - 1.0f)));
+                            item->axis[first_trigger_axis+i] = gamepadState.analogButton[first_trigger_button+i];
                         }
                     }
                 }


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
This PR fixes JoyCon controller triggers detection in case they're in mini gamepad mode.
Previously they weren't detected because the browser reported having 2 real axes, while the SDL code expected to have at least 4.

The triggers still don't work correctly in Firefox, because they're detected as d-pad inputs, so I think that's a bug in the browser itself.

## Existing Issue(s)
None
