### PR TITLE
ci: don't trigger on documentation-only commits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,13 @@
 name: 'Build (All)'
-
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").




## Description

Don't run ci if a diff only changes files in the docs directory or *.MD files.
GitHub runs a diff between the head of the branch and the commit, so ci should run if you push a series of commits where the last one is a doc-only change.
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#git-diff-comparisons

## Existing Issue(s)
Fixes #14960