### PR TITLE
gpu: validate transfer buffer usage

### DIFF
--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -1431,8 +1431,8 @@ SDL_GPUTransferBuffer *SDL_CreateGPUTransferBuffer(
     }
 
     if (device->debug_mode) {
-        if (createinfo->usage != SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD
-            && createinfo->usage != SDL_GPU_TRANSFERBUFFERUSAGE_DOWNLOAD) {
+        if (createinfo->usage != SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD &&
+            createinfo->usage != SDL_GPU_TRANSFERBUFFERUSAGE_DOWNLOAD) {
             SDL_assert_release(!"Invalid transfer buffer usage!");
         }
     }

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -1430,6 +1430,13 @@ SDL_GPUTransferBuffer *SDL_CreateGPUTransferBuffer(
         return NULL;
     }
 
+    if (device->debug_mode) {
+        if (createinfo->usage != SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD
+            && createinfo->usage != SDL_GPU_TRANSFERBUFFERUSAGE_DOWNLOAD) {
+            SDL_assert_release(!"Invalid transfer buffer usage!");
+        }
+    }
+
     const char *debugName = SDL_GetStringProperty(createinfo->props, SDL_PROP_GPU_TRANSFERBUFFER_CREATE_NAME_STRING, NULL);
 
     return device->CreateTransferBuffer(


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Add a validation check in `SDL_CreateGPUTransferBuffer(...)` to ensure that transfer buffers are created with a valid usage (`SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD` or `SDL_GPU_TRANSFERBUFFERUSAGE_DOWNLOAD`) when debug mode is enabled.

## Description
This prevents invalid transfer buffer usages from reaching backend implementations. While Vulkan permits bidirectional transfer buffers, Direct3D backends expect transfer buffers to be explicitly designated as either upload or download, and can crash if an unsupported usage is provided.

The error/assert message can be adjusted or refined if needed to better reflect backend constraints or improve clarity for developers encountering the validation failure.