### PR TITLE
DOS: Fix BIOS keyboard buffer overflow beeps during key autorepeat

### DIFF
--- a/src/video/dos/SDL_dosevents.c
+++ b/src/video/dos/SDL_dosevents.c
@@ -252,6 +252,20 @@ static Uint8 keyevents_ringbuffer[256];
 static int keyevents_head = 0;
 static int keyevents_tail = 0;
 
+static void DOSVESA_DrainBIOSKeyboardBuffer(void)
+{
+    __dpmi_regs regs;
+    for (;;) {
+        regs.h.ah = 0x01; // BIOS: check for keystroke
+        __dpmi_int(0x16, &regs);
+        if (regs.x.flags & 0x40) { // ZF set = buffer empty
+            break;
+        }
+        regs.h.ah = 0x00; // BIOS: read keystroke (removes it)
+        __dpmi_int(0x16, &regs);
+    }
+}
+
 void DOSVESA_PumpEvents(SDL_VideoDevice *device)
 {
     /* Give cooperative threads a chance to run.  Audio mixing now runs
@@ -322,6 +336,10 @@ void DOSVESA_PumpEvents(SDL_VideoDevice *device)
         }
     }
 
+    // We chain IRQ1 to BIOS, so drain its keyboard queue continuously to prevent
+    // BIOS buffer overflow beeps during long key autorepeat.
+    DOSVESA_DrainBIOSKeyboardBuffer();
+
     SDL_Mouse *mouse = SDL_GetMouse();
     if (mouse->internal) { // if non-NULL, there's a mouse detected on the system.
         __dpmi_regs regs;
@@ -380,18 +398,7 @@ void DOSVESA_QuitKeyboard(SDL_VideoDevice *device)
 
     // Drain the BIOS keyboard buffer so held keys (like ESC) don't
     // bleed through to the DOS command line after we exit.
-    {
-        __dpmi_regs regs;
-        for (;;) {
-            regs.h.ah = 0x01; // BIOS: check for keystroke
-            __dpmi_int(0x16, &regs);
-            if (regs.x.flags & 0x40) { // ZF set = buffer empty
-                break;
-            }
-            regs.h.ah = 0x00; // BIOS: read keystroke (removes it)
-            __dpmi_int(0x16, &regs);
-        }
-    }
+    DOSVESA_DrainBIOSKeyboardBuffer();
 }
 
 #endif // SDL_VIDEO_DRIVER_DOSVESA


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").


Problem
In the current implementation, KeyboardIRQHandler is chained on IRQ1, which is the safest approach. However, the BIOS keyboard buffer is never drained during normal operation; it is only flushed when the ISR is uninstalled on exit. When a user holds down a key (arrow keys, letters, etc.), autorepeat fills the BIOS buffer within a few seconds. Once full, the BIOS signals overflow, causing the PC speaker to emit a continuous series of annoying beeps.
This issue is reproducible on real hardware with a piezo buzzer and under 86box, but not in DOSBox (which does not strictly emulate this BIOS buffer overflow behavior).

Solution
Factor out the existing BIOS-draining logic from DOSVESA_QuitKeyboard() into a new static helper DOSVESA_DrainBIOSKeyboardBuffer() and call it in DOSVESA_PumpEvents() so the BIOS queue is flushed every frame. No measurable performance overhead was observed.

Impact
Eliminates the beeps without altering IRQ handling.
Minimal, low-risk change.

Testing
Before this patch, holding down any key ( for exam. arrow keys ) triggered a continuous stream of beeps from the PC speaker on all tested platforms above ( beeps would start within a few seconds of autorepeat and continue incessantly until the key was released ):
Various 86box configurations
An older 845GL board with a built-in buzzer
A B450 board with an external buzzer attached (since modern motherboards no longer have a built-in buzzer)
After applying the patch, no keybuf-overflow beeps occur on these environments, while keyboard input remains fully responsive.