### PR TITLE
stdinc: SDL_SetMemoryFunctions now handles NULL function pointers better.

### DIFF
--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -1573,12 +1573,18 @@ extern SDL_DECLSPEC void SDLCALL SDL_GetMemoryFunctions(SDL_malloc_func *malloc_
  * If used, usually this needs to be the first call made into the SDL library,
  * if not the very first thing done at program startup time.
  *
+ * It is legal to call this with all 4 parameters set to NULL, which will
+ * restore the original memory functions without having to query them with
+ * SDL_GetOriginalMemoryFunctions() first.
+ *
  * \param malloc_func custom malloc function.
  * \param calloc_func custom calloc function.
  * \param realloc_func custom realloc function.
  * \param free_func custom free function.
- * \returns true on success or false on failure; call SDL_GetError() for more
- *          information.
+ * \returns true on success or false on failure. This only fails if there is
+ *          a mix of NULL and non-NULL parameters. Failure will not set an
+ *          error message (which allocates memory) so do _not_ call
+ *          SDL_GetError() in response to a failure here.
  *
  * \threadsafety It is safe to call this function from any thread, but one
  *               should not replace the memory functions once any allocations
@@ -1590,9 +1596,9 @@ extern SDL_DECLSPEC void SDLCALL SDL_GetMemoryFunctions(SDL_malloc_func *malloc_
  * \sa SDL_GetOriginalMemoryFunctions
  */
 extern SDL_DECLSPEC bool SDLCALL SDL_SetMemoryFunctions(SDL_malloc_func malloc_func,
-                                                            SDL_calloc_func calloc_func,
-                                                            SDL_realloc_func realloc_func,
-                                                            SDL_free_func free_func);
+                                                        SDL_calloc_func calloc_func,
+                                                        SDL_realloc_func realloc_func,
+                                                        SDL_free_func free_func);
 
 /**
  * Allocate memory aligned to a specific alignment.

--- a/src/stdlib/SDL_malloc.c
+++ b/src/stdlib/SDL_malloc.c
@@ -6537,23 +6537,16 @@ bool SDL_SetMemoryFunctions(SDL_malloc_func malloc_func,
                                 SDL_realloc_func realloc_func,
                                 SDL_free_func free_func)
 {
-    CHECK_PARAM(!malloc_func) {
-        return SDL_InvalidParamError("malloc_func");
+    if (!malloc_func && !calloc_func && !realloc_func && !free_func) {
+        SDL_GetOriginalMemoryFunctions(&s_mem.malloc_func, &s_mem.calloc_func, &s_mem.realloc_func, &s_mem.free_func);
+    } else if (!malloc_func || !calloc_func || !realloc_func || !free_func) {  // if not all are NULL, none of them can be NULL.
+        return false;  // do _not_ set an error message in here, since it will allocate memory!
+    } else {
+        s_mem.malloc_func = malloc_func;
+        s_mem.calloc_func = calloc_func;
+        s_mem.realloc_func = realloc_func;
+        s_mem.free_func = free_func;
     }
-    CHECK_PARAM(!calloc_func) {
-        return SDL_InvalidParamError("calloc_func");
-    }
-    CHECK_PARAM(!realloc_func) {
-        return SDL_InvalidParamError("realloc_func");
-    }
-    CHECK_PARAM(!free_func) {
-        return SDL_InvalidParamError("free_func");
-    }
-
-    s_mem.malloc_func = malloc_func;
-    s_mem.calloc_func = calloc_func;
-    s_mem.realloc_func = realloc_func;
-    s_mem.free_func = free_func;
     return true;
 }
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Now it does _not_ call SDL_SetError(), since that would allocate memory with the system in a weird state, and setting all four functions to NULL will restore the original memory functions, as a shortcut vs having to query SDL_GetOriginalMemoryFunctions() first.

Fixes #15914.

