### PR TITLE
Add new controller mappings for the web from Nintorch

### DIFF
--- a/src/joystick/SDL_gamepad_db.h
+++ b/src/joystick/SDL_gamepad_db.h
@@ -863,6 +863,10 @@ static const char *s_GamepadMappings[] = {
 #endif
 #ifdef SDL_JOYSTICK_EMSCRIPTEN
     "default,*,a:b0,b:b1,back:b6,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b10,leftshoulder:b4,leftstick:b8,lefttrigger:a4,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b9,righttrigger:a5,rightx:a2,righty:a3,start:b7,x:b2,y:b3,",
+    "030000007e0500000620000000000085,Nintendo Switch Joy-Con (L),a:b0,b:b1,guide:b10,leftshoulder:b4,leftstick:b8,leftx:a0,lefty:a1,paddle2:b6,paddle4:a4,rightshoulder:b5,start:b7,x:b2,y:b3,",
+    "030000007e0500000e20000000000085,Nintendo Switch Joy-Con (L/R),a:b0,b:b1,back:b6,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b10,leftshoulder:b4,leftstick:b8,lefttrigger:a4,leftx:a0,lefty:a1,misc1:b11,paddle1:b15,paddle2:b12,paddle3:b14,paddle4:b13,rightshoulder:b5,rightstick:b9,righttrigger:a5,rightx:a2,righty:a3,start:b7,x:b2,y:b3,",
+    "030000007e0500000720000000000085,Nintendo Switch Joy-Con (R),a:b0,b:b1,guide:b10,leftshoulder:b4,leftstick:b8,leftx:a0,lefty:a1,paddle1:b6,paddle3:a5,rightshoulder:b5,start:b7,x:b2,y:b3,",
+    "030000004c050000cc09000000000085,PS4 Controller,a:b0,b:b1,back:b6,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b10,leftshoulder:b4,leftstick:b8,lefttrigger:a4,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b9,righttrigger:a5,rightx:a2,righty:a3,start:b7,touchpad:b11,x:b2,y:b3,",
 #endif
 #ifdef SDL_JOYSTICK_PS2
     "0000000050533220436f6e74726f6c00,PS2 Controller,crc:ed87,a:b14,b:b13,back:b0,dpdown:b6,dpleft:b7,dpright:b5,dpup:b4,leftshoulder:b10,leftstick:b1,lefttrigger:b8,leftx:a0,lefty:a1,rightshoulder:b11,rightstick:b2,righttrigger:b9,rightx:a2,righty:a3,start:b3,x:b15,y:b12,",


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
This PR adds controller mappings for my DualShock 4 and JoyCon controllers to make their mappings match the HIDAPI mappings:
- DualShock 4: touchpad button is now detected
- JoyCons: "paddle" buttons are now properly detected for both mini-gamepad and combined modes

The mappings here are done for Chromium browsers on Windows (tested in Microsoft Edge).
The DualShock mapping also works for Firefox, but the JoyCon ones don't work properly due to possible bugs in the browser. In this case should these mappings be removed or should we file a bug report for Firefox?

But this PR begs the question: should we start adding new gamepad mappings to the Emscripten joystick backend, or should we wait until the GUID is finalized, if it ever does?

If we want to start adding new mappings, I think we should document the rules for them, here are the ones I propose:
- Mappings for controllers that are already mapped by the browser (the `mapping` property contains the `"standard"` string and the device subtype (in hex) in the controller's GUID starts with 8) should adhere to the standard browser mapping (or the one inside Chrome, if it's correct). If the browser's internal mapping is incorrect, an SDL mapping shouldn't be made, and a bug report should probably be filed for the browser. This is done in case the browser mapping ever becomes different in the future due to bug fixes, so SDL's mapping doesn't become broken.
- If the controller doesn't have a browser mapping (the device subtype starts with 0), then the mapping should follow the same rules as on other platforms.

There are also controller mappings for the web from Godot that SDL may or may not want to add as well:
https://github.com/godotengine/godot/blob/eb03ae8fc5465793f8f617d7a320e3b208f16919/core/input/godotcontrollerdb.txt#L27-L52
They may not be fully compatible due to SDL removing d-pad and triggers from the buttons, I'll check it out properly later and make a PR, if acceptable.

Please let me know what you think about this!

## Existing Issue(s)
None
