### PR TITLE
Cygwin: Reduce warning

### DIFF
--- a/src/joystick/windows/SDL_dinputjoystick.c
+++ b/src/joystick/windows/SDL_dinputjoystick.c
@@ -231,7 +231,7 @@ const DIDATAFORMAT SDL_c_dfDIJoystick2 = {
 // Convert a DirectInput return code to a text message
 static bool SetDIerror(const char *function, HRESULT code)
 {
-    return SDL_SetError("%s() DirectX error 0x%8.8lx", function, code);
+    return SDL_SetError("%s() DirectX error 0x%8.8" SDL_PRIxSLONG, function, code);
 }
 
 static bool SDL_IsXInputDevice(Uint16 vendor_id, Uint16 product_id, const char *hidPath)


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

Use macro SDL_PRIxSLONG to prevent warning when using -DHAVE_DINPUT_H=1

## Description
<!--- Describe your changes in detail -->

Before and after

Testing main without SDLTEST_GDB=YES and with HAVE_DINPUT_H=1
```
/cygdrive/c/devel/repos/SDL/src/notification/windows/SDL_windowsnotification.c: In function ‘InitToastSystem’:
/cygdrive/c/devel/repos/SDL/src/notification/windows/SDL_windowsnotification.c:474: note: ‘-Wmisleading-indentation’ is disabled from this point onwards, since column-tracking was disabled due to the size of the code/headers
  474 |     RESOLVE(RoGetActivationFactory);
/cygdrive/c/devel/repos/SDL/src/notification/windows/SDL_windowsnotification.c:474: note: adding ‘-flarge-source-files’ will allow for more column-tracking support, at the expense of compilation time and memory
/cygdrive/c/devel/repos/SDL/src/joystick/windows/SDL_dinputjoystick.c: In function ‘SetDIerror’:
/cygdrive/c/devel/repos/SDL/src/joystick/windows/SDL_dinputjoystick.c:234:52: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 3 has type ‘HRESULT’ {aka ‘int’} [-Wformat=]
  234 |     return SDL_SetError("%s() DirectX error 0x%8.8lx", function, code);
      |                                               ~~~~~^             ~~~~
      |                                                    |             |
      |                                                    |             HRESULT {aka int}
      |                                                    long unsigned int
      |                                               %8.8x
```
Testing main_staging without SDLTEST_GDB=YES and with HAVE_DINPUT_H=1
```/cygdrive/c/devel/repos/SDL/src/notification/windows/SDL_windowsnotification.c: In function ‘InitToastSystem’:
/cygdrive/c/devel/repos/SDL/src/notification/windows/SDL_windowsnotification.c:474: note: ‘-Wmisleading-indentation’ is disabled from this point onwards, since column-tracking was disabled due to the size of the code/headers
  474 |     RESOLVE(RoGetActivationFactory);
/cygdrive/c/devel/repos/SDL/src/notification/windows/SDL_windowsnotification.c:474: note: adding ‘-flarge-source-files’ will allow for more column-tracking support, at the expense of compilation time and memory
```

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
