### PR TITLE
timer: drop unused mach_base_info on Apple

### DIFF
--- a/src/timer/unix/SDL_systimer.c
+++ b/src/timer/unix/SDL_systimer.c
@@ -47,9 +47,6 @@
 #if defined(HAVE_NANOSLEEP) || defined(HAVE_CLOCK_GETTIME)
 #include <time.h>
 #endif
-#ifdef SDL_PLATFORM_APPLE
-#include <mach/mach_time.h>
-#endif
 
 // Use CLOCK_MONOTONIC_RAW, if available, which is not subject to adjustment by NTP
 #ifdef HAVE_CLOCK_GETTIME
@@ -62,10 +59,6 @@
 #endif
 #endif
 
-// The first ticks value of the application
-#if !defined(HAVE_CLOCK_GETTIME) && defined(SDL_PLATFORM_APPLE)
-mach_timebase_info_data_t mach_base_info;
-#endif
 static bool checked_monotonic_time = false;
 static bool has_monotonic_time = false;
 
@@ -77,9 +70,8 @@ static void CheckMonotonicTime(void)
         has_monotonic_time = true;
     }
 #elif defined(SDL_PLATFORM_APPLE)
-    if (mach_timebase_info(&mach_base_info) == 0) {
-        has_monotonic_time = true;
-    }
+    // CLOCK_UPTIME_RAW (via clock_gettime_nsec_np) is always available on Apple platforms
+    has_monotonic_time = true;
 #endif
     checked_monotonic_time = true;
 }


### PR DESCRIPTION
Follow-up to https://github.com/libsdl-org/SDL/pull/15861

> we probably can delete the mach_base_info stuff completely

The Apple counter uses clock_gettime_nsec_np(CLOCK_UPTIME_RAW) and the frequency is SDL_NS_PER_SECOND, so the mach timebase is no longer used.

- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

