### PR TITLE
Fix Android fullscreen for API level >=30

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -38,6 +38,8 @@ import android.view.Surface;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
+import android.view.WindowInsets;
+import android.view.WindowInsetsController;
 import android.view.WindowManager;
 import android.view.inputmethod.BaseInputConnection;
 import android.view.inputmethod.EditorInfo;
@@ -773,21 +775,45 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
                         Window window = ((Activity) context).getWindow();
                         if (window != null) {
                             if ((msg.obj instanceof Integer) && ((Integer) msg.obj != 0)) {
-                                int flags = View.SYSTEM_UI_FLAG_FULLSCREEN |
-                                        View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
-                                        View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY |
-                                        View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
-                                        View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
-                                        View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.INVISIBLE;
-                                window.getDecorView().setSystemUiVisibility(flags);
-                                window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-                                window.clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+                                if (Build.VERSION.SDK_INT >= 30 /* Android 11 (R) */) {
+                                    // The legacy setSystemUiVisibility() flags are ignored on
+                                    // Android 15+ (API 35+), where edge-to-edge is enforced for
+                                    // apps targeting that SDK, so the status/navigation bars
+                                    // would never hide. Use WindowInsetsController instead.
+                                    window.setDecorFitsSystemWindows(false);
+                                    final WindowInsetsController controller = window.getInsetsController();
+                                    if (controller != null) {
+                                        controller.hide(WindowInsets.Type.systemBars());
+                                        // Sticky-immersive (replaces SYSTEM_UI_FLAG_IMMERSIVE_STICKY):
+                                        // a swipe shows the bars transiently, then they auto-hide.
+                                        controller.setSystemBarsBehavior(
+                                                WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+                                    }
+                                } else {
+                                    int flags = View.SYSTEM_UI_FLAG_FULLSCREEN |
+                                            View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
+                                            View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY |
+                                            View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
+                                            View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
+                                            View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.INVISIBLE;
+                                    window.getDecorView().setSystemUiVisibility(flags);
+                                    window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+                                    window.clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+                                }
                                 SDLActivity.mFullscreenModeActive = true;
                             } else {
-                                int flags = View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_VISIBLE;
-                                window.getDecorView().setSystemUiVisibility(flags);
-                                window.addFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
-                                window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+                                if (Build.VERSION.SDK_INT >= 30 /* Android 11 (R) */) {
+                                    window.setDecorFitsSystemWindows(true);
+                                    final WindowInsetsController controller = window.getInsetsController();
+                                    if (controller != null) {
+                                        controller.show(WindowInsets.Type.systemBars());
+                                    }
+                                } else {
+                                    int flags = View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_VISIBLE;
+                                    window.getDecorView().setSystemUiVisibility(flags);
+                                    window.addFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+                                    window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+                                }
                                 SDLActivity.mFullscreenModeActive = false;
                             }
                             if (Build.VERSION.SDK_INT >= 28 /* Android 9 (Pie) */) {
@@ -1623,7 +1649,13 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     private final Runnable rehideSystemUi = new Runnable() {
         @Override
         public void run() {
-            if (Build.VERSION.SDK_INT >= 19 /* Android 4.4 (KITKAT) */) {
+            if (Build.VERSION.SDK_INT >= 30 /* Android 11 (R) */) {
+                final WindowInsetsController controller =
+                        SDLActivity.this.getWindow().getInsetsController();
+                if (controller != null) {
+                    controller.hide(WindowInsets.Type.systemBars());
+                }
+            } else if (Build.VERSION.SDK_INT >= 19 /* Android 4.4 (KITKAT) */) {
                 int flags = View.SYSTEM_UI_FLAG_FULLSCREEN |
                         View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
                         View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY |


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->
Hi! I am one of the developers of [OpenLieroX](https://github.com/openlierox/openlierox), which is based on SDL2. It has an Android version among other platforms that is supports  . We have problems that Fullscreen on Android API level 30 and above does not work. This PR aims to address this.

## Description

### Changes
* Hide/show the system bars via WindowInsetsController on API 30+, using BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE to keep the sticky-immersive behaviour (swipe reveals the bars transiently, then they auto-hide).
* The legacy setSystemUiVisibility() path is kept unchanged for API < 30.
* The rehideSystemUi runnable uses the same WindowInsetsController call on API 30+.

## Existing Issue(s)
Fullscreen does not work on newer Android phones. See screenshot of OpenLieroX running on Samsung Galaxy S25:

<img width="2340" height="1080" alt="Broken-Fullscreen-Android" src="https://github.com/user-attachments/assets/43d640f8-d2f1-4a2e-a3df-0cd3b16d8937" />
