### PR TITLE
Loadso's Unload returns bool to indicate success/failure

### DIFF
--- a/include/SDL3/SDL_loadso.h
+++ b/include/SDL3/SDL_loadso.h
@@ -127,6 +127,8 @@ extern SDL_DECLSPEC SDL_FunctionPointer SDLCALL SDL_LoadFunction(SDL_SharedObjec
  * SDL_LoadFunction() will no longer be valid.
  *
  * \param handle a valid shared object handle returned by SDL_LoadObject().
+ * \returns a boolean value, where true indicates success and false
+ *          indicates failure; call SDL_GetError() for more information.
  *
  * \threadsafety It is safe to call this function from any thread.
  *
@@ -134,7 +136,7 @@ extern SDL_DECLSPEC SDL_FunctionPointer SDLCALL SDL_LoadFunction(SDL_SharedObjec
  *
  * \sa SDL_LoadObject
  */
-extern SDL_DECLSPEC void SDLCALL SDL_UnloadObject(SDL_SharedObject *handle);
+extern SDL_DECLSPEC bool SDLCALL SDL_UnloadObject(SDL_SharedObject *handle);
 
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus

--- a/src/loadso/dlopen/SDL_sysloadso.c
+++ b/src/loadso/dlopen/SDL_sysloadso.c
@@ -72,11 +72,17 @@ SDL_FunctionPointer SDL_LoadFunction(SDL_SharedObject *handle, const char *name)
     return symbol;
 }
 
-void SDL_UnloadObject(SDL_SharedObject *handle)
+bool SDL_UnloadObject(SDL_SharedObject *handle)
 {
-    if (handle) {
-        dlclose(handle);
+    if (!handle) {
+        return true;
     }
+    int error_code = dlclose(handle);
+    if (error_code) {
+        SDL_SetError("Failed unloading library. Error code: %d. Message: %s
+                     error_code, (const char *)dlerror());
+    }
+    return error_code == 0;
 }
 
 #endif // SDL_LOADSO_DLOPEN

--- a/src/loadso/dummy/SDL_sysloadso.c
+++ b/src/loadso/dummy/SDL_sysloadso.c
@@ -37,9 +37,9 @@ SDL_FunctionPointer SDL_LoadFunction(SDL_SharedObject *handle, const char *name)
     return NULL;
 }
 
-void SDL_UnloadObject(SDL_SharedObject *handle)
+bool SDL_UnloadObject(SDL_SharedObject *handle)
 {
-    // no-op.
+    return true;
 }
 
 #endif // SDL_LOADSO_DUMMY

--- a/src/loadso/windows/SDL_sysloadso.c
+++ b/src/loadso/windows/SDL_sysloadso.c
@@ -58,11 +58,18 @@ SDL_FunctionPointer SDL_LoadFunction(SDL_SharedObject *handle, const char *name)
     return symbol;
 }
 
-void SDL_UnloadObject(SDL_SharedObject *handle)
+bool SDL_UnloadObject(SDL_SharedObject *handle)
 {
-    if (handle) {
-        FreeLibrary((HMODULE)handle);
+    if (!handle) {
+        return true;
     }
+    bool success = FreeLibrary((HMODULE)handle);
+    if (!success) {
+        char errbuf[512];
+        SDL_snprintf(errbuf, sizeof (errbuf), "Failed unloading library");
+        WIN_SetError(errbuf);
+    }
+    return success;
 }
 
 #endif // SDL_LOADSO_WINDOWS

--- a/test/testloadso.c
+++ b/test/testloadso.c
@@ -104,7 +104,11 @@ int main(int argc, char *argv[])
                 SDL_Log("Unloading library...");
             }
         }
-        SDL_UnloadObject(lib);
+        bool close_success = SDL_UnloadObject(lib);
+        if (!close_success) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_UnloadObject('%s') failed: %s",
+                         libname, SDL_GetError());
+        }
     }
     SDL_Quit();
     SDLTest_CommonDestroyState(state);


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description

While debugging loading dynamic libraries, and in this case, while debugging unloading them, it would be good to have the necessary debug tools. This PR allows the user to rule out any possibility that it is loadso's unloading that is failing, but rather something else in the user's code. Or if it actually is failing, then the user will know of the failure and also get an appropriate error message from the OS.

## Existing Issue(s)

No existing issues
