### PR TITLE
Free capacitive sensors on joystick close

### DIFF
--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -2259,6 +2259,7 @@ void SDL_CloseJoystick(SDL_Joystick *joystick)
         }
         SDL_free(joystick->touchpads);
         SDL_free(joystick->sensors);
+        SDL_free(joystick->capsenses);
         SDL_free(joystick);
     }
     SDL_UnlockJoysticks();


### PR DESCRIPTION
Fixes: #15856

- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Issue described in detail here: https://github.com/libsdl-org/SDL/issues/15856

## Description
Support for the steam controllers capacitive sensors were added roughly a month ago in https://github.com/libsdl-org/SDL/pull/15627 and in this change we call realloc whenever a capacitive sensor is added. We don't free this array of capacitive sensors when the gamepad is closed however which leads the leak valgrind detected (pasted in the issue I made).

After applying this change I reran the repro example #15856 under valgrind and it resolves the warning with the steam controller. I also did another run with a PS5 (since the PS5 controller doesn't have capacitive sensors afaik) controller connected and there were no valgrind warnings or uninitialized accesses.