### PR TITLE
DOS: Fix VGA detection on some VLB/ISA16 cards

### DIFF
--- a/src/video/dos/SDL_dosmodes.c
+++ b/src/video/dos/SDL_dosmodes.c
@@ -224,13 +224,14 @@ static const SDL_VESAInfo *GetVESAInfo(void)
 // doesn't exist (reads 0xFF) or isn't writable.
 static bool DetectVGA(void)
 {
-    const Uint8 original = inportb(VGA_DAC_PIXEL_MASK);
-    outportb(VGA_DAC_PIXEL_MASK, 0xA5);
-    (void)inportb(0x80); // small I/O delay
-    const Uint8 readback = inportb(VGA_DAC_PIXEL_MASK);
-    outportb(VGA_DAC_PIXEL_MASK, original);
+    const uint8_t original = inportb(VGA_MISC_READ);
+    uint8_t test_val = original ^ 0x03;
+    outportb(VGA_MISC_WRITE, test_val);
+    (void)inportb(0x80);
+    uint8_t readback = inportb(VGA_MISC_READ);
+    outportb(VGA_MISC_WRITE, original);
 
-    return (readback == 0xA5);
+    return ((readback & 0x03) == (test_val & 0x03));
 }
 
 bool DOSVESA_SupportsVESA(void)

--- a/src/video/dos/SDL_dosmodes.h
+++ b/src/video/dos/SDL_dosmodes.h
@@ -35,6 +35,8 @@ extern const char *DOSVESA_GetGPUName(void);
 #define VGA_DAC_PIXEL_MASK  0x3C6 // pixel mask register (read/write, VGA-only)
 #define VGA_DAC_WRITE_INDEX 0x3C8 // write index register (set starting color index)
 #define VGA_DAC_DATA        0x3C9 // data register (write R, G, B in sequence)
+#define VGA_MISC_READ       0x3CC // read miscellaneous output register (read-only, VGA-only)
+#define VGA_MISC_WRITE      0x3C2 // write miscellaneous output register (write-only, VGA-only)
 
 // VGA Input Status Register 1 (for vblank detection)
 #define VGA_STATUS_PORT   0x3DA


### PR DESCRIPTION
### Problem

The current VGA detection routine uses the DAC Pixel Mask (0x3C6) by writing 0xA5 and reading it back. This fails on certain VLB/ISA16 implementations. This causes the detection to return false on many display cards that do have VGA capability, breaking SDL3 for DOS from using them.

### Solution

Use the Miscellaneous Output Register instead:
- Read port:  0x3CC
- Write port: 0x3C2

The test modifies the low two bits, waits for a sufficient delay, reads back to verify the change, and restores the original value.

### Test Matrix

| Hardware                          | Environment   | Old method | New method |Result |
|-----------------------------------|---------------|------------|------------|------------|
| NVIDIA GeForce RTX 3060 Ti   | Real Hardware    | true      | true       |PASS   |
| VMWare VMSVGA                            | VirtualBox    | false      | true       |FIXED |
|AGP/PCI 3Dfx Voodoo 3 | 86box             | true      | true       |PASS   |
| PCI S3 ViRGE/GX2        | 86box         | true | true       |PASS   |
| VLB S3 Trio64V+       | 86box         | false      | true       |FIXED |
| ISA16 S3 86c801        | 86box         | false      | true       |FIXED |
| ISA IBM VGA                | 86box         | true      | true      |PASS   |
| ISA IBM CGA                | 86box         | false      | false      |PASS   |
| ISA IBM EGA                | 86box         | false      | false      |PASS   |
