### PR TITLE
doc: use testspriteminimal instead of testgles in android example

### DIFF
--- a/docs/README-android.md
+++ b/docs/README-android.md
@@ -49,10 +49,10 @@ There's two ways of using it:
 
 sources.list should be a text file with a source file name in each line
 Filenames should be specified relative to the current directory, for example if
-you are in the build-scripts directory and want to create the testgles.c test, you'll
+you are in the build-scripts directory and want to create the testspriteminimal.c test, you'll
 run:
 
-    ./create-android-project.py org.libsdl.testgles ../test/testgles.c
+    ./create-android-project.py org.libsdl.testspriteminimal ../test/testspriteminimal.c ../test/icon.h
 
 One limitation of this script is that all sources provided will be aggregated into
 a single directory, thus all your source files should have a unique name.
@@ -60,6 +60,9 @@ a single directory, thus all your source files should have a unique name.
 Once the project is complete the script will tell you how to build the project.
 If you want to create a signed release APK, you can use the project created by this
 utility to generate it.
+
+If you see link errors about missing `SDLTest_*` symbols,
+you need to add `../src/test/*.c` as an extra argument to `create-android-project.py`.
 
 Running the script with `--help` will list all available options, and their purposes.
 


### PR DESCRIPTION
testgles depends on SDL_test so would need ../src/test/*.c as an additonal argument.

- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
