### PR TITLE
Avoid unnescessarily updating fullscreen display modes

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -1519,9 +1519,6 @@ const SDL_DisplayMode *SDL_GetCurrentDisplayMode(SDL_DisplayID displayID)
 
     CHECK_DISPLAY_MAGIC(display, NULL);
 
-    // Make sure our mode list is updated
-    SDL_UpdateFullscreenDisplayModes(display);
-
     return display->current_mode;
 }
 


### PR DESCRIPTION
I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
Avoid enumerating fullscreen display modes from "SDL_GetCurrentDisplayMode()".

"SDL_GetCurrentDisplayMode()" returns "display->current_mode", which is already tracked by the SDL display state. It does not need to populate the fullscreen mode list before returning that pointer.

On Windows, the removed call to "SDL_UpdateFullscreenDisplayModes()" can be expensive. It calls the video backend's "GetDisplayModes()" implementation, which walks the display modes. The Windows backend then resolves refresh rates through DXGI, which includes calls to "IDXGIOutput_FindClosestMatchingMode()".

As a result, using "SDL_GetCurrentDisplayMode()" is slower than it needs to be (discussed in issue here: #15934, thanks to magcius for writing a detailed and helpful issue).

## The Change

Remove the fullscreen mode cache update from "SDL_GetCurrentDisplayMode()".

Fullscreen modes are still populated by APIs that actually need them, in:

"SDL_GetFullscreenDisplayModes()"
"SDL_GetClosestFullscreenDisplayMode()"

## Benchmark
I also ran a benchmark to compare speeds for the function with and without the fix. The benchmark initializes SDL video, gets the primary display, and checks the time of the first SDL_GetCurrentDisplayMode() call. Then, it also times a loop of 1000 additional "SDL_GetCurrentDisplayMode()" calls.

### First Run:
Unmodified SDL: 
first_call_ms=173.928
loop_avg_ms=0.000010

With the fix: 
first_call_ms=0.001
loop_avg_ms=0.000009

### Second Run:

Unmodified SDL:
first_call_ms=181.995
loop_avg_ms=0.000011

With the fix:
first_call_ms=0.000
loop_avg_ms=0.000009


## Existing Issue(s)
This resolves #15934.
