### PR TITLE
Fix Apple performance frequency to match nanosecond counter

### DIFF
--- a/src/timer/unix/SDL_systimer.c
+++ b/src/timer/unix/SDL_systimer.c
@@ -128,10 +128,7 @@ Uint64 SDL_GetPerformanceFrequency(void)
 #ifdef HAVE_CLOCK_GETTIME
         return SDL_NS_PER_SECOND;
 #elif defined(SDL_PLATFORM_APPLE)
-        Uint64 freq = mach_base_info.denom;
-        freq *= SDL_NS_PER_SECOND;
-        freq /= mach_base_info.numer;
-        return freq;
+        return SDL_NS_PER_SECOND;
 #endif
     }
 


### PR DESCRIPTION
The counter returns ns via clock_gettime_nsec_np, so the frequency must be SDL_NS_PER_SECOND.

- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

This regression was introduced in commit https://github.com/libsdl-org/SDL/commit/225001b53b6897e9309e593cd220d74a0f9dd5cc