### PR TITLE
PSP: Allow non-ascii characters and more characters from osk

### DIFF
--- a/src/video/psp/SDL_pspvideo.c
+++ b/src/video/psp/SDL_pspvideo.c
@@ -394,7 +394,7 @@ bool PSP_HasScreenKeyboardSupport(SDL_VideoDevice *_this)
 
 void PSP_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesID props)
 {
-    char list[0x20000] __attribute__((aligned(64)));  // Needed for sceGuStart to work
+    char list[0x20000] __attribute__((aligned(64))); // Needed for sceGuStart to work
     int done = 0;
     int input_text_length = 128;
     void *received_text = SDL_calloc(input_text_length, sizeof(Uint16));
@@ -451,7 +451,7 @@ void PSP_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window, SDL_Prop
     data.intext = NULL;
     data.outtextlength = input_text_length;
     data.outtextlimit = input_text_length;
-    data.outtext = (unsigned short *) received_text;
+    data.outtext = (unsigned short *)received_text;
 
     params.base.size = sizeof(params);
     sceUtilityGetSystemParamInt(PSP_SYSTEMPARAM_ID_INT_LANGUAGE, &params.base.language);
@@ -467,7 +467,7 @@ void PSP_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window, SDL_Prop
 
     SDL_SendScreenKeyboardShown();
 
-    while(!done) {
+    while (!done) {
         sceGuStart(GU_DIRECT, list);
         sceGuClearColor(0);
         sceGuClear(GU_COLOR_BUFFER_BIT);
@@ -476,21 +476,20 @@ void PSP_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window, SDL_Prop
             sceGuClear(GU_DEPTH_BUFFER_BIT);
         }
         sceGuFinish();
-        sceGuSync(0,0);
+        sceGuSync(0, 0);
 
-        switch(sceUtilityOskGetStatus())
-        {
-            case PSP_UTILITY_DIALOG_VISIBLE:
-                sceUtilityOskUpdate(1);
-                break;
-            case PSP_UTILITY_DIALOG_QUIT:
-                sceUtilityOskShutdownStart();
-                break;
-            case PSP_UTILITY_DIALOG_NONE:
-                done = 1;
-                break;
-            default :
-                break;
+        switch (sceUtilityOskGetStatus()) {
+        case PSP_UTILITY_DIALOG_VISIBLE:
+            sceUtilityOskUpdate(1);
+            break;
+        case PSP_UTILITY_DIALOG_QUIT:
+            sceUtilityOskShutdownStart();
+            break;
+        case PSP_UTILITY_DIALOG_NONE:
+            done = 1;
+            break;
+        default:
+            break;
         }
         sceDisplayWaitVblankStart();
         sceGuSwapBuffers();
@@ -506,7 +505,7 @@ void PSP_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window, SDL_Prop
         return;
     }
 
-    string_to_send = SDL_calloc(input_text_length, 3);  // utf-8 characters can use up to 4 bytes, but the PSP keyboard has characters up to 3
+    string_to_send = SDL_calloc(input_text_length, 3); // utf-8 characters can use up to 4 bytes, but the PSP keyboard has characters up to 3
     if (!string_to_send) {
         SDL_Log("Error: Failed to allocate buffer for converting osk input to utf-8");
         SDL_free(string_to_send);
@@ -518,7 +517,7 @@ void PSP_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window, SDL_Prop
 
     text_string = string_to_send;
     outbytesleft = input_text_length * 3;
-    iconv_result = SDL_iconv(iconv, (const char **) &received_text, (size_t *) &inbytesleft, (char **) &text_string, &outbytesleft);
+    iconv_result = SDL_iconv(iconv, (const char **)&received_text, (size_t *)&inbytesleft, (char **)&text_string, &outbytesleft);
     if (iconv_result == 0) {
         SDL_SendKeyboardText(string_to_send);
     } else {

--- a/src/video/psp/SDL_pspvideo.c
+++ b/src/video/psp/SDL_pspvideo.c
@@ -519,7 +519,6 @@ void PSP_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window, SDL_Prop
 done:
     SDL_free(string_to_send);
     SDL_free(received_text_start);
-    SDL_iconv_close(iconv);
 
     SDL_SendScreenKeyboardHidden();
 }

--- a/src/video/psp/SDL_pspvideo.c
+++ b/src/video/psp/SDL_pspvideo.c
@@ -395,16 +395,21 @@ bool PSP_HasScreenKeyboardSupport(SDL_VideoDevice *_this)
 void PSP_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesID props)
 {
     char list[0x20000] __attribute__((aligned(64)));  // Needed for sceGuStart to work
-    int i;
+    int i = 0;
     int done = 0;
-    int input_text_length = 32; // SDL_SendKeyboardText supports up to 32 characters per event
-    unsigned short outtext[input_text_length];
-    char text_string[input_text_length];
+    int input_text_length = 128;
+    void * received_text = SDL_calloc(input_text_length, sizeof(Uint16));
+    void * received_text_start = received_text;
+    void * text_string = NULL;
+    void * string_to_send = NULL;
+
+    SDL_iconv_t iconv = NULL;
+    size_t outbytesleft = input_text_length;
+    size_t inbytesleft = input_text_length * sizeof(Uint16);
+    size_t iconv_result = 0;
 
     SceUtilityOskData data;
     SceUtilityOskParams params;
-
-    SDL_memset(outtext, 0, input_text_length * sizeof(unsigned short));
 
     data.language = PSP_UTILITY_OSK_LANGUAGE_DEFAULT;
     data.lines = 1;
@@ -443,7 +448,7 @@ void PSP_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window, SDL_Prop
     data.intext = NULL;
     data.outtextlength = input_text_length;
     data.outtextlimit = input_text_length;
-    data.outtext = outtext;
+    data.outtext = (unsigned short *) received_text;
 
     params.base.size = sizeof(params);
     sceUtilityGetSystemParamInt(PSP_SYSTEMPARAM_ID_INT_LANGUAGE, &params.base.language);
@@ -462,8 +467,11 @@ void PSP_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window, SDL_Prop
     while(!done) {
         sceGuStart(GU_DIRECT, list);
         sceGuClearColor(0);
-        sceGuClearDepth(0);
-        sceGuClear(GU_COLOR_BUFFER_BIT|GU_DEPTH_BUFFER_BIT);
+        sceGuClear(GU_COLOR_BUFFER_BIT);
+        if (sceGuGetStatus(GU_DEPTH_TEST)) {
+            sceGuClearDepth(0);
+            sceGuClear(GU_DEPTH_BUFFER_BIT);
+        }
         sceGuFinish();
         sceGuSync(0,0);
 
@@ -485,11 +493,20 @@ void PSP_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window, SDL_Prop
         sceGuSwapBuffers();
     }
 
-    // Convert input list to string
-    for (i = 0; i < input_text_length; i++) {
-        text_string[i] = outtext[i];
+    // Convert input list to strings
+    iconv = SDL_iconv_open("UTF-8", "UCS-2-INTERNAL");
+    string_to_send = SDL_calloc(input_text_length, 3);  // utf-8 characters can use up to 4 bytes, but the PSP keyboard has characters up to 3
+    text_string = string_to_send;
+    outbytesleft = input_text_length * 3;
+    iconv_result = SDL_iconv(iconv, (const char **) &received_text, (size_t *) &inbytesleft, (char **) &text_string, &outbytesleft);
+    if (iconv_result == 0) {
+        SDL_SendKeyboardText(string_to_send);
+    } else {
+        SDL_SetError("Conversion of string received from on screen keyboard to utf-8 failed with status %u", iconv_result);
     }
-    SDL_SendKeyboardText((const char *) text_string);
+    SDL_free(string_to_send);
+    SDL_free(received_text_start);
+    SDL_iconv_close(iconv);
 
     SDL_SendScreenKeyboardHidden();
 }

--- a/src/video/psp/SDL_pspvideo.c
+++ b/src/video/psp/SDL_pspvideo.c
@@ -498,21 +498,13 @@ void PSP_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window, SDL_Prop
     // Convert input list to strings
     iconv = SDL_iconv_open("UTF-8", "UCS-2-INTERNAL");
     if ((size_t)iconv == SDL_ICONV_ERROR) {
-        SDL_Log("Error: Failed to open iconv for ucs-2-internal conversion to utf-8");
-        SDL_free(string_to_send);
-        SDL_free(received_text_start);
-        SDL_SendScreenKeyboardHidden();
-        return;
+        goto done;
     }
 
     string_to_send = SDL_calloc(input_text_length, 3); // utf-8 characters can use up to 4 bytes, but the PSP keyboard has characters up to 3
     if (!string_to_send) {
-        SDL_Log("Error: Failed to allocate buffer for converting osk input to utf-8");
-        SDL_free(string_to_send);
-        SDL_free(received_text_start);
         SDL_iconv_close(iconv);
-        SDL_SendScreenKeyboardHidden();
-        return;
+        goto done;
     }
 
     text_string = string_to_send;
@@ -520,10 +512,11 @@ void PSP_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window, SDL_Prop
     iconv_result = SDL_iconv(iconv, (const char **)&received_text, (size_t *)&inbytesleft, (char **)&text_string, &outbytesleft);
     if (iconv_result == 0) {
         SDL_SendKeyboardText(string_to_send);
-    } else {
-        SDL_SetError("Conversion of string received from on screen keyboard to utf-8 failed with status %u", iconv_result);
     }
 
+    SDL_iconv_close(iconv);
+
+done:
     SDL_free(string_to_send);
     SDL_free(received_text_start);
     SDL_iconv_close(iconv);

--- a/src/video/psp/SDL_pspvideo.c
+++ b/src/video/psp/SDL_pspvideo.c
@@ -398,10 +398,14 @@ void PSP_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window, SDL_Prop
     int i = 0;
     int done = 0;
     int input_text_length = 128;
-    void * received_text = SDL_calloc(input_text_length, sizeof(Uint16));
-    void * received_text_start = received_text;
-    void * text_string = NULL;
-    void * string_to_send = NULL;
+    void *received_text = SDL_calloc(input_text_length, sizeof(Uint16));
+    if (!received_text) {
+        SDL_Log("Error: Failed to allocate buffer for receiving osk input");
+        return;
+    }
+    void *received_text_start = received_text;
+    void *text_string = NULL;
+    void *string_to_send = NULL;
 
     SDL_iconv_t iconv = NULL;
     size_t outbytesleft = input_text_length;
@@ -495,7 +499,24 @@ void PSP_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window, SDL_Prop
 
     // Convert input list to strings
     iconv = SDL_iconv_open("UTF-8", "UCS-2-INTERNAL");
+    if (iconv == SDL_ICONV_ERROR) {
+        SDL_Log("Error: Failed to open iconv for ucs-2-internal conversion to utf-8");
+        SDL_free(string_to_send);
+        SDL_free(received_text_start);
+        SDL_SendScreenKeyboardHidden();
+        return;
+    }
+
     string_to_send = SDL_calloc(input_text_length, 3);  // utf-8 characters can use up to 4 bytes, but the PSP keyboard has characters up to 3
+    if (!string_to_send) {
+        SDL_Log("Error: Failed to allocate buffer for converting osk input to utf-8");
+        SDL_free(string_to_send);
+        SDL_free(received_text_start);
+        SDL_iconv_close(iconv);
+        SDL_SendScreenKeyboardHidden();
+        return;
+    }
+
     text_string = string_to_send;
     outbytesleft = input_text_length * 3;
     iconv_result = SDL_iconv(iconv, (const char **) &received_text, (size_t *) &inbytesleft, (char **) &text_string, &outbytesleft);
@@ -504,6 +525,7 @@ void PSP_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window, SDL_Prop
     } else {
         SDL_SetError("Conversion of string received from on screen keyboard to utf-8 failed with status %u", iconv_result);
     }
+
     SDL_free(string_to_send);
     SDL_free(received_text_start);
     SDL_iconv_close(iconv);

--- a/src/video/psp/SDL_pspvideo.c
+++ b/src/video/psp/SDL_pspvideo.c
@@ -395,7 +395,6 @@ bool PSP_HasScreenKeyboardSupport(SDL_VideoDevice *_this)
 void PSP_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window, SDL_PropertiesID props)
 {
     char list[0x20000] __attribute__((aligned(64)));  // Needed for sceGuStart to work
-    int i = 0;
     int done = 0;
     int input_text_length = 128;
     void *received_text = SDL_calloc(input_text_length, sizeof(Uint16));
@@ -499,7 +498,7 @@ void PSP_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window, SDL_Prop
 
     // Convert input list to strings
     iconv = SDL_iconv_open("UTF-8", "UCS-2-INTERNAL");
-    if (iconv == SDL_ICONV_ERROR) {
+    if ((size_t)iconv == SDL_ICONV_ERROR) {
         SDL_Log("Error: Failed to open iconv for ucs-2-internal conversion to utf-8");
         SDL_free(string_to_send);
         SDL_free(received_text_start);

--- a/src/video/psp/SDL_pspvideo.c
+++ b/src/video/psp/SDL_pspvideo.c
@@ -399,7 +399,6 @@ void PSP_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window, SDL_Prop
     int input_text_length = 128;
     void *received_text = SDL_calloc(input_text_length, sizeof(Uint16));
     if (!received_text) {
-        SDL_Log("Error: Failed to allocate buffer for receiving osk input");
         return;
     }
     void *received_text_start = received_text;


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
At the moment we're only allowing ascii characters to be used on the on screen keyboard and only 32 characters. This makes it so all characters work and 128 characters are allowed.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
