### PR TITLE
for 'pinch end' on mobile, send dummy value -1 for (focus|span)_(x|y)

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -1144,7 +1144,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     public static native void onNativeFileDialog(int requestCode, String[] filelist, int filter);
     public static native void onNativePinchStart(float span_x, float span_y, float focus_x, float focus_y);
     public static native void onNativePinchUpdate(float scale, float span_x, float span_y, float focus_x, float focus_y);
-    public static native void onNativePinchEnd(float span_x, float span_y, float focus_x, float focus_y);
+    public static native void onNativePinchEnd();
 
     /**
      * This method is called by SDL using JNI.

--- a/android-project/app/src/main/java/org/libsdl/app/SDLSurface.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLSurface.java
@@ -460,11 +460,7 @@ public class SDLSurface extends SurfaceView implements SurfaceHolder.Callback,
 
     @Override
     public void onScaleEnd(ScaleGestureDetector detector) {
-        float span_x = getNormalizedX(detector.getCurrentSpanX());
-        float span_y = getNormalizedY(detector.getCurrentSpanY());
-        float focus_x = getNormalizedX(detector.getFocusX());
-        float focus_y = getNormalizedY(detector.getFocusY());
-        SDLActivity.onNativePinchEnd(span_x, span_y, focus_x, focus_y);
+        SDLActivity.onNativePinchEnd();
     }
 
 }

--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -854,10 +854,10 @@ typedef struct SDL_PinchFingerEvent
     Uint64 timestamp;   /**< In nanoseconds, populated using SDL_GetTicksNS() */
     float scale;        /**< The scale change since the last SDL_EVENT_PINCH_UPDATE. Scale < 1 is "zoom out". Scale > 1 is "zoom in". */
     SDL_WindowID windowID; /**< The window underneath the finger, if any */
-    float span_x;        /**< On mobile devices, the average X distance between each of the pointers forming the pinch in window coordinates.  Otherwise, -1. */
-    float span_y;        /**< On mobile devices, the average Y distance between each of the pointers forming the pinch in window coordinates.  Otherwise, -1. */
-    float focus_x;        /**< On mobile devices, the X coordinate of the current gesture's focal point in window coordinates.  Otherwise, -1. */
-    float focus_y;        /**< On mobile devices, the Y coordinate of the current gesture's focal point in window coordinates.  Otherwise, -1. */
+    float span_x;        /**< On mobile devices for BEGIN and UPDATE events, the average X distance between each of the pointers forming the pinch in window coordinates.  Otherwise, -1. */
+    float span_y;        /**< On mobile devices for BEGIN and UPDATE events, the average Y distance between each of the pointers forming the pinch in window coordinates.  Otherwise, -1. */
+    float focus_x;        /**< On mobile devices for BEGIN and UPDATE events, the X coordinate of the current gesture's focal point in window coordinates.  Otherwise, -1. */
+    float focus_y;        /**< On mobile devices for BEGIN and UPDATE events, the Y coordinate of the current gesture's focal point in window coordinates.  Otherwise, -1. */
 } SDL_PinchFingerEvent;
 
 /**

--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -134,8 +134,7 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(onNativePinchUpdate)(
     jfloat scale, jfloat span_x, jfloat span_y, jfloat focus_x, jfloat focus_y);
 
 JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(onNativePinchEnd)(
-    JNIEnv *env, jclass jcls,
-    jfloat span_x, jfloat span_y, jfloat focus_x, jfloat focus_y);
+    JNIEnv *env, jclass jcls);
 
 JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(onNativeMouse)(
     JNIEnv *env, jclass jcls,
@@ -255,7 +254,7 @@ static JNINativeMethod SDLActivity_tab[] = {
     { "onNativeTouch", "(IIIFFF)V", SDL_JAVA_INTERFACE(onNativeTouch) },
     { "onNativePinchStart", "(FFFF)V", SDL_JAVA_INTERFACE(onNativePinchStart) },
     { "onNativePinchUpdate", "(FFFFF)V", SDL_JAVA_INTERFACE(onNativePinchUpdate) },
-    { "onNativePinchEnd", "(FFFF)V", SDL_JAVA_INTERFACE(onNativePinchEnd) },
+    { "onNativePinchEnd", "()V", SDL_JAVA_INTERFACE(onNativePinchEnd) },
     { "onNativeMouse", "(IIFFZ)V", SDL_JAVA_INTERFACE(onNativeMouse) },
     { "onNativePen", "(IIIIFFF)V", SDL_JAVA_INTERFACE(onNativePen) },
     { "onNativeClipboardChanged", "()V", SDL_JAVA_INTERFACE(onNativeClipboardChanged) },
@@ -1497,12 +1496,12 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(onNativePinchUpdate)(
 }
 
 JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(onNativePinchEnd)(
-    JNIEnv *env, jclass jcls, jfloat span_x, jfloat span_y, jfloat focus_x, jfloat focus_y)
+    JNIEnv *env, jclass jcls)
 {
     SDL_LockMutex(Android_ActivityMutex);
 
     if (Android_Window) {
-        SDL_SendPinch(SDL_EVENT_PINCH_END, 0, Android_Window, 0, span_x, span_y, focus_x, focus_y);
+        SDL_SendPinch(SDL_EVENT_PINCH_END, 0, Android_Window, 0, -1.0f, -1.0f, -1.0f, -1.0f);
     }
 
     SDL_UnlockMutex(Android_ActivityMutex);

--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -2042,17 +2042,17 @@ static void Cocoa_SendMouseButtonClicks(SDL_Mouse *mouse, NSEvent *theEvent, SDL
 {
     switch ([theEvent phase]) {
     case NSEventPhaseBegan:
-        SDL_SendPinch(SDL_EVENT_PINCH_BEGIN, Cocoa_GetEventTimestamp([theEvent timestamp]), NULL, 0, -1, -1, -1, -1);
+        SDL_SendPinch(SDL_EVENT_PINCH_BEGIN, Cocoa_GetEventTimestamp([theEvent timestamp]), NULL, 0, -1.0f, -1.0f, -1.0f, -1.0f);
         break;
     case NSEventPhaseChanged:
         {
             CGFloat scale = 1.0f + [theEvent magnification];
-            SDL_SendPinch(SDL_EVENT_PINCH_UPDATE, Cocoa_GetEventTimestamp([theEvent timestamp]), NULL, scale, -1, -1, -1, -1);
+            SDL_SendPinch(SDL_EVENT_PINCH_UPDATE, Cocoa_GetEventTimestamp([theEvent timestamp]), NULL, scale, -1.0f, -1.0f, -1.0f, -1.0f);
         }
         break;
     case NSEventPhaseEnded:
     case NSEventPhaseCancelled:
-        SDL_SendPinch(SDL_EVENT_PINCH_END, Cocoa_GetEventTimestamp([theEvent timestamp]), NULL, 0, -1, -1, -1, -1);
+        SDL_SendPinch(SDL_EVENT_PINCH_END, Cocoa_GetEventTimestamp([theEvent timestamp]), NULL, 0, -1.0f, -1.0f, -1.0f, -1.0f);
         break;
     default:
         break;

--- a/src/video/uikit/SDL_uikitview.m
+++ b/src/video/uikit/SDL_uikitview.m
@@ -514,7 +514,7 @@ extern int SDL_AppleTVRemoteOpenedAsJoystick;
         case UIGestureRecognizerStateFailed:
         case UIGestureRecognizerStateEnded:
         case UIGestureRecognizerStateCancelled:
-            SDL_SendPinch(SDL_EVENT_PINCH_END, 0, sdlwindow, 0, span_x, span_y, focus_x, focus_y);
+            SDL_SendPinch(SDL_EVENT_PINCH_END, 0, sdlwindow, 0, -1.0f, -1.0f, -1.0f, -1.0f);
             break;
 
         default:


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
Following up on the "pinch" part of #15880. I also noticed that the int->float type changes in SDL_cocoawindow.m that were originally made as part of a code review on #15092 were somehow reverted, so I re-introduced the changes.
