### PR TITLE
testprocess: handle async exec failure for missing executables

### DIFF
--- a/test/testprocess.c
+++ b/test/testprocess.c
@@ -790,6 +790,8 @@ static int process_testNonExistingExecutable(void *arg)
     char *random_stem;
     char *random_path;
     SDL_Process *process = NULL;
+    bool result;
+    int exit_code = 0;
 
     random_stem = SDLTest_RandomAsciiStringOfSize(STEM_LENGTH);
     random_path = SDL_malloc(STEM_LENGTH + SDL_strlen(EXE) + 1);
@@ -802,7 +804,15 @@ static int process_testNonExistingExecutable(void *arg)
 
     SDLTest_AssertPass("About to call SDL_CreateProcess");
     process = SDL_CreateProcess((const char * const *)process_args, false);
-    SDLTest_AssertCheck(process == NULL, "SDL_CreateProcess() should have failed (%s)", SDL_GetError());
+    if (process) {
+        SDLTest_AssertPass("SDL_CreateProcess() returned a process, waiting for exec failure");
+        result = SDL_WaitProcess(process, true, &exit_code);
+        SDLTest_AssertCheck(result, "SDL_WaitProcess()");
+        SDLTest_AssertCheck(exit_code != 0, "Exit code should be non-zero, is %d", exit_code);
+        SDL_DestroyProcess(process);
+    } else {
+        SDLTest_AssertPass("SDL_CreateProcess() failed synchronously (%s)", SDL_GetError());
+    }
 
     DestroyStringArray(process_args);
     return TEST_COMPLETED;


### PR DESCRIPTION
## Summary

`process_testNonExistingExecutable` currently assumes that creating a process for a missing executable must fail synchronously. Some POSIX-like process backends can instead create the child process successfully and report the exec failure through the child exit status.

This keeps the test strict while accepting both valid backend behaviors:

- `SDL_CreateProcess()` returning `NULL` still passes as the synchronous failure path.
- If a process is returned, the test waits for it, requires `SDL_WaitProcess()` to succeed, and requires a non-zero exit status.
- The returned process is destroyed before the argument array is cleaned up.

This does not change the SDL process API contract or any platform process implementation.

## Background

I hit this in an aarch64 Crossbow/Nix sandbox build. The unpatched package failed only `testprocess`:

```text
16/25 Test #23: testprocess ......................***Failed    1.33 sec
Assert 'SDL_CreateProcess() should have failed (Can't stat: No such file or directory)': Failed
Run Summary: Total=15 Passed=11 Failed=1 Skipped=3
Harness input to repro failures: --seed UNSG0K87T8WBXOOI --filter process_testNonExistingExecutable
```

The child-process path is consistent with `posix_spawnp`/backend differences where a missing executable may be surfaced either while creating the process or as a child exec failure. Related PR #11007 adds diagnostics for `testprocess`, but does not address this missing-executable semantic case.

## Validation

- Native x86_64 Linux:
  - `cmake --build build-native --target testprocess`
  - `./build-native/test/testprocess --filter process_testNonExistingExecutable ./build-native/test/childprocess`
  - `./build-native/test/testprocess ./build-native/test/childprocess`
  - Result: full Process suite passed, `Total=15 Passed=12 Failed=0 Skipped=3`.
- aarch64 Crossbow/Nix-style package build with this patch applied to nixpkgs SDL3:
  - `nix build -L --impure --expr ... pkgs.sdl3.overrideAttrs (old: { patches = (old.patches or []) ++ [ /tmp/sdl-testprocess-async-exec-failure.patch ]; }) --no-link`
  - Result: `testprocess` passed and CTest reported `100% tests passed, 0 tests failed out of 25`.
