### PR TITLE
Clarify `joystick->nbuttons` infinite loop prevention

### DIFF
--- a/src/joystick/SDL_sysjoystick.h
+++ b/src/joystick/SDL_sysjoystick.h
@@ -102,6 +102,9 @@ struct SDL_Joystick
     int nhats _guarded;   // Number of hats on the joystick
     Uint8 *hats _guarded; // Current hat states
 
+    // Do NOT use Uint8 for looping over a joystick's buttons. Even though a physical controller can't have 256 or more buttons,
+    // it will make the application stuck in case `nbuttons` is 256 (`i < joystick->nbuttons` is always true in case of Uint8).
+    // See https://github.com/libsdl-org/SDL/pull/15304 and https://github.com/libsdl-org/SDL/issues/14961
     int nbuttons _guarded;   // Number of buttons on the joystick
     bool *buttons _guarded; // Current button states
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
This PR clarifies how to prevent possible application freezes in case there's a need to loop over a joystick's buttons.
If the loop uses `Uint8` as the index and the joystick's `nbuttons` property is equal to `256`, the application will freeze.

(Is it a good idea to document this? Is this the right place to do it?)

## Existing Issue(s)
See https://github.com/libsdl-org/SDL/pull/15304 and https://github.com/libsdl-org/SDL/issues/14961
