### PR TITLE
iOS: Fix crash on pinch gesture

### DIFF
--- a/Xcode/SDL/SDL.xcodeproj/project.pbxproj
+++ b/Xcode/SDL/SDL.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		00D0D08410675DD9004B05EF /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00D0D08310675DD9004B05EF /* CoreFoundation.framework */; platformFilters = (ios, maccatalyst, macos, tvos, xros, ); settings = {ATTRIBUTES = (Required, ); }; };
 		00D0D0D810675E46004B05EF /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 007317C10858E15000B2BC32 /* Carbon.framework */; platformFilters = (macos, ); };
 		02D6A1C228A84B8F00A7F002 /* SDL_hidapi_sinput.c in Sources */ = {isa = PBXBuildFile; fileRef = 02D6A1C128A84B8F00A7F001 /* SDL_hidapi_sinput.c */; };
+		1095A6892FEBDF7200554160 /* SDL_notification.h in Headers */ = {isa = PBXBuildFile; fileRef = 1095A6882FEBDF7200554160 /* SDL_notification.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1485C3312BBA4AF30063985B /* UniformTypeIdentifiers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1485C32F2BBA4A0C0063985B /* UniformTypeIdentifiers.framework */; platformFilters = (maccatalyst, macos, ); settings = {ATTRIBUTES = (Weak, ); }; };
 		30840D4C2F76A822000F1D1B /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 30840D4B2F76A822000F1D1B /* UserNotifications.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		30840D4E2F76A8E7000F1D1B /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 30840D4D2F76A8E7000F1D1B /* Security.framework */; };
@@ -632,6 +633,7 @@
 		00CFA89C106B4BA100758660 /* ForceFeedback.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ForceFeedback.framework; path = System/Library/Frameworks/ForceFeedback.framework; sourceTree = SDKROOT; };
 		00D0D08310675DD9004B05EF /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
 		02D6A1C128A84B8F00A7F001 /* SDL_hidapi_sinput.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = SDL_hidapi_sinput.c; sourceTree = "<group>"; };
+		1095A6882FEBDF7200554160 /* SDL_notification.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SDL_notification.h; path = ../../include/SDL3/SDL_notification.h; sourceTree = "<group>"; };
 		1485C32F2BBA4A0C0063985B /* UniformTypeIdentifiers.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UniformTypeIdentifiers.framework; path = System/Library/Frameworks/UniformTypeIdentifiers.framework; sourceTree = SDKROOT; };
 		30840D4B2F76A822000F1D1B /* UserNotifications.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotifications.framework; path = System/Library/Frameworks/UserNotifications.framework; sourceTree = SDKROOT; };
 		30840D4D2F76A8E7000F1D1B /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
@@ -1410,6 +1412,7 @@
 		0867D691FE84028FC02AAC07 /* SDLFramework */ = {
 			isa = PBXGroup;
 			children = (
+				1095A6882FEBDF7200554160 /* SDL_notification.h */,
 				F3F7BE3B2CBD79D200C984AF /* config.xcconfig */,
 				F5A2EF3900C6A39A01000001 /* BUGS.txt */,
 				F59C70FC00D5CB5801000001 /* pkg-support */,
@@ -2595,6 +2598,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1095A6892FEBDF7200554160 /* SDL_notification.h in Headers */,
 				E4F257942C81903800FCEAFC /* SDL_gpu_vulkan_vkfuncs.h in Headers */,
 				F3C1BD762D1F1A3000846529 /* SDL_tray_utils.h in Headers */,
 				F310138D2C1F2CB700FBE946 /* SDL_getenv_c.h in Headers */,

--- a/src/video/uikit/SDL_uikitview.m
+++ b/src/video/uikit/SDL_uikitview.m
@@ -484,8 +484,9 @@ extern int SDL_AppleTVRemoteOpenedAsJoystick;
 {
     CGFloat scale = sender.scale;
     UIGestureRecognizerState state = sender.state;
+    bool pinchHasTwoPoints = sender.numberOfTouches == 2;
     CGPoint point1 = [sender locationOfTouch:0 inView:self];
-    CGPoint point2 = [sender locationOfTouch:1 inView:self];
+    CGPoint point2 = pinchHasTwoPoints ? [sender locationOfTouch:1 inView:self] : point1;
     CGFloat focus_x = (point1.x + point2.x)/2;
     CGFloat focus_y = (point1.y + point2.y)/2;
     CGFloat span_x = SDL_fabs(point1.x - point2.x);
@@ -504,7 +505,7 @@ extern int SDL_AppleTVRemoteOpenedAsJoystick;
             break;
 
         case UIGestureRecognizerStateChanged:
-            if (pinch_scale > 0.0f) {
+            if (pinch_scale > 0.0f && pinchHasTwoPoints) {
                 SDL_SendPinch(SDL_EVENT_PINCH_UPDATE, 0, sdlwindow, scale / pinch_scale, span_x, span_y, focus_x, focus_y);
             }
             pinch_scale = scale;


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description

### [Fix Xcode project not building due to missing header](https://github.com/libsdl-org/SDL/commit/921edd265e246145f1cfb1cfbde40186d19cf79d)

Both `SDL3/SDL.h` and `SDL3/SDL_events.h` attempt to `#include <SDL3/SDL_notification.h>` and that header was not added to the Xcode project, leading to compilation failures.

> [!IMPORTANT]
> I did this by the following sequence of steps:
> - Go to the `SDL.xcodeproj` project settings in Xcode
> - Select the `SDL3` target
> - Go to *Build Phases*, then to *Headers* section
> - Add `../../include/SDL3/SDL_notification.h` via the plus button
> - Mark the header as public
>
> This seemed about right, and fixed the immediate problem, but there is no clear documentation on whether this is correct procedure, so please advise if it is not.

### [iOS: Fix crash on pinch gesture](https://github.com/libsdl-org/SDL/commit/e64d4b643cc0087685b10c699aaeac251224a6b9)

Related: https://github.com/libsdl-org/SDL/commit/65091012b47f68e6e7185014ed64bae7301e17fc, cc @brentfpage

After the aforementioned commit, pinching in any iOS app using SDL crashes with

	*** Terminating app due to uncaught exception 'NSRangeException', reason: '-[UIPinchGestureRecognizer locationOfTouch:inView:]: index (1) beyond bounds (1).'
	*** First throw call stack:
	(0x19d31a23c 0x199de9224 0x19d37fec4 0x1a3f99bf0 0x1a3fa3c68 0x103277370 0x1a33b8b7c 0x1a33b848c 0x1a33b8238 0x1a2efc9a4 0x1a2ec1310 0x1a8ab8754 0x1a8af6c1c 0x1a8abc324 0x1a8ac79f4 0x1a2f010e8 0x1a2ee9550 0x1a2efd638 0x1a2eea040 0x1a2f0318c 0x1a2eecd48 0x1a2f062a8 0x1a2f03834 0x2b210f56c 0x19d2a5358 0x19d2a52cc 0x19d26a5a8 0x19d2341a0 0x19d23354c 0x1032bcdd8 0x1032ee2a0 0x1032ee3fc 0x1032ee360 0x102280644 0x10228042c 0x1033cd0cc 0x1032a8198 0x19a61f5dc 0x19d273960 0x19d273658 0x19d2731cc 0x19d234584 0x19d23354c 0x24299f498 0x1a2f2c244 0x1a2e97158 0x1032a5780 0x102280030 0x199e41c1c)
	libc++abi: terminating due to uncaught exception of type NSException

As it turns out, `UIPinchGestureRecognizer` does not guarantee the presence of two touches throughout the entire duration of the pinch. When the user is releasing the touches that constitute the pinch gesture, more often than not they will release one touch before the other. When this happens, `UIPinchGestureRecognizer` *does not terminate the pinch*, but continues updating it, only with one touch remaining in the gesture. The gesture is only marked concluded when the user releases *both* touches.

To prevent the crash, check that the second touch is actually available via the `numberOfTouches` property. If it is not, avoid emitting `SDL_EVENT_PINCH_UPDATE` events to prevent sending unexpected payloads downstream; there is no second touch to use anymore to calculate `(focus|span)_(x|y)`.