### PR TITLE
SDL_joystick: add Austgame adapter to gamecube devices

### DIFF
--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -494,6 +494,7 @@ static Uint32 initial_gamecube_devices[] = {
     MAKE_VIDPID(0x0079, 0x1846), // DragonRise GameCube Controller Adapter
     MAKE_VIDPID(0x057e, 0x0337), // Nintendo Wii U GameCube Controller Adapter
     MAKE_VIDPID(0x057e, 0x2073), // Nintendo Switch 2 NSO GameCube Controller
+    MAKE_VIDPID(0x05e3, 0x0681), // Austgame GameCube to USB convertor
     MAKE_VIDPID(0x0926, 0x8888), // Cyber Gadget GameCube Controller
     MAKE_VIDPID(0x0e6f, 0x0185), // PDP Wired Fight Pad Pro for Nintendo Switch
     MAKE_VIDPID(0x1a34, 0xf705), // GameCube {HuiJia USB box}


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
"Austgame GameCube to USB converter" is an GameCube-to-USB adapter. This PR adds it to the `initial_gamecube_devices`, so that it maps the buttons at the correct location.

The mapping itself was added to SDL_GameControllerDB (https://github.com/mdqinc/SDL_GameControllerDB/pull/957)

### macOS `hitutils list`
<img width="2320" height="630" alt="Capture d’écran 2026-06-14 à 14 07 32" src="https://github.com/user-attachments/assets/d43f0258-219a-4926-90d9-393fe160c89e" />

### SDL `testcontroller`

<img width="2260" height="1480" alt="605341034-021cdf5c-3371-4a5d-9f44-449e2281e9b4" src="https://github.com/user-attachments/assets/9149741e-fea6-4899-be54-aa9bfeff37eb" />
