### PR TITLE
cocoa: restore discrete mouse wheel ticks

### DIFF
--- a/src/video/cocoa/SDL_cocoamouse.m
+++ b/src/video/cocoa/SDL_cocoamouse.m
@@ -918,8 +918,6 @@ void Cocoa_HandleMouseWheel(SDL_Window *window, NSEvent *event)
     SDL_MouseWheelDirection direction;
     CGFloat x, y;
 
-    x = -[event scrollingDeltaX];
-    y = [event scrollingDeltaY];
     direction = SDL_MOUSEWHEEL_NORMAL;
 
     if ([event isDirectionInvertedFromDevice] == YES) {
@@ -927,8 +925,21 @@ void Cocoa_HandleMouseWheel(SDL_Window *window, NSEvent *event)
     }
 
     if ([event hasPreciseScrollingDeltas]) {
-        x *= 0.1;
-        y *= 0.1;
+        x = -[event scrollingDeltaX] * 0.1f;
+        y = [event scrollingDeltaY] * 0.1f;
+    } else {
+        x = -[event deltaX];
+        y = [event deltaY];
+        if (x > 0) {
+            x = SDL_ceil(x);
+        } else if (x < 0) {
+            x = SDL_floor(x);
+        }
+        if (y > 0) {
+            y = SDL_ceil(y);
+        } else if (y < 0) {
+            y = SDL_floor(y);
+        }
     }
 
     SDL_SendMouseWheel(Cocoa_GetEventTimestamp([event timestamp]), window, mouseID, x, y, direction);


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Summary

On macOS, `Cocoa_HandleMouseWheel()` currently uses `scrollingDeltaX/Y * 0.1f` for wheel input. That is appropriate for precise devices such as touchpads, but it makes conventional mouse wheels feel under-responsive because a single detent can arrive as a small fractional value instead of a discrete step.

This change splits the Cocoa wheel path by device behavior:

- `hasPreciseScrollingDeltas == YES`: keep using `scrollingDeltaX/Y * 0.1f`
- otherwise: use `deltaX/Y`, rounded away from zero with `SDL_ceil` / `SDL_floor`

## Why

For standard wheel mice, applications often interpret SDL wheel input as discrete line/tick steps. When Cocoa always goes through `scrollingDelta*`, a single wheel detent may be too small to trigger a visible response unless the app accumulates multiple events.

Using `delta*` for non-precise devices restores the expected one-detent behavior, while leaving the high-frequency fractional path intact for touchpads.

## Scope

- Cocoa `NSEvent` path only
- No change to `GCMouse` handling
- No behavioral change for precise scrolling devices

## Notes

This mirrors the same precise-vs-discrete split I needed in a downstream AppKit wrapper, and matches the approach used by dvui on macOS.

Related: #15058
