### PR TITLE
Guard SDL_SYS_ShowFileDialogWithProperties against SDL_DIALOG_DISABLED

### DIFF
--- a/src/dialog/android/SDL_androiddialog.c
+++ b/src/dialog/android/SDL_androiddialog.c
@@ -23,6 +23,8 @@
 #include "../SDL_dialog.h"
 #include "../../core/android/SDL_android.h"
 
+#ifndef SDL_DIALOG_DISABLED
+
 void SDL_SYS_ShowFileDialogWithProperties(SDL_FileDialogType type, SDL_DialogFileCallback callback, void *userdata, SDL_PropertiesID props)
 {
     SDL_DialogFileFilter *filters = SDL_GetPointerProperty(props, SDL_PROP_FILE_DIALOG_FILTERS_POINTER, NULL);
@@ -41,3 +43,5 @@ void SDL_SYS_ShowFileDialogWithProperties(SDL_FileDialogType type, SDL_DialogFil
         callback(userdata, NULL, -1);
     }
 }
+
+#endif // !SDL_DIALOG_DISABLED


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

C99's implicit function declaration means that the compiler will choke if SDL_DIALOG_DISABLED is defined, even though the code-path will never call Android_JNI_ShowFileDialog; it still needs to exist. 

Fixes 15932