### PR TITLE
time: Convert the PS2 time implementation to a dummy implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3348,10 +3348,6 @@ elseif(PS2)
   )
   set(HAVE_SDL_THREADS TRUE)
 
-  set(SDL_TIME_PS2 1)
-  sdl_glob_sources("${SDL3_SOURCE_DIR}/src/time/ps2/*.c")
-  set(HAVE_SDL_TIME TRUE)
-
   set(SDL_TIMER_PS2 1)
   sdl_glob_sources("${SDL3_SOURCE_DIR}/src/timer/ps2/*.c")
   set(HAVE_SDL_TIMERS TRUE)
@@ -3845,6 +3841,12 @@ if(NOT HAVE_SDL_THREADS)
     message(FATAL_ERROR "Threads are needed by many SDL subsystems and may not be disabled")
   endif()
 endif()
+
+if(NOT HAVE_SDL_TIME)
+  set(SDL_TIME_DUMMY 1)
+  sdl_glob_sources("${SDL3_SOURCE_DIR}/src/time/dummy/*.c")
+endif()
+
 if(NOT HAVE_SDL_TIMERS)
   message(FATAL_ERROR "Timers are needed by many SDL subsystems and may not be disabled")
 endif()

--- a/include/build_config/SDL_build_config.h.cmake
+++ b/include/build_config/SDL_build_config.h.cmake
@@ -383,9 +383,9 @@
 #cmakedefine SDL_TIME_WINDOWS 1
 #cmakedefine SDL_TIME_VITA 1
 #cmakedefine SDL_TIME_PSP 1
-#cmakedefine SDL_TIME_PS2 1
 #cmakedefine SDL_TIME_N3DS 1
 #cmakedefine SDL_TIME_NGAGE 1
+#cmakedefine SDL_TIME_DUMMY 1
 
 #cmakedefine SDL_TIME_PRIVATE 1
 

--- a/src/time/dummy/SDL_systime.c
+++ b/src/time/dummy/SDL_systime.c
@@ -20,16 +20,13 @@
 */
 #include "SDL_internal.h"
 
-#ifdef SDL_TIME_PS2
+#ifdef SDL_TIME_DUMMY
 
 #include "../SDL_time_c.h"
 
-// PS2 epoch is Jan 1 2000 JST (UTC +9)
-#define UNIX_EPOCH_OFFSET_SEC 946717200
-
-// TODO: Implement this...
 void SDL_GetSystemTimeLocalePreferences(SDL_DateFormat *df, SDL_TimeFormat *tf)
 {
+    // NOP
 }
 
 bool SDL_GetCurrentTime(SDL_Time *ticks)
@@ -38,9 +35,10 @@ bool SDL_GetCurrentTime(SDL_Time *ticks)
         return SDL_InvalidParamError("ticks");
     }
 
+    // Jan 1, 1970
     *ticks = 0;
 
-    return true;
+    return SDL_Unsupported();
 }
 
 bool SDL_TimeToDateTime(SDL_Time ticks, SDL_DateTime *dt, bool localTime)
@@ -49,7 +47,6 @@ bool SDL_TimeToDateTime(SDL_Time ticks, SDL_DateTime *dt, bool localTime)
         return SDL_InvalidParamError("dt");
     }
 
-    // FIXME: Need implementation
     dt->year = 1970;
     dt->month = 1;
     dt->day = 1;
@@ -60,7 +57,7 @@ bool SDL_TimeToDateTime(SDL_Time ticks, SDL_DateTime *dt, bool localTime)
     dt->day_of_week = 4;
     dt->utc_offset = 0;
 
-    return true;
+    return SDL_Unsupported();
 }
 
-#endif // SDL_TIME_PS2
+#endif // SDL_TIME_DUMMY


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

SDL has no dummy fallback for the RTC functions, and the PS2 implementation is just an empty dummy implementation, so rename it and build it if no system-specific time functionality is found.

A full CI build with all platforms passed.