### PR TITLE
x11: fix refresh rate reported as 0 for high pixel-clock modes

### DIFF
--- a/src/video/x11/SDL_x11modes.c
+++ b/src/video/x11/SDL_x11modes.c
@@ -399,8 +399,16 @@ static void CalculateXRandRRefreshRate(const XRRModeInfo *info, int *numerator, 
     }
 
     if (info->hTotal && vTotal) {
-        *numerator = info->dotClock;
-        *denominator = (info->hTotal * vTotal);
+        // The pixel clock can exceed INT_MAX (e.g. 4K@240Hz), overflowing the int numerator.
+        // Scale the fraction to fit while preserving the ratio (the rate is rounded afterwards).
+        Uint64 num = info->dotClock;
+        Uint64 den = (Uint64)info->hTotal * vTotal;
+        while (num > SDL_MAX_SINT32 || den > SDL_MAX_SINT32) {
+            num >>= 1;
+            den >>= 1;
+        }
+        *numerator = (int)num;
+        *denominator = (int)den;
     } else {
         *numerator = 0;
         *denominator = 0;


### PR DESCRIPTION

- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources ~, including code generated by a Large Language Model ("AI")~

_If the AI code completion part is a problem consider this an issue an let somebody else come up with a fix._

## Description

On X11, `SDL_GetDesktopDisplayMode()` reports a refresh rate of `0` for high pixel-clock modes such as 4K@240Hz, while lower-clock modes on the same machine (4K@60, 1080p) are fine.

The X11 refresh-rate calculation overflows for those high pixel clocks and falls back to 0. It is a regression from when the calculation moved to the numerator/denominator representation, which dropped the wide-integer handling the earlier path had (#8933).

## Testing

Reproduced with a small program calling `SDL_GetDesktopDisplayMode()` per display on a dual-monitor setup (a 4K@240Hz DP-1 and a 4K@60Hz portrait DP-4), and cross-checked against `xrandr`:

| Display | unpatched SDL (x11) | patched SDL (x11) | xrandr | SDL (wayland) |
| --- | --- | --- | --- | --- |
| DP-1 (240Hz) | `0.000` (num=0) | `239.980` (num=1626625000) | `239.98` | `240.000` |
| DP-4 (60Hz) | `59.980` | `59.980` | `59.98` | `60.000` |

Note: this surfaced while running an SDL app under Xwayland, but it is not Xwayland-specific - the same overflow applies to any high pixel-clock mode on a native X server.
