### PR TITLE
perf: fast-path pure palette animation for dos

### DIFF
--- a/src/video/dos/SDL_dosframebuffer.c
+++ b/src/video/dos/SDL_dosframebuffer.c
@@ -502,6 +502,12 @@ bool DOSVESA_UpdateWindowFramebuffer(SDL_VideoDevice *device, SDL_Window *window
             }
         }
 
+        // No rectangles to update, so just program the palette and return.
+        // This is useful for pure palette animations.
+        if (numrects <= 0) {
+            return true;
+        }
+
         if (fb_state.use_dosmemput) {
             // dosmemput path (banked window, possibly multi-bank)
             const int src_pitch = fb_state.src_pitch;


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
This PR adds a fast path to `DOSVESA_UpdateWindowFramebuffer` when `numrects` is zero.

In pure palette animations (e.g., palette cycling or color lookup updates), the pixel data does not change — only the palette registers need to be programmed. Previously, even when there were no rectangles to update, the function would continue into the pixel‑copying code path, performing unnecessary work.

The early return avoids this overhead, improving performance without changing behavior for normal dirty‑rectangle updates.
