### PR TITLE
gpu: make NULL object releases no-ops

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -3060,6 +3060,9 @@ extern SDL_DECLSPEC void SDLCALL SDL_PopGPUDebugGroup(
  *
  * You must not reference the texture after calling this function.
  *
+ * It is safe to pass NULL for `texture`, in that case this function
+ * is a no-op.
+ *
  * \param device a GPU context.
  * \param texture a texture to be destroyed.
  *
@@ -3073,6 +3076,9 @@ extern SDL_DECLSPEC void SDLCALL SDL_ReleaseGPUTexture(
  * Frees the given sampler as soon as it is safe to do so.
  *
  * You must not reference the sampler after calling this function.
+ *
+ * It is safe to pass NULL for `sampler`, in that case this function
+ * is a no-op.
  *
  * \param device a GPU context.
  * \param sampler a sampler to be destroyed.
@@ -3088,6 +3094,9 @@ extern SDL_DECLSPEC void SDLCALL SDL_ReleaseGPUSampler(
  *
  * You must not reference the buffer after calling this function.
  *
+ * It is safe to pass NULL for `buffer`, in that case this function
+ * is a no-op.
+ *
  * \param device a GPU context.
  * \param buffer a buffer to be destroyed.
  *
@@ -3101,6 +3110,9 @@ extern SDL_DECLSPEC void SDLCALL SDL_ReleaseGPUBuffer(
  * Frees the given transfer buffer as soon as it is safe to do so.
  *
  * You must not reference the transfer buffer after calling this function.
+ *
+ * It is safe to pass NULL for `transfer_buffer`, in that case this
+ * function is a no-op.
  *
  * \param device a GPU context.
  * \param transfer_buffer a transfer buffer to be destroyed.
@@ -3116,6 +3128,9 @@ extern SDL_DECLSPEC void SDLCALL SDL_ReleaseGPUTransferBuffer(
  *
  * You must not reference the compute pipeline after calling this function.
  *
+ * It is safe to pass NULL for `compute_pipeline`, in that case this
+ * function is a no-op.
+ *
  * \param device a GPU context.
  * \param compute_pipeline a compute pipeline to be destroyed.
  *
@@ -3130,6 +3145,9 @@ extern SDL_DECLSPEC void SDLCALL SDL_ReleaseGPUComputePipeline(
  *
  * You must not reference the shader after calling this function.
  *
+ * It is safe to pass NULL for `shader`, in that case this function
+ * is a no-op.
+ *
  * \param device a GPU context.
  * \param shader a shader to be destroyed.
  *
@@ -3143,6 +3161,9 @@ extern SDL_DECLSPEC void SDLCALL SDL_ReleaseGPUShader(
  * Frees the given graphics pipeline as soon as it is safe to do so.
  *
  * You must not reference the graphics pipeline after calling this function.
+ *
+ * It is safe to pass NULL for `graphics_pipeline`, in that case this
+ * function is a no-op.
  *
  * \param device a GPU context.
  * \param graphics_pipeline a graphics pipeline to be destroyed.
@@ -4486,6 +4507,9 @@ extern SDL_DECLSPEC bool SDLCALL SDL_QueryGPUFence(
  * Releases a fence obtained from SDL_SubmitGPUCommandBufferAndAcquireFence.
  *
  * You must not reference the fence after calling this function.
+ *
+ * It is safe to pass NULL for `fence`, in that case this function
+ * is a no-op.
  *
  * \param device a GPU context.
  * \param fence a fence.

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -1549,11 +1549,11 @@ void SDL_ReleaseGPUTexture(
     SDL_GPUDevice *device,
     SDL_GPUTexture *texture)
 {
-    CHECK_DEVICE_MAGIC(device, );
-
-    CHECK_PARAM(texture == NULL) {
+    if(texture == NULL) {
         return;
     }
+
+    CHECK_DEVICE_MAGIC(device, );
 
     device->ReleaseTexture(
         device->driverData,
@@ -1564,11 +1564,11 @@ void SDL_ReleaseGPUSampler(
     SDL_GPUDevice *device,
     SDL_GPUSampler *sampler)
 {
-    CHECK_DEVICE_MAGIC(device, );
-
-    CHECK_PARAM(sampler == NULL) {
+    if(sampler == NULL) {
         return;
     }
+
+    CHECK_DEVICE_MAGIC(device, );
 
     device->ReleaseSampler(
         device->driverData,
@@ -1579,11 +1579,11 @@ void SDL_ReleaseGPUBuffer(
     SDL_GPUDevice *device,
     SDL_GPUBuffer *buffer)
 {
-    CHECK_DEVICE_MAGIC(device, );
-
-    CHECK_PARAM(buffer == NULL) {
+    if(buffer == NULL) {
         return;
     }
+
+    CHECK_DEVICE_MAGIC(device, );
 
     device->ReleaseBuffer(
         device->driverData,
@@ -1594,11 +1594,11 @@ void SDL_ReleaseGPUTransferBuffer(
     SDL_GPUDevice *device,
     SDL_GPUTransferBuffer *transfer_buffer)
 {
-    CHECK_DEVICE_MAGIC(device, );
-
-    CHECK_PARAM(transfer_buffer == NULL) {
+    if(transfer_buffer == NULL) {
         return;
     }
+
+    CHECK_DEVICE_MAGIC(device, );
 
     device->ReleaseTransferBuffer(
         device->driverData,
@@ -1609,11 +1609,11 @@ void SDL_ReleaseGPUShader(
     SDL_GPUDevice *device,
     SDL_GPUShader *shader)
 {
-    CHECK_DEVICE_MAGIC(device, );
-
-    CHECK_PARAM(shader == NULL) {
+    if(shader == NULL) {
         return;
     }
+
+    CHECK_DEVICE_MAGIC(device, );
 
     device->ReleaseShader(
         device->driverData,
@@ -1624,11 +1624,11 @@ void SDL_ReleaseGPUComputePipeline(
     SDL_GPUDevice *device,
     SDL_GPUComputePipeline *compute_pipeline)
 {
-    CHECK_DEVICE_MAGIC(device, );
-
-    CHECK_PARAM(compute_pipeline == NULL) {
+    if(compute_pipeline == NULL) {
         return;
     }
+
+    CHECK_DEVICE_MAGIC(device, );
 
     device->ReleaseComputePipeline(
         device->driverData,
@@ -1639,11 +1639,11 @@ void SDL_ReleaseGPUGraphicsPipeline(
     SDL_GPUDevice *device,
     SDL_GPUGraphicsPipeline *graphics_pipeline)
 {
-    CHECK_DEVICE_MAGIC(device, );
-
-    CHECK_PARAM(graphics_pipeline == NULL) {
+    if(graphics_pipeline == NULL) {
         return;
     }
+
+    CHECK_DEVICE_MAGIC(device, );
 
     device->ReleaseGraphicsPipeline(
         device->driverData,
@@ -3504,11 +3504,11 @@ void SDL_ReleaseGPUFence(
     SDL_GPUDevice *device,
     SDL_GPUFence *fence)
 {
-    CHECK_DEVICE_MAGIC(device, );
-
-    CHECK_PARAM(fence == NULL) {
+    if(fence == NULL) {
         return;
     }
+
+    CHECK_DEVICE_MAGIC(device, );
 
     device->ReleaseFence(
         device->driverData,


### PR DESCRIPTION
These functions already return immediately for NULL objects in normal builds, but it was done through `CHECK_PARAM`. When building with `SDL_DISABLE_INVALID_PARAMS`, these checks were compiled out, and NULL resources could reach backend release functions and cause segfault.

Always return on NULL so API behaves consistently regardless of `SDL_DISABLE_INVALID_PARAMS`.

Note: I'd also consider making every SDL_ReleaseX function a no-op on NULL objects, so API is more consistent and predictable. This doesn't harm performance, since objects are not freed often.

- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").
