### PR TITLE
Add normalized names for Emscripten joysticks

### DIFF
--- a/src/joystick/emscripten/SDL_sysjoystick.c
+++ b/src/joystick/emscripten/SDL_sysjoystick.c
@@ -120,6 +120,41 @@ static int SDL_GetEmscriptenOSID()
     });
 }
 
+EM_JS_DEPS(sdljoystick, "$stringToUTF8");
+
+static void SDL_GetEmscriptenNormalizedName(int device_index, char *out, int length)
+{
+    MAIN_THREAD_EM_ASM({
+        let gamepad = navigator['getGamepads']()[$0];
+        if (!gamepad) {
+            stringToUTF8('\0', $1, $2); // Silence the compiler here, because '' is not valid
+            return;
+        }
+
+        let id = gamepad['id'];
+        let output = id;
+        // Chrome
+        if (id['indexOf'](' (STANDARD GAMEPAD') > 0) { // Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 09cc)
+            output = id['substr'](0, id['indexOf'](' (STANDARD GAMEPAD'));
+        } else if (id['indexOf'](' (Vendor:') > 0) { // usb gamepad            (Vendor: 0810 Product: e501)
+            output = id['substr'](0, id['indexOf'](' (Vendor:'));
+        } else if (id['indexOf'](' (XInput') > 0) { // Xbox 360 Controller (XInput STANDARD GAMEPAD)
+            output = id['substr'](0, id['indexOf'](' (XInput'));
+        }
+
+        // Firefox, Safari: "046d-c216-Logitech Dual Action", "46d-c216-Logicool Dual Action", or "xinput"
+        let id_split = id['split']('-');
+        if (id_split['length'] > 1 && !isNaN(parseInt(id_split[0], 16))) {
+            // Let's not assume the length of the vendor/product IDs in the string
+            // and just find the second '-' using indexOf
+            let start = id['indexOf']('-', id['indexOf']('-')+1)+1;
+            output = id['substr'](start);
+        }
+
+        stringToUTF8(output.trim(), $1, $2);
+    }, device_index, out, length);
+}
+
 static EM_BOOL Emscripten_JoyStickConnected(int eventType, const EmscriptenGamepadEvent *gamepadEvent, void *userData)
 {
     SDL_joylist_item *item;
@@ -128,6 +163,7 @@ static EM_BOOL Emscripten_JoyStickConnected(int eventType, const EmscriptenGamep
     Uint16 vendor, product;
     Uint8 os_id;
     bool is_xinput;
+    char name[128];
 
     SDL_LockJoysticks();
 
@@ -187,14 +223,15 @@ static EM_BOOL Emscripten_JoyStickConnected(int eventType, const EmscriptenGamep
         os_id += 0x80;
     }
 
-    item->name = SDL_CreateJoystickName(vendor, product, NULL, gamepadEvent->id);
+    SDL_GetEmscriptenNormalizedName(gamepadEvent->index, name, sizeof(name));
+    item->name = SDL_CreateJoystickName(vendor, product, NULL, name);
     if (!item->name) {
         SDL_free(item);
         goto done;
     }
 
     if (vendor && product) {
-        item->guid = SDL_CreateJoystickGUID(bus, vendor, product, 0, NULL, gamepadEvent->id, 0, os_id);
+        item->guid = SDL_CreateJoystickGUID(bus, vendor, product, 0, NULL, name, 0, os_id);
     } else {
         item->guid = SDL_CreateJoystickGUIDForName(item->name);
         item->guid.data[15] = os_id;


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
This PR normalizes the joystick names for the Emscripten joystick backend (i.e. removes the vendor/product IDs from the name, because they can be retrieved from the GUID). Here's a table that shows the current and new names:

| |Chrome, current|Chrome, new|Firefox, current|Firefox, new|
| ----------- | ----------- | ----------- | ----------- | ----------- |
|An unmapped controller|`usb gamepad (Vendor: 0810 Product: e501)`|`usb gamepad`|`0810-e501-usb gamepad`|`usb gamepad`|
|PS4 controller with 8BitDo adapter in XInput mode|`Xbox 360 Wireless Controller`|`Xbox 360 Wireless Controller`|`Xbox 360 Wireless Controller`|`Xbox 360 Wireless Controller`|
|PS4 controller|`Wireless Controller (STANDARD GAMEPAD Vendor: 054c Product: 09c`|`Wireless Controller`|`054c-09cc-Wireless Controller`|`Wireless Controller`|
|Xbox One controller|`Xbox One S Controller`|`Xbox One S Controller`|`Xbox 360 Wireless Controller`|`Xbox 360 Wireless Controller`|
|JoyCon Left|`Wireless Gamepad (STANDARD GAMEPAD Vendor: 057e Product: 2006)`|`Wireless Gamepad`|-|-|
|JoyCon Right|`Wireless Gamepad (STANDARD GAMEPAD Vendor: 057e Product: 2007)`|`Wireless Gamepad`|-|-|
|JoyCon Pair|`Joy-Con L+R (STANDARD GAMEPAD Vendor: 057e Product: 200e)`|`Joy-Con L+R`|-|-|

Would this be a good idea?

## Existing Issue(s)
None