### PR TITLE
Cygwin: testautomation run-time fix

### DIFF
--- a/src/stdlib/SDL_getenv.c
+++ b/src/stdlib/SDL_getenv.c
@@ -22,7 +22,7 @@
 
 #include "SDL_getenv_c.h"
 
-#if defined(SDL_PLATFORM_WINDOWS)
+#if defined(SDL_PLATFORM_WINDOWS) && !defined(SDL_PLATFORM_CYGWIN)
 #include "../core/windows/SDL_windows.h"
 #endif
 
@@ -30,7 +30,7 @@
 #include "../core/android/SDL_android.h"
 #endif
 
-#if defined(SDL_PLATFORM_WINDOWS)
+#if defined(SDL_PLATFORM_WINDOWS) && !defined(SDL_PLATFORM_CYGWIN)
 #define HAVE_WIN32_ENVIRONMENT
 #elif defined(HAVE_GETENV) && \
       (defined(HAVE_SETENV) || defined(HAVE_PUTENV)) && \
@@ -103,7 +103,7 @@ SDL_Environment *SDL_CreateEnvironment(bool populated)
     env->lock = SDL_CreateMutex();
 
     if (populated) {
-#ifdef SDL_PLATFORM_WINDOWS
+#if defined(SDL_PLATFORM_WINDOWS) && !defined(SDL_PLATFORM_CYGWIN)
         LPWCH strings = GetEnvironmentStringsW();
         if (strings) {
             for (LPWCH string = strings; *string; string += SDL_wcslen(string) + 1) {
@@ -146,7 +146,7 @@ SDL_Environment *SDL_CreateEnvironment(bool populated)
                 SDL_InsertIntoHashTable(env->strings, variable, value, true);
             }
         }
-#endif // SDL_PLATFORM_WINDOWS
+#endif // SDL_PLATFORM_WINDOWS && !SDL_PLATFORM_CYGWIN
     }
 
     return env;


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

Stop using WIN32 ENVIRONMENT and use instead Unix GETENV under Cygwin

## Description
<!--- Describe your changes in detail -->
Add not SDL_PLATFORM_CYGWIN guards to code.

Before and after testing results.

Testing main without SDLTEST_GDB=YES
The following tests FAILED:
          2 - testautomation (Failed)             #  8 out of 10 times
         15 - testsem (Failed)                    # 10 out of 10 times
         18 - testyuv (Timeout)                   # 10 out of 10 times
         23 - testprocess (Failed)                # 10 out of 10 times
         24 - testautomation-no-simd (Failed)     #  6 out of 10 times
Errors while running CTest

Testing main_staging without SDLTEST_GDB=YES
The following tests FAILED:
         15 - testsem (Failed)                    # 10 out of 10 times
         18 - testyuv (Timeout)                   # 10 out of 10 times
         23 - testprocess (Failed)                # 10 out of 10 times
Errors while running CTest

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
