### PR TITLE
Add "set(HAVE_LEAN_AND_MEAN TRUE)"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -652,6 +652,7 @@ if(SDL_LEAN_AND_MEAN)
     PRIVATE
       SDL_LEAN_AND_MEAN
   )
+  set(HAVE_LEAN_AND_MEAN TRUE)
 endif()
 
 # Compiler option evaluation


### PR DESCRIPTION
- [ x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The cmake command was displaying
`--   SDL_LEAN_AND_MEAN           (Wanted: YES): OFF` after the change it displays 
`--   SDL_LEAN_AND_MEAN           (Wanted: YES): ON`
I added "set(HAVE_LEAN_AND_MEAN TRUE)" to fix it.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
