### PR TITLE
Fixes invalid dereference in Wayland animated cursor sort

### DIFF
--- a/src/video/wayland/SDL_waylandmouse.c
+++ b/src/video/wayland/SDL_waylandmouse.c
@@ -720,8 +720,8 @@ static bool Wayland_GetSystemCursor(SDL_CursorData *cdata, SDL_WaylandCursorStat
 
 static int surface_sort_callback(const void *a, const void *b)
 {
-    SDL_Surface *s1 = (SDL_Surface *)a;
-    SDL_Surface *s2 = (SDL_Surface *)b;
+    SDL_Surface *s1 = *(SDL_Surface **)a;
+    SDL_Surface *s2 = *(SDL_Surface **)b;
 
     return (s1->w * s1->h) <= (s2->w * s2->h) ? -1 : 1;
 }


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

`Wayland_CreateAnimatedCursor` calls `SDL_qsort` on an array of type `**SDL_Surface`, not on an array of `*SDL_Surface`. As such the void pointers in the callback need to be casted to `SDL_Surface **` not `SDL_Surface *`.

## Description

This was likely not caught previously since it's very unlikely that reading a few bytes past the end of this array results in reading unreadable memory, so the only side effect was invalid sort results which is a pretty subtle bug.

I caught this because I build SDL with UBSAN enabled in my debug builds, and it trapped when the multiplication of the garbage `SDL_Surface*` width and heights overflowed. I validated that the change is correct by adding logs (since removed) demonstrating that it was previously comparing garbage, and is now comparing the actual cursor surfaces.

## Existing Issue(s)

(n/a as far as I'm aware)
