### PR TITLE
Android: honor suggested filename in ShowSaveFileDialog

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -2209,6 +2209,19 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
             intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI, initialPathUri);
         }
 
+        /* Handle a suggested filename when saving */
+        if (type == SDL_FILEDIALOG_SAVEFILE && initialPath != null && !initialPath.isEmpty() &&
+            !initialPath.endsWith("/") && !initialPath.endsWith("\\")) {
+            String title = initialPath;
+            int lastSeparator = Math.max(title.lastIndexOf('/'), title.lastIndexOf('\\'));
+            if (lastSeparator >= 0) {
+                title = title.substring(lastSeparator + 1);
+            }
+            if (!title.isEmpty()) {
+                intent.putExtra(Intent.EXTRA_TITLE, title);
+            }
+        }
+
         /* Display the file/folder dialog */
         try {
             mSingleton.startActivityForResult(intent, requestCode);


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description

Currently, when an app calls SDL_ShowSaveFileDialog with a default_location on Android, only the default path is respected. The suggested filename is ignored. This behaviour is different to other platforms, where the suggested name is pre-filled in the save file dialog. This PR allows Android to pre-fill a suggested file name.

It does this by filling the Intent.EXTRA_TITLE field. This is documented here: https://developer.android.com/training/data-storage/shared/documents-files#create-file

Basically, we examine initialPath. If it doesn't end in a path separator, we assume it's ending (or entirely) a suggested filename. We trim any preceding file path and attach the remainder to the intent.

Tested on a real device. Calling
```c++
    SDL_ShowSaveFileDialog(save_dialog_callback, NULL, NULL, NULL, 0,
                           "sdl-default-name.txt");
```

Gives:

<img width="2304" height="1440" alt="screenshot_20260621_181724" src="https://github.com/user-attachments/assets/3fbbb9fe-031b-47fe-b39d-a61e69c83a5f" />

<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
