### PR TITLE
keyboard: Limit text input event size for sdl2-compat

### DIFF
--- a/src/events/SDL_keyboard.c
+++ b/src/events/SDL_keyboard.c
@@ -784,11 +784,33 @@ void SDL_SendKeyboardText(const char *text)
         event.type = SDL_EVENT_TEXT_INPUT;
         event.common.timestamp = 0;
         event.text.windowID = keyboard->focus ? keyboard->focus->id : 0;
-        event.text.text = SDL_CreateTemporaryString(text);
-        if (!event.text.text) {
-            return;
+
+        if (SDL_GetHintBoolean("SDL2_COMPAT", false)) {
+            size_t pos = 0, advance, length = SDL_strlen(text);
+
+            // Limit SDL_EVENT_TEXT_INPUT events to 32 bytes for SDL2 compatibility
+            while (pos < length) {
+                char trimmed_text[32];
+
+                advance = SDL_utf8strlcpy(trimmed_text, text + pos, SDL_arraysize(trimmed_text));
+                if (!advance) {
+                    break;
+                }
+                pos += advance;
+
+                event.text.text = SDL_CreateTemporaryString(trimmed_text);
+                if (!event.text.text) {
+                    return;
+                }
+                SDL_PushEvent(&event);
+            }
+        } else {
+            event.text.text = SDL_CreateTemporaryString(text);
+            if (!event.text.text) {
+                return;
+            }
+            SDL_PushEvent(&event);
         }
-        SDL_PushEvent(&event);
     }
 }
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
This ports the `SDL_EVENT_TEXT_INPUT` splitting logic from SDL2 into SDL3 for use with sdl2-compat. When SDL3 is loaded by sdl2-compat (as indicated by the `SDL2_COMPAT` hint), SDL3 will split `SDL_EVENT_TEXT_INPUT` events into 32 byte chunks to match SDL2 behavior (without requiring major reworking of event processing in sdl2-compat).

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/libsdl-org/sdl2-compat/issues/609
