### PR TITLE
dos: Use INT 0x10/AX=0x1A00 to detect VGA presence

### DIFF
--- a/src/video/dos/SDL_dosmodes.c
+++ b/src/video/dos/SDL_dosmodes.c
@@ -219,18 +219,15 @@ static const SDL_VESAInfo *GetVESAInfo(void)
     return vesa_info;
 }
 
-// Test by writing and reading back the DAC Pixel Mask register
-// On VGA this is a read/write register, on EGA/CGA the port either
-// doesn't exist (reads 0xFF) or isn't writable.
+// Check for VGA using BIOS function GET DISPLAY COMBINATION CODE.
+// Call INT 0x10 with AX=0x1A00; function is supported if AL=0x1A.
+// Returns true for VGA-compatible hardware. 
 static bool DetectVGA(void)
 {
-    const Uint8 original = inportb(VGA_DAC_PIXEL_MASK);
-    outportb(VGA_DAC_PIXEL_MASK, 0xA5);
-    (void)inportb(0x80); // small I/O delay
-    const Uint8 readback = inportb(VGA_DAC_PIXEL_MASK);
-    outportb(VGA_DAC_PIXEL_MASK, original);
-
-    return (readback == 0xA5);
+    __dpmi_regs regs = {};
+    regs.x.ax = 0x1A00;
+    __dpmi_int(0x10, &regs);
+    return ((regs.x.ax & 0x00FF) == 0x001A);
 }
 
 bool DOSVESA_SupportsVESA(void)


### PR DESCRIPTION
### Problem

The current VGA detection routine fails on certain VLB and ISA16 SVGA implementations, causing SDL3 for DOS to falsely report no VGA hardware on systems that do have it.

### Solution

Use the BIOS function GET DISPLAY COMBINATION CODE(`INT 0x10, AX=0x1A00`), as [suggested](../pull/15906) by @AJenbo.

### Test Matrix

| Hardware                          | Environment   | Old method | New method |Result |
|-----------------------------------|---------------|------------|------------|------------|
| NVIDIA GeForce RTX 3060 Ti   | Real Hardware    | true      | true       |PASS   |
| VMWare VMSVGA                            | VirtualBox    | false      | true       |FIXED |
|AGP/PCI 3Dfx Voodoo 3 | 86box             | true      | true       |PASS   |
| PCI S3 ViRGE/GX2        | 86box         | true | true       |PASS   |
| VLB S3 Trio64V+       | 86box         | false      | true       |FIXED |
| ISA16 S3 86c801        | 86box         | false      | true       |FIXED |
| ISA IBM VGA                | 86box         | true      | true      |PASS   |
| ISA IBM CGA                | 86box         | false      | false      |PASS   |
| ISA IBM EGA                | 86box         | false      | false      |PASS   |
