### PR TITLE
hidapi: do not enumerate XInput devices owned by a kernel driver via libusb on macOS

### DIFF
--- a/src/hidapi/libusb/hid.c
+++ b/src/hidapi/libusb/hid.c
@@ -1069,6 +1069,17 @@ struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, 
 						struct hid_device_info *tmp;
 
 						res = libusb_open(dev, &handle);
+#ifdef SDL_PLATFORM_MACOS
+						if (res == 0) {
+							/* Do not enumerate XInput devices already owned by a kernel driver */
+							int is_xbox = is_xbox360(dev_vid, intf_desc) || is_xboxone(dev_vid, intf_desc);
+							if (is_xbox && libusb_kernel_driver_active(handle, intf_desc->bInterfaceNumber) == 1) {
+								libusb_close(handle);
+								handle = NULL;
+								continue;
+							}
+						}
+#endif
 
 #ifdef __ANDROID__
 						if (handle) {


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
With commit 18fc4d9 now XInput devices on macOS are enumerated by libusb in hidapi. Since devices enumerated by libusb are not enumerated by the platform backend:
https://github.com/libsdl-org/SDL/blob/da8aa39222221039a448054a66b713f5f30390c0/src/hidapi/SDL_hidapi.c#L1440-L1445

When a device is enumerated by libusb but it cannot be opened (usually due to `libusb_claim_interface` failure), it doesn't fallback to the platform backend. This is ok for `GCController` devices but it is a problem for devices which work with the hidapi platform backend. XInput controllers working with 360Controller driver are examples.

This PR adds checking if a device is already owned by KEXT by `libusb_kernel_driver_active` function when enumerating devices.