### PR TITLE
gpu: Metal fence fixes

### DIFF
--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -454,8 +454,7 @@ typedef struct MetalTextureContainer
 
 typedef struct MetalFence
 {
-    // can be NULL if the command buffer was recycled
-    MetalCommandBuffer *commandBuffer;
+    id<MTLCommandBuffer> commandBuffer;
     SDL_AtomicInt referenceCount;
 } MetalFence;
 
@@ -2137,7 +2136,7 @@ static bool METAL_INTERNAL_AcquireFence(
 
     // Associate the fence with the command buffer
     commandBuffer->fence = fence;
-    fence->commandBuffer = commandBuffer;
+    fence->commandBuffer = commandBuffer->handle;
     (void)SDL_AtomicIncRef(&commandBuffer->fence->referenceCount);
 
     return true;
@@ -3407,6 +3406,7 @@ static void METAL_ReleaseFence(
     SDL_GPUFence *fence)
 {
     MetalFence *metalFence = (MetalFence *)fence;
+    metalFence->commandBuffer = nil;
     if (SDL_AtomicDecRef(&metalFence->referenceCount)) {
         METAL_INTERNAL_ReleaseFenceToPool(
             (MetalRenderer *)driverData,
@@ -3518,8 +3518,6 @@ static void METAL_INTERNAL_CleanCommandBuffer(
         METAL_ReleaseFence(
             (SDL_GPURenderer *)renderer,
             (SDL_GPUFence *)commandBuffer->fence);
-    } else {
-        commandBuffer->fence->commandBuffer = NULL;
     }
 
     // Return command buffer to pool
@@ -3593,11 +3591,7 @@ static void METAL_INTERNAL_PerformPendingDestroys(
 static bool METAL_INTERNAL_IsFenceBusy(
         MetalFence *fence
 ) {
-    if (!fence->commandBuffer) {
-        return false; // command buffer was recycled
-    }
-
-    MTLCommandBufferStatus status = fence->commandBuffer->handle.status;
+    MTLCommandBufferStatus status = fence->commandBuffer.status;
     return status == MTLCommandBufferStatusCommitted || status == MTLCommandBufferStatusScheduled;
 }
 
@@ -3613,25 +3607,19 @@ static bool METAL_WaitForFences(
         if (waitAll) {
             for (Uint32 i = 0; i < numFences; i += 1) {
                 MetalFence *fence = (MetalFence *)fences[i];
-                if (METAL_INTERNAL_IsFenceBusy(fence)) {
-                    [fence->commandBuffer->handle waitUntilCompleted];
-                }
+                [fence->commandBuffer waitUntilCompleted];
             }
         } else {
-            dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-            for (Uint32 i = 0; i < numFences; i += 1) {
-                MetalFence *fence = (MetalFence *)fences[i];
-                // command buffer has completed and been recycled
-                if(!fence->commandBuffer)
-                    return true;
-
-                // even if it's completed, the handle will call back straight away
-                [fence->commandBuffer->handle addCompletedHandler:^(id<MTLCommandBuffer> buffer) {
-                    dispatch_semaphore_signal(semaphore);
-                }];
+            bool waiting = true;
+            while (waiting) {
+                for (Uint32 i = 0; i < numFences; i += 1) {
+                    MetalFence *fence = (MetalFence *)fences[i];
+                    if (!METAL_INTERNAL_IsFenceBusy(fence)) {
+                        waiting = false;
+                        break;
+                    }
+                }
             }
-
-            dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
         }
 
         METAL_INTERNAL_PerformPendingDestroys(renderer);
@@ -4125,7 +4113,6 @@ static bool METAL_Submit(
 
         // Check if we can perform any cleanups
         for (Sint32 i = renderer->submittedCommandBufferCount - 1; i >= 0; i -= 1) {
-
             if (!METAL_INTERNAL_IsFenceBusy(renderer->submittedCommandBuffers[i]->fence)) {
                 METAL_INTERNAL_CleanCommandBuffer(
                     renderer,


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
The recent changes to the GPU Metal driver in https://github.com/libsdl-org/SDL/pull/15223 introduced some issues:
1. `MetalFence` held a pointer to a `MetalCommandBuffer`. When a fence's associated command buffer was cleaned up for reuse, it would set this pointer to NULL. However, fences are supposed to be independent objects with separate lifetimes from their originating command buffer. The reliance on the `MetalCommandBuffer` pointer resulted in fences returning incorrect results from queries after their parent command buffer was recycled. To fix this, I changed `MetalFence` to hold onto the command buffer's underlying `id<MTLCommandBuffer>` instead, which cannot change and is what we actually need to use anyway.
2. `WaitForFences` was not spec-compliant in the case where we wait for _any_ fence to be signaled. Metal does not allow adding completion handlers after a command buffer has already been committed, and the debug layer complains if we try. Unfortunately since neither Metal nor the operating system has any mechanism for "wait on any", this means we have no choice but to go back to spin-waiting for that case.
3. Closing an application with allocated-but-unused command buffers would cause a crash, due to the device cleanup operation attempting to set the `commandBuffer` variable on a NULL `fence`.

With the changes in this PR, the `testgpu_spinning_cube` and the SDL_gpu_examples behave correctly again on my machine.

## Existing Issue(s)
Resolves https://github.com/libsdl-org/SDL/issues/15862
