### PR TITLE
Win32: Swap maskColor assignment based on alpha value

### DIFF
--- a/src/core/windows/SDL_windows.c
+++ b/src/core/windows/SDL_windows.c
@@ -605,7 +605,7 @@ HICON WIN_CreateIconFromSurface(SDL_Surface *surface)
         for (int x = 0; x < width; x++) {
             BYTE* pixel = (BYTE*)pBits + (y * width + x) * 4;
             BYTE alpha = pixel[3];
-            COLORREF maskColor = (alpha == 0) ? RGB(0, 0, 0) : RGB(255, 255, 255);
+            COLORREF maskColor = (alpha == 0) ? RGB(255, 255, 255) : RGB(0, 0, 0);
             SetPixel(hdcMem, x, y, maskColor);
         }
     }


### PR DESCRIPTION
Looks like mask pixels was inverted.

- [+] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
