### PR TITLE
gpu/vulkan renderer: Reconfigure the window on renderer creation if i…

### DIFF
--- a/src/render/gpu/SDL_render_gpu.c
+++ b/src/render/gpu/SDL_render_gpu.c
@@ -24,6 +24,7 @@
 
 #include "../../events/SDL_windowevents_c.h"
 #include "../../video/SDL_pixels_c.h"
+#include "../../video/SDL_sysvideo.h"
 #include "../SDL_d3dmath.h"
 #include "../SDL_sysrender.h"
 #include "SDL_gpu_util.h"
@@ -1686,6 +1687,13 @@ static bool GPU_SetVSync(SDL_Renderer *renderer, const int vsync)
 static bool GPU_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_PropertiesID create_props)
 {
     GPU_RenderData *data = NULL;
+
+    // Clear any OpenGL properties on the window to avoid potential driver conflicts.
+    SDL_WindowFlags flags = SDL_GetWindowFlags(window);
+    if (flags & SDL_WINDOW_OPENGL) {
+        flags &= ~SDL_WINDOW_OPENGL;
+        SDL_ReconfigureWindow(window, flags);
+    }
 
     SDL_SetupRendererColorspace(renderer, create_props);
 

--- a/src/render/vulkan/SDL_render_vulkan.c
+++ b/src/render/vulkan/SDL_render_vulkan.c
@@ -4518,6 +4518,13 @@ static bool VULKAN_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SD
 {
     VULKAN_RenderData *rendererData;
 
+    // Clear any OpenGL properties on the window to avoid potential driver conflicts.
+    SDL_WindowFlags flags = SDL_GetWindowFlags(window);
+    if (flags & SDL_WINDOW_OPENGL) {
+        flags &= ~SDL_WINDOW_OPENGL;
+        SDL_ReconfigureWindow(window, flags);
+    }
+
     SDL_SetupRendererColorspace(renderer, create_props);
 
     if (renderer->output_colorspace != SDL_COLORSPACE_SRGB &&


### PR DESCRIPTION
…t has the OpenGL flag

Issues can arise if a window initially configured for OpenGL is later used with a Vulkan-based renderer. Try to reconfigure or recreate the window in the unlikely event that it has the OpenGL flag set when initializing the Vulkan or GPU renderer to remove any platform or driver-specific OpenGL objects and properties.

Fixes hot-swapping between an OpenGL renderer and the GPU renderer on some platforms in #15847

- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").