### PR TITLE
Use SDL_PROCESS_WINDOWS instead of SDL_PLATFORM_WINDOWS ...

### DIFF
--- a/src/process/SDL_process.c
+++ b/src/process/SDL_process.c
@@ -45,7 +45,7 @@ SDL_Process *SDL_CreateProcess(const char * const *args, bool pipe_stdio)
 SDL_Process *SDL_CreateProcessWithProperties(SDL_PropertiesID props)
 {
     const char * const *args = SDL_GetPointerProperty(props, SDL_PROP_PROCESS_CREATE_ARGS_POINTER, NULL);
-#if defined(SDL_PLATFORM_WINDOWS)
+#if defined(SDL_PROCESS_WINDOWS)
     const char *cmdline = SDL_GetStringProperty(props, SDL_PROP_PROCESS_CREATE_CMDLINE_STRING, NULL);
     CHECK_PARAM((!args || !args[0] || !args[0][0]) && (!cmdline || !cmdline[0])) {
         SDL_SetError("Either SDL_PROP_PROCESS_CREATE_ARGS_POINTER or SDL_PROP_PROCESS_CREATE_CMDLINE_STRING must be valid");


### PR DESCRIPTION

- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

Use SDL_PROCESS_WINDOWS instead; reason to allow trying SDL_PROCESS_POSIX and SDL_PROCESS_WINDOWS under Cygwin to see if one works better than the other.

## Description
<!--- Describe your changes in detail -->

Change code guard to SDL_PROCESS_WINDOWS instead of SDL_PLATFORM_WINDOWS in three files.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
