### PR TITLE
Don't modify the driver signature on the web for XInput controllers

### DIFF
--- a/src/joystick/emscripten/SDL_sysjoystick.c
+++ b/src/joystick/emscripten/SDL_sysjoystick.c
@@ -182,10 +182,6 @@ static EM_BOOL Emscripten_JoyStickConnected(int eventType, const EmscriptenGamep
         item->guid.data[15] = os_id;
     }
 
-    if (is_xinput) {
-        item->guid.data[14] = 'x'; // See SDL_IsJoystickXInput
-    }
-
     item->mapping = SDL_strdup(gamepadEvent->mapping);
     if (!item->mapping) {
         SDL_free(item->name);


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
This PR removes the code that changes the driver signature to the value of `'x'`, since at the time it was written I misunderstood the purpose of `SDL_IsJoystickXInput` function. This function reports if the controller is of type XInput, and if it is, other SDL code gets the type of XInput controller from the device subtype section, which is used for a different purpose in the Emscripten joystick backend.

## Existing Issue(s)
None
