### PR TITLE
cocoa: Workaround for an issue with incorrect window position after exiting fullscreen

### DIFF
--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -1566,7 +1566,10 @@ static NSCursor *Cocoa_GetDesiredCursor(void)
         } else {
             [nswindow setCollectionBehavior:NSWindowCollectionBehaviorManaged];
         }
-        [NSMenu setMenuBarVisible:YES];
+
+        if (![NSMenu menuBarVisible]) {
+            [NSMenu setMenuBarVisible:YES];
+        }
 
         // Toggle zoom, if changed while fullscreen.
         if ([self windowOperationIsPending:PENDING_OPERATION_ZOOM]) {


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

On macOS, in some cases, the window can move to an incorrect position after exiting fullscreen

## Description
<!--- Describe your changes in detail -->

In some cases the [NSMenu setMenuBarVisible:YES]; call in windowDidExitFullScreen: makes Cocoa call windowDidMove: with an incorrectly set window frame. [nswindow frame] in windowDidExitFullScreen: right before that setMenuBarVisible: call is correct.

Calling [NSMenu setMenuBarVisible:YES] in windowDidExitFullScreen: only if [NSMenu menuBarVisible] is false works around this problem.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->

https://github.com/libsdl-org/SDL/issues/15920