### PR TITLE
metal: check MTLBuffer allocations for nil before using their contents.

### DIFF
--- a/src/render/metal/SDL_render_metal.m
+++ b/src/render/metal/SDL_render_metal.m
@@ -1606,6 +1606,9 @@ static bool SetDrawState(SDL_Renderer *renderer, const SDL_RenderCommand *cmd, c
     if (statecache->shader_constants_dirty ||
         SDL_memcmp(shader_constants, &statecache->shader_constants, sizeof(*shader_constants)) != 0) {
         id<MTLBuffer> mtlbufconstants = [data.mtldevice newBufferWithLength:sizeof(*shader_constants) options:MTLResourceStorageModeShared];
+        if (mtlbufconstants == nil) {
+            return SDL_OutOfMemory();
+        }
         mtlbufconstants.label = @"SDL shader constants data";
         SDL_memcpy([mtlbufconstants contents], shader_constants, sizeof(*shader_constants));
         [data.mtlcmdencoder setFragmentBuffer:mtlbufconstants offset:0 atIndex:0];
@@ -1776,6 +1779,9 @@ static bool METAL_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd
              * practices guide recommends this approach for streamed vertex data.
              */
             mtlbufvertex = [data.mtldevice newBufferWithLength:vertsize options:MTLResourceStorageModeShared];
+            if (mtlbufvertex == nil) {
+                return SDL_OutOfMemory();
+            }
             mtlbufvertex.label = @"SDL vertex data";
             SDL_memcpy([mtlbufvertex contents], vertices, vertsize);
 


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->
Check for nil after allocating MTLBuffer within SetDrawState.

## Description
<!--- Describe your changes in detail -->

SetDrawState allocates a constants buffer with `newBufferWithLength` and memcpys into [buffer contents] without checking for nil. When the allocation fails, `[mtlbufconstants contents]` returns nil, and the memcpy will write to address 0.

The vertex buffer in METAL_RunCommandQueue has the same pattern so I fixed it here as well.

The staging buffers in METAL_CreateRenderer are the same pattern too, but since it's just a one time init, I left it as it is.

## Existing Issue(s)
[15944](https://github.com/libsdl-org/SDL/issues/15944)
