### PR TITLE
PSP: Fix on screen keyboard not sending an event the first time

### DIFF
--- a/src/video/psp/SDL_pspvideo.c
+++ b/src/video/psp/SDL_pspvideo.c
@@ -465,6 +465,10 @@ void PSP_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window, SDL_Prop
     sceUtilityOskInitStart(&params);
 
     SDL_SendScreenKeyboardShown();
+
+    // window->text_input_active needs to be true for SDL_SendKeyboardText to be able to send events
+    // The SDL_StartTextInputWithProperties only sets text_input_active after PSP_ShowScreenKeyboard is called
+    // This means only setting it here too can guaranatee an events are created from the screen keyboard
     window->text_input_active = true;
 
     while (!done) {

--- a/src/video/psp/SDL_pspvideo.c
+++ b/src/video/psp/SDL_pspvideo.c
@@ -465,6 +465,7 @@ void PSP_ShowScreenKeyboard(SDL_VideoDevice *_this, SDL_Window *window, SDL_Prop
     sceUtilityOskInitStart(&params);
 
     SDL_SendScreenKeyboardShown();
+    window->text_input_active = true;
 
     while (!done) {
         sceGuStart(GU_DIRECT, list);


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is not the prettiest solution, but with the function being blocking, there is no other way to make sure what is entered into the on screen keyboard to actually creates an event for the user. At the moment the first time the on screen keyboard is called, it never works. The problem is that text_input_active is set after the function to enter text is called here: https://github.com/libsdl-org/SDL/blob/ac6e7c795e638e256af7b2f8555fc1a8e1cecff4/src/video/SDL_video.c#L5842

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
