### PR TITLE
Fix background process creation on macOS

### DIFF
--- a/src/process/posix/SDL_posixprocess.c
+++ b/src/process/posix/SDL_posixprocess.c
@@ -340,16 +340,14 @@ bool SDL_SYS_CreateProcessWithProperties(SDL_Process *process, SDL_PropertiesID 
     // Spawn the new process
     if (process->background) {
         int status = -1;
-        #ifdef SDL_PLATFORM_APPLE  // Apple has vfork marked as deprecated and (as of macOS 10.12) is almost identical to calling fork() anyhow.
+        int pid_pipe[2];
+        if (!CreatePipe(pid_pipe)) {
+            goto posix_spawn_fail_all;
+        }
         const pid_t pid = fork();
-        const char *forkname = "fork";
-        #else
-        const pid_t pid = vfork();
-        const char *forkname = "vfork";
-        #endif
         switch (pid) {
         case -1:
-            SDL_SetError("%s() failed: %s", forkname, strerror(errno));
+            SDL_SetError("fork() failed: %s", strerror(errno));
             goto posix_spawn_fail_all;
 
         case 0:
@@ -358,9 +356,23 @@ bool SDL_SYS_CreateProcessWithProperties(SDL_Process *process, SDL_PropertiesID 
             if (posix_spawnp(&data->pid, args[0], &fa, &attr, args, envp) != 0) {
                 _exit(errno);
             }
+            // Write the PID back to the parent so it can be waited on
+            close(pid_pipe[READ_END]);
+            if (write(pid_pipe[WRITE_END], &data->pid, sizeof(data->pid)) != sizeof(data->pid)) {
+                _exit(errno);
+            }
+            close(pid_pipe[WRITE_END]);
             _exit(0);
 
         default:
+            // Wait for the child to launch and report the PID back
+            close(pid_pipe[WRITE_END]);
+            ssize_t bytes_read = read(pid_pipe[READ_END], &data->pid, sizeof(data->pid));
+            close(pid_pipe[READ_END]);
+            if ((size_t)bytes_read != sizeof(data->pid)) {
+                SDL_SetError("Failed to read child PID from pipe: %s", strerror(errno));
+                goto posix_spawn_fail_all;
+            }
             if (waitpid(pid, &status, 0) < 0) {
                 SDL_SetError("waitpid() failed: %s", strerror(errno));
                 goto posix_spawn_fail_all;


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

This fixes an issue on macOS where the PID of a background child process is never stored by the main process.

## Description
Currently on macOS, when creating a process with `SDL_PROP_PROCESS_BACKGROUND_BOOLEAN=true`, the PID returned by `posix_spawnp()` is never visible to the parent process, since it is stored in a different address space created by `fork()`. So, a PID of 0 is stored in in the parent process, and attempting to call `KillProcess(child)` actually sends the signal to the parent process. This issue did not occur on other posix systems since they used `vfork()` instead of `fork()`, allowing the child process to record the PID in the parent's address space directly.

To resolve this, the process created by `fork()` sends the PID returned by `posix_spawnp()` back to the parent process over a pipe. Additionally, I switched to using `fork()` instead of `vfork()` in all cases, for the sake of consistency and standard-compliance.

## Existing Issue(s)
N/A
