### PR TITLE
Added RIDEV_NOLEGACY to improve performance in mouse relative mode

### DIFF
--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -1419,7 +1419,13 @@ bool SDL_UpdateRelativeMouseMode(void)
 {
     SDL_Mouse *mouse = SDL_GetMouse();
     SDL_Window *focus = SDL_GetKeyboardFocus();
-    bool relative_mode = (focus && (focus->flags & SDL_WINDOW_MOUSE_RELATIVE_MODE));
+    bool relative_mode = false;
+
+    if (focus &&
+        (focus->flags & SDL_WINDOW_MOUSE_RELATIVE_MODE) &&
+        (focus->flags & SDL_WINDOW_MOUSE_FOCUS)) {
+        relative_mode = true;
+    }
 
     if (relative_mode == mouse->relative_mode) {
         return true;

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -4398,10 +4398,12 @@ void SDL_OnWindowEnter(SDL_Window *window)
     if (_this->OnWindowEnter) {
         _this->OnWindowEnter(_this, window);
     }
+    SDL_UpdateRelativeMouseMode();
 }
 
 void SDL_OnWindowLeave(SDL_Window *window)
 {
+    SDL_UpdateRelativeMouseMode();
 }
 
 void SDL_OnWindowFocusGained(SDL_Window *window)

--- a/src/video/windows/SDL_windowsrawinput.c
+++ b/src/video/windows/SDL_windowsrawinput.c
@@ -98,7 +98,7 @@ static bool UpdateRawInputDeviceFlags(HWND window, Uint32 last_flags, Uint32 new
         devices[count].usUsage = USB_USAGE_GENERIC_MOUSE;
 
         if (new_flags & ENABLE_RAW_MOUSE_INPUT) {
-            devices[count].dwFlags = 0;
+            devices[count].dwFlags = RIDEV_NOLEGACY;
             devices[count].hwndTarget = window;
         } else {
             devices[count].dwFlags = RIDEV_REMOVE;


### PR DESCRIPTION
This change also makes it so relative mode doesn't kick in until the mouse enters the window client area. This prevents relative mode from kicking in while clicking and dragging on the title bar, etc.

- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").
