### PR TITLE
events: Add additional wheel scroll info and gestures for client-side kinetic scrolling

### DIFF
--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -227,6 +227,10 @@ typedef enum SDL_EventType
     SDL_EVENT_PINCH_UPDATE,                 /**< Pinch gesture updated */
     SDL_EVENT_PINCH_END,                    /**< Pinch gesture ended */
 
+    /* Hold events */
+    SDL_EVENT_HOLD_BEGIN       = 0x720,     /**< Hold gesture started */
+    SDL_EVENT_HOLD_END,                     /**< Hold gestured ended */
+
     /* 0x800, 0x801, and 0x802 were the Gesture events from SDL2. Do not reuse these values! sdl2-compat needs them! */
 
     /* Clipboard events */
@@ -866,6 +870,23 @@ typedef struct SDL_PinchFingerEvent
 } SDL_PinchFingerEvent;
 
 /**
+ * Hold event structure (event.hold.*)
+ *
+ * Indicates fingers being held motionless on a device, such as a trackpad.
+ * In particular, this gesture is used to cancel kinetic scrolling.
+ *
+ * \since 3.6.0
+ */
+typedef struct SDL_HoldFingerEvent
+{
+    SDL_EventType type; /**< ::SDL_EVENT_HOLD_BEGIN or ::SDL_EVENT_HOLD_END */
+    Uint32 reserved;
+    Uint64 timestamp;      /**< In nanoseconds, populated using SDL_GetTicksNS() */
+    SDL_WindowID windowID; /**< The window underneath the finger, if any */
+    Uint32 fingers;        /**< For the BEGIN event, the number of fingers held on the device */
+} SDL_HoldFingerEvent;
+
+/**
  * Pressure-sensitive pen proximity event structure (event.pproximity.*)
  *
  * When a pen becomes visible to the system (it is close enough to a tablet,
@@ -1107,6 +1128,7 @@ typedef union SDL_Event
     SDL_UserEvent user;                     /**< Custom event data */
     SDL_TouchFingerEvent tfinger;           /**< Touch finger event data */
     SDL_PinchFingerEvent pinch;             /**< Pinch event data */
+    SDL_HoldFingerEvent hold;               /**< Hold event data */
     SDL_PenProximityEvent pproximity;       /**< Pen proximity event data */
     SDL_PenTouchEvent ptouch;               /**< Pen tip touching event data */
     SDL_PenMotionEvent pmotion;             /**< Pen motion event data */

--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -500,6 +500,10 @@ typedef struct SDL_MouseButtonEvent
 /**
  * Mouse wheel event structure (event.wheel.*)
  *
+ * An SDL_EVENT_MOUSE_WHEEL event with a source value of SDL_MOUSEWHEEL_SOURCE_FINGER and
+ * 0.0 for the x and y values indicates that the scroll ended due to the finger being lifted
+ * from the device.
+ *
  * \since This struct is available since SDL 3.2.0.
  */
 typedef struct SDL_MouseWheelEvent
@@ -516,6 +520,7 @@ typedef struct SDL_MouseWheelEvent
     float mouse_y;      /**< Y coordinate, relative to window */
     Sint32 integer_x;   /**< The amount scrolled horizontally, accumulated to whole scroll "ticks" (added in 3.2.12) */
     Sint32 integer_y;   /**< The amount scrolled vertically, accumulated to whole scroll "ticks" (added in 3.2.12) */
+    SDL_MouseWheelSource source; /**< Set to one of the SDL_MOUSEWHEEL_SOURCE_* defines (added in 3.6.0) */
 } SDL_MouseWheelEvent;
 
 /**

--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -239,6 +239,10 @@ typedef enum SDL_EventType
     SDL_EVENT_PINCH_FIRST = SDL_EVENT_PINCH_BEGIN,
     SDL_EVENT_PINCH_LAST = SDL_EVENT_PINCH_END,
 
+    /* Hold events */
+    SDL_EVENT_HOLD_BEGIN       = 0x720,     /**< Hold gesture started */
+    SDL_EVENT_HOLD_END,                     /**< Hold gestured ended */
+
     /* 0x800, 0x801, and 0x802 were the Gesture events from SDL2. Do not reuse these values! sdl2-compat needs them! */
 
     /* Clipboard events */
@@ -894,6 +898,23 @@ typedef struct SDL_PinchFingerEvent
 } SDL_PinchFingerEvent;
 
 /**
+ * Hold event structure (event.hold.*)
+ *
+ * Indicates fingers being held motionless on a device, such as a trackpad.
+ * In particular, this gesture is used to cancel kinetic scrolling.
+ *
+ * \since 3.6.0
+ */
+typedef struct SDL_HoldFingerEvent
+{
+    SDL_EventType type; /**< ::SDL_EVENT_HOLD_BEGIN or ::SDL_EVENT_HOLD_END */
+    Uint32 reserved;
+    Uint64 timestamp;      /**< In nanoseconds, populated using SDL_GetTicksNS() */
+    SDL_WindowID windowID; /**< The window underneath the finger, if any */
+    Uint32 fingers;        /**< For the BEGIN event, the number of fingers held on the device */
+} SDL_HoldFingerEvent;
+
+/**
  * Pressure-sensitive pen proximity event structure (event.pproximity.*)
  *
  * When a pen becomes visible to the system (it is close enough to a tablet,
@@ -1136,6 +1157,7 @@ typedef union SDL_Event
     SDL_UserEvent user;                     /**< Custom event data */
     SDL_TouchFingerEvent tfinger;           /**< Touch finger event data */
     SDL_PinchFingerEvent pinch;             /**< Pinch event data */
+    SDL_HoldFingerEvent hold;               /**< Hold event data */
     SDL_PenProximityEvent pproximity;       /**< Pen proximity event data */
     SDL_PenTouchEvent ptouch;               /**< Pen tip touching event data */
     SDL_PenMotionEvent pmotion;             /**< Pen motion event data */

--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -528,6 +528,10 @@ typedef struct SDL_MouseButtonEvent
 /**
  * Mouse wheel event structure (event.wheel.*)
  *
+ * An SDL_EVENT_MOUSE_WHEEL event with a source value of SDL_MOUSEWHEEL_SOURCE_FINGER and
+ * 0.0 for the x and y values indicates that the scroll ended due to the finger being lifted
+ * from the device.
+ *
  * \since This struct is available since SDL 3.2.0.
  */
 typedef struct SDL_MouseWheelEvent
@@ -544,6 +548,7 @@ typedef struct SDL_MouseWheelEvent
     float mouse_y;      /**< Y coordinate, relative to window */
     Sint32 integer_x;   /**< The amount scrolled horizontally, accumulated to whole scroll "ticks" (added in 3.2.12) */
     Sint32 integer_y;   /**< The amount scrolled vertically, accumulated to whole scroll "ticks" (added in 3.2.12) */
+    SDL_MouseWheelSource source; /**< Set to one of the SDL_MOUSEWHEEL_SOURCE_* defines (added in 3.6.0) */
 } SDL_MouseWheelEvent;
 
 /**

--- a/include/SDL3/SDL_mouse.h
+++ b/include/SDL3/SDL_mouse.h
@@ -145,6 +145,17 @@ typedef enum SDL_MouseWheelDirection
 } SDL_MouseWheelDirection;
 
 /**
+ * Scroll source types for the Scroll event
+ *
+ * \since This enum is available since SDL 3.6.0.
+ */
+typedef enum SDL_MouseWheelSource
+{
+    SDL_MOUSEWHEEL_SOURCE_WHEEL, /**< The scroll source is a wheel */
+    SDL_MOUSEWHEEL_SOURCE_FINGER /**< The scroll source is a finger */
+} SDL_MouseWheelSource;
+
+/**
  * Animated cursor frame info.
  *
  * \since This struct is available since SDL 3.4.0.

--- a/src/core/haiku/SDL_BApp.h
+++ b/src/core/haiku/SDL_BApp.h
@@ -288,7 +288,7 @@ class SDL_BLooper : public BLooper
             return;
         }
         win = GetSDLWindow(winID);
-        SDL_SendMouseWheel(0, win, SDL_DEFAULT_MOUSE_ID, xTicks, -yTicks, SDL_MOUSEWHEEL_NORMAL);
+        SDL_SendMouseWheel(0, win, SDL_DEFAULT_MOUSE_ID, xTicks, -yTicks, SDL_MOUSEWHEEL_NORMAL, SDL_MOUSEWHEEL_SOURCE_WHEEL);
     }
 
     void _HandleKey(BMessage *msg)

--- a/src/core/linux/SDL_evdev.c
+++ b/src/core/linux/SDL_evdev.c
@@ -521,7 +521,7 @@ void SDL_EVDEV_Poll(void)
                                                mouse->focus, (SDL_MouseID)item->fd,
                                                item->mouse_hwheel / denom,
                                                item->mouse_wheel / denom,
-                                               SDL_MOUSEWHEEL_NORMAL);
+                                               SDL_MOUSEWHEEL_NORMAL, SDL_MOUSEWHEEL_SOURCE_WHEEL);
                             item->mouse_wheel = item->mouse_hwheel = 0;
                         }
 

--- a/src/core/linux/SDL_evdev.c
+++ b/src/core/linux/SDL_evdev.c
@@ -520,7 +520,7 @@ void SDL_EVDEV_Poll(void)
                                                mouse->focus, (SDL_MouseID)item->fd,
                                                item->mouse_hwheel / (item->high_res_hwheel ? 120.0f : 1.0f),
                                                item->mouse_wheel / (item->high_res_wheel ? 120.0f : 1.0f),
-                                               SDL_MOUSEWHEEL_NORMAL);
+                                               SDL_MOUSEWHEEL_NORMAL, SDL_MOUSEWHEEL_SOURCE_WHEEL);
                             item->mouse_wheel = item->mouse_hwheel = 0;
                         }
 

--- a/src/core/openbsd/SDL_wscons_mouse.c
+++ b/src/core/openbsd/SDL_wscons_mouse.c
@@ -102,12 +102,12 @@ void updateMouse(SDL_WSCONS_mouse_input_data *input)
             }
             case WSCONS_EVENT_MOUSE_DELTA_W:
             {
-                SDL_SendMouseWheel(timestamp, mouse->focus, input->mouseID, events[i].value, 0, SDL_MOUSEWHEEL_NORMAL);
+                SDL_SendMouseWheel(timestamp, mouse->focus, input->mouseID, events[i].value, 0, SDL_MOUSEWHEEL_NORMAL, SDL_MOUSEWHEEL_SOURCE_WHEEL);
                 break;
             }
             case WSCONS_EVENT_MOUSE_DELTA_Z:
             {
-                SDL_SendMouseWheel(timestamp, mouse->focus, input->mouseID, 0, -events[i].value, SDL_MOUSEWHEEL_NORMAL);
+                SDL_SendMouseWheel(timestamp, mouse->focus, input->mouseID, 0, -events[i].value, SDL_MOUSEWHEEL_NORMAL, SDL_MOUSEWHEEL_SOURCE_WHEEL);
                 break;
             }
             default:

--- a/src/events/SDL_categories.c
+++ b/src/events/SDL_categories.c
@@ -149,6 +149,10 @@ SDL_EventCategory SDL_GetEventCategory(Uint32 type)
     case SDL_EVENT_PINCH_END:
         return SDL_EVENTCATEGORY_PINCH;
 
+    case SDL_EVENT_HOLD_BEGIN:
+    case SDL_EVENT_HOLD_END:
+        return SDL_EVENTCATEGORY_HOLD;
+
     case SDL_EVENT_CLIPBOARD_UPDATE:
         return SDL_EVENTCATEGORY_CLIPBOARD;
 
@@ -254,6 +258,9 @@ SDL_Window *SDL_GetWindowFromEvent(const SDL_Event *event)
         break;
     case SDL_EVENTCATEGORY_PINCH:
         windowID = event->pinch.windowID;
+        break;
+    case SDL_EVENTCATEGORY_HOLD:
+        windowID = event->hold.windowID;
         break;
     default:
         // < 0  -> invalid event type (error is set by SDL_GetEventCategory)

--- a/src/events/SDL_categories_c.h
+++ b/src/events/SDL_categories_c.h
@@ -66,6 +66,7 @@ typedef enum SDL_EventCategory
     SDL_EVENTCATEGORY_RENDER,
     SDL_EVENTCATEGORY_NOTIFICATION,
     SDL_EVENTCATEGORY_PINCH,
+    SDL_EVENTCATEGORY_HOLD,
 } SDL_EventCategory;
 
 extern SDL_EventCategory SDL_GetEventCategory(Uint32 type);

--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -662,11 +662,12 @@ int SDL_GetEventDescription(const SDL_Event *event, char *buf, int buflen)
 #undef PRINT_MBUTTON_EVENT
 
         SDL_EVENT_CASE(SDL_EVENT_MOUSE_WHEEL)
-        (void)SDL_snprintf(details, sizeof(details), " (timestamp=%" SDL_PRIu64 " windowid=%u which=%u x=%g y=%g integer_x=%d integer_y=%d direction=%s)",
+        (void)SDL_snprintf(details, sizeof(details), " (timestamp=%" SDL_PRIu64 " windowid=%u which=%u x=%g y=%g integer_x=%d integer_y=%d direction=%s source=%s)",
                            event->wheel.timestamp, (uint)event->wheel.windowID,
                            (uint)event->wheel.which, event->wheel.x, event->wheel.y,
                            (int)event->wheel.integer_x, (int)event->wheel.integer_y,
-                           event->wheel.direction == SDL_MOUSEWHEEL_NORMAL ? "normal" : "flipped");
+                           event->wheel.direction == SDL_MOUSEWHEEL_NORMAL ? "normal" : "flipped",
+                           event->wheel.source == SDL_MOUSEWHEEL_SOURCE_WHEEL ? "wheel" : "finger");
         break;
 
         SDL_EVENT_CASE(SDL_EVENT_JOYSTICK_AXIS_MOTION)

--- a/src/events/SDL_events.c
+++ b/src/events/SDL_events.c
@@ -821,6 +821,16 @@ int SDL_GetEventDescription(const SDL_Event *event, char *buf, int buflen)
         break;
 #undef PRINT_PINCH_EVENT
 
+#define PRINT_HOLD_EVENT(event)                                                                                                                      \
+    (void)SDL_snprintf(details, sizeof(details), " (timestamp=%" SDL_PRIu64 " fingers=%" SDL_PRIu32 ")", event->hold.timestamp, event->hold.fingers)
+        SDL_EVENT_CASE(SDL_EVENT_HOLD_BEGIN)
+        PRINT_HOLD_EVENT(event);
+        break;
+        SDL_EVENT_CASE(SDL_EVENT_HOLD_END)
+        PRINT_HOLD_EVENT(event);
+        break;
+#undef PRINT_HOLD_EVENT
+
 #define PRINT_PTOUCH_EVENT(event)                                                                             \
     (void)SDL_snprintf(details, sizeof(details), " (timestamp=%" SDL_PRIu64 " windowid=%u which=%u pen_state=%u x=%g y=%g eraser=%s state=%s)", \
                        event->ptouch.timestamp, (uint)event->ptouch.windowID, (uint)event->ptouch.which, (uint)event->ptouch.pen_state, event->ptouch.x, event->ptouch.y, \

--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -1055,7 +1055,7 @@ void SDL_SendMouseButton(Uint64 timestamp, SDL_Window *window, SDL_MouseID mouse
     SDL_PrivateSendMouseButton(timestamp, window, mouseID, button, down, -1);
 }
 
-void SDL_SendMouseWheel(Uint64 timestamp, SDL_Window *window, SDL_MouseID mouseID, float x, float y, SDL_MouseWheelDirection direction)
+void SDL_SendMouseWheel(Uint64 timestamp, SDL_Window *window, SDL_MouseID mouseID, float x, float y, SDL_MouseWheelDirection direction, SDL_MouseWheelSource source)
 {
     SDL_Mouse *mouse = SDL_GetMouse();
 
@@ -1063,7 +1063,8 @@ void SDL_SendMouseWheel(Uint64 timestamp, SDL_Window *window, SDL_MouseID mouseI
         SDL_SetMouseFocus(window);
     }
 
-    if (x == 0.0f && y == 0.0f) {
+    // Pass through 0,0 to indicate a finger scroll stopping due to the finger being lifted.
+    if (source != SDL_MOUSEWHEEL_SOURCE_FINGER && x == 0.0f && y == 0.0f) {
         return;
     }
 
@@ -1082,6 +1083,7 @@ void SDL_SendMouseWheel(Uint64 timestamp, SDL_Window *window, SDL_MouseID mouseI
         event.wheel.windowID = mouse->focus ? mouse->focus->id : 0;
         event.wheel.which = mouseID;
         event.wheel.direction = direction;
+        event.wheel.source = source;
         event.wheel.mouse_x = mouse->x;
         event.wheel.mouse_y = mouse->y;
 

--- a/src/events/SDL_mouse.c
+++ b/src/events/SDL_mouse.c
@@ -1030,7 +1030,7 @@ void SDL_SendMouseButton(Uint64 timestamp, SDL_Window *window, SDL_MouseID mouse
     SDL_PrivateSendMouseButton(timestamp, window, mouseID, button, down, -1);
 }
 
-void SDL_SendMouseWheel(Uint64 timestamp, SDL_Window *window, SDL_MouseID mouseID, float x, float y, SDL_MouseWheelDirection direction)
+void SDL_SendMouseWheel(Uint64 timestamp, SDL_Window *window, SDL_MouseID mouseID, float x, float y, SDL_MouseWheelDirection direction, SDL_MouseWheelSource source)
 {
     SDL_Mouse *mouse = SDL_GetMouse();
 
@@ -1038,7 +1038,8 @@ void SDL_SendMouseWheel(Uint64 timestamp, SDL_Window *window, SDL_MouseID mouseI
         SDL_SetMouseFocus(window);
     }
 
-    if (x == 0.0f && y == 0.0f) {
+    // Pass through 0,0 to indicate a finger scroll stopping due to the finger being lifted.
+    if (source != SDL_MOUSEWHEEL_SOURCE_FINGER && x == 0.0f && y == 0.0f) {
         return;
     }
 
@@ -1057,6 +1058,7 @@ void SDL_SendMouseWheel(Uint64 timestamp, SDL_Window *window, SDL_MouseID mouseI
         event.wheel.windowID = mouse->focus ? mouse->focus->id : 0;
         event.wheel.which = mouseID;
         event.wheel.direction = direction;
+        event.wheel.source = source;
         event.wheel.mouse_x = mouse->x;
         event.wheel.mouse_y = mouse->y;
 

--- a/src/events/SDL_mouse_c.h
+++ b/src/events/SDL_mouse_c.h
@@ -221,7 +221,7 @@ extern void SDL_SendMouseButton(Uint64 timestamp, SDL_Window *window, SDL_MouseI
 extern void SDL_SendMouseButtonClicks(Uint64 timestamp, SDL_Window *window, SDL_MouseID mouseID, Uint8 button, bool down, int clicks);
 
 // Send a mouse wheel event
-extern void SDL_SendMouseWheel(Uint64 timestamp, SDL_Window *window, SDL_MouseID mouseID, float x, float y, SDL_MouseWheelDirection direction);
+extern void SDL_SendMouseWheel(Uint64 timestamp, SDL_Window *window, SDL_MouseID mouseID, float x, float y, SDL_MouseWheelDirection direction, SDL_MouseWheelSource source);
 
 // Warp the mouse within the window, potentially overriding relative mode
 extern void SDL_PerformWarpMouseInWindow(SDL_Window *window, float x, float y, bool ignore_relative_mode);

--- a/src/events/SDL_mouse_c.h
+++ b/src/events/SDL_mouse_c.h
@@ -217,7 +217,7 @@ extern void SDL_SendMouseButton(Uint64 timestamp, SDL_Window *window, SDL_MouseI
 extern void SDL_SendMouseButtonClicks(Uint64 timestamp, SDL_Window *window, SDL_MouseID mouseID, Uint8 button, bool down, int clicks);
 
 // Send a mouse wheel event
-extern void SDL_SendMouseWheel(Uint64 timestamp, SDL_Window *window, SDL_MouseID mouseID, float x, float y, SDL_MouseWheelDirection direction);
+extern void SDL_SendMouseWheel(Uint64 timestamp, SDL_Window *window, SDL_MouseID mouseID, float x, float y, SDL_MouseWheelDirection direction, SDL_MouseWheelSource source);
 
 // Warp the mouse within the window, potentially overriding relative mode
 extern void SDL_PerformWarpMouseInWindow(SDL_Window *window, float x, float y, bool ignore_relative_mode);

--- a/src/events/SDL_touch.c
+++ b/src/events/SDL_touch.c
@@ -633,3 +633,17 @@ int SDL_SendPinch(SDL_EventType type, Uint64 timestamp, SDL_Window *window, floa
     return posted;
 }
 
+int SDL_SendHold(SDL_EventType type, Uint64 timestamp, SDL_Window *window, Uint32 fingers)
+{
+    /* Post the event, if desired */
+    int posted = 0;
+    if (SDL_EventEnabled(type)) {
+        SDL_Event event;
+        event.type = type;
+        event.common.timestamp = timestamp;
+        event.hold.windowID = window ? SDL_GetWindowID(window) : 0;
+        event.hold.fingers = fingers;
+        posted = (SDL_PushEvent(&event) > 0);
+    }
+    return posted;
+}

--- a/src/events/SDL_touch_c.h
+++ b/src/events/SDL_touch_c.h
@@ -51,5 +51,6 @@ extern void SDL_QuitTouch(void);
 
 // Send Gesture events
 extern int SDL_SendPinch(SDL_EventType type, Uint64 timestamp, SDL_Window *window, float scale, float span_x, float span_y, float focus_x, float focus_y);
+extern int SDL_SendHold(SDL_EventType type, Uint64 timestamp, SDL_Window *window, Uint32 fingers);
 
 #endif // SDL_touch_c_h_

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -1797,8 +1797,8 @@ void SDLTest_PrintEvent(const SDL_Event *event)
                 event->button.windowID);
         break;
     case SDL_EVENT_MOUSE_WHEEL:
-        SDL_Log("SDL EVENT: Mouse: wheel scrolled %g in x and %g in y (reversed: %d) in window %" SDL_PRIu32,
-                event->wheel.x, event->wheel.y, event->wheel.direction, event->wheel.windowID);
+        SDL_Log("SDL EVENT: Mouse: wheel scrolled %g in x and %g in y (reversed: %d, source: %d) in window %" SDL_PRIu32,
+                event->wheel.x, event->wheel.y, event->wheel.direction, event->wheel.source, event->wheel.windowID);
         break;
     case SDL_EVENT_JOYSTICK_ADDED:
         SDL_Log("SDL EVENT: Joystick %" SDL_PRIu32 " (%s) attached",

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -1938,6 +1938,13 @@ void SDLTest_PrintEvent(const SDL_Event *event)
         SDL_Log("SDL EVENT: Pinch End");
         break;
 
+    case SDL_EVENT_HOLD_BEGIN:
+        SDL_Log("SDL EVENT: Hold Begin (fingers=%" SDL_PRIu32 ")", event->hold.fingers);
+        break;
+    case SDL_EVENT_HOLD_END:
+        SDL_Log("SDL EVENT: Hold End");
+        break;
+
     case SDL_EVENT_RENDER_TARGETS_RESET:
         SDL_Log("SDL EVENT: render targets reset in window %" SDL_PRIu32, event->render.windowID);
         break;

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -1933,6 +1933,13 @@ void SDLTest_PrintEvent(const SDL_Event *event)
         SDL_Log("SDL EVENT: Pinch End");
         break;
 
+    case SDL_EVENT_HOLD_BEGIN:
+        SDL_Log("SDL EVENT: Hold Begin (fingers=%" SDL_PRIu32 ")", event->hold.fingers);
+        break;
+    case SDL_EVENT_HOLD_END:
+        SDL_Log("SDL EVENT: Hold End");
+        break;
+
     case SDL_EVENT_RENDER_TARGETS_RESET:
         SDL_Log("SDL EVENT: render targets reset in window %" SDL_PRIu32, event->render.windowID);
         break;

--- a/src/test/SDL_test_common.c
+++ b/src/test/SDL_test_common.c
@@ -1792,8 +1792,8 @@ void SDLTest_PrintEvent(const SDL_Event *event)
                 event->button.windowID);
         break;
     case SDL_EVENT_MOUSE_WHEEL:
-        SDL_Log("SDL EVENT: Mouse: wheel scrolled %g in x and %g in y (reversed: %d) in window %" SDL_PRIu32,
-                event->wheel.x, event->wheel.y, event->wheel.direction, event->wheel.windowID);
+        SDL_Log("SDL EVENT: Mouse: wheel scrolled %g in x and %g in y (reversed: %d, source: %d) in window %" SDL_PRIu32,
+                event->wheel.x, event->wheel.y, event->wheel.direction, event->wheel.source, event->wheel.windowID);
         break;
     case SDL_EVENT_JOYSTICK_ADDED:
         SDL_Log("SDL EVENT: Joystick %" SDL_PRIu32 " (%s) attached",

--- a/src/video/android/SDL_androidmouse.c
+++ b/src/video/android/SDL_androidmouse.c
@@ -238,7 +238,7 @@ void Android_OnMouse(SDL_Window *window, int state, int action, float x, float y
         break;
 
     case ACTION_SCROLL:
-        SDL_SendMouseWheel(0, window, SDL_DEFAULT_MOUSE_ID, x, y, SDL_MOUSEWHEEL_NORMAL);
+        SDL_SendMouseWheel(0, window, SDL_DEFAULT_MOUSE_ID, x, y, SDL_MOUSEWHEEL_NORMAL, SDL_MOUSEWHEEL_SOURCE_WHEEL);
         break;
 
     default:

--- a/src/video/cocoa/SDL_cocoamouse.m
+++ b/src/video/cocoa/SDL_cocoamouse.m
@@ -413,7 +413,7 @@ static void Cocoa_OnGCMouseConnected(GCMouse *mouse)
             }
             SDL_SendMouseWheel(timestamp, SDL_GetMouseFocus(), mouseID,
                                horizontal, vertical,
-                               cocoa_mouse_scroll_direction);
+                               cocoa_mouse_scroll_direction, SDL_MOUSEWHEEL_SOURCE_WHEEL);
         };
     Cocoa_UpdateGCMouseScrollDirection();
     #endif // USE_GCMOUSE_SCROLL
@@ -942,7 +942,7 @@ void Cocoa_HandleMouseWheel(SDL_Window *window, NSEvent *event)
         }
     }
 
-    SDL_SendMouseWheel(Cocoa_GetEventTimestamp([event timestamp]), window, mouseID, x, y, direction);
+    SDL_SendMouseWheel(Cocoa_GetEventTimestamp([event timestamp]), window, mouseID, x, y, direction, SDL_MOUSEWHEEL_SOURCE_WHEEL);
 }
 
 void Cocoa_HandleMouseWarp(CGFloat x, CGFloat y)

--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -342,7 +342,7 @@ static EM_BOOL Emscripten_HandleWheel(int eventType, const EmscriptenWheelEvent 
         break;
     }
 
-    SDL_SendMouseWheel(0, window_data->window, SDL_DEFAULT_MOUSE_ID, deltaX, -deltaY, SDL_MOUSEWHEEL_NORMAL);
+    SDL_SendMouseWheel(0, window_data->window, SDL_DEFAULT_MOUSE_ID, deltaX, -deltaY, SDL_MOUSEWHEEL_NORMAL, SDL_MOUSEWHEEL_SOURCE_WHEEL);
     return SDL_EventEnabled(SDL_EVENT_MOUSE_WHEEL);
 }
 

--- a/src/video/qnx/SDL_qnxpointer.c
+++ b/src/video/qnx/SDL_qnxpointer.c
@@ -85,5 +85,5 @@ void handlePointerEvent(screen_event_t event)
     // Capture mouse wheel
     // TODO: Verify this. I can at least confirm that this behaves the same
     //       way as x11.
-    SDL_SendMouseWheel(timestamp, window, 0, (float) mouse_wheel, (float) mouse_h_wheel, SDL_MOUSEWHEEL_NORMAL);
+    SDL_SendMouseWheel(timestamp, window, 0, (float) mouse_wheel, (float) mouse_h_wheel, SDL_MOUSEWHEEL_NORMAL, SDL_MOUSEWHEEL_SOURCE_WHEEL);
 }

--- a/src/video/uikit/SDL_uikitevents.m
+++ b/src/video/uikit/SDL_uikitevents.m
@@ -380,7 +380,7 @@ static void OnGCMouseConnected(GCMouse *mouse) API_AVAILABLE(macos(11.0), ios(14
             vertical = -vertical;
             horizontal = -horizontal;
         }
-        SDL_SendMouseWheel(timestamp, SDL_GetMouseFocus(), mouseID, horizontal, vertical, mouse_scroll_direction);
+        SDL_SendMouseWheel(timestamp, SDL_GetMouseFocus(), mouseID, horizontal, vertical, mouse_scroll_direction, SDL_MOUSEWHEEL_SOURCE_WHEEL);
     };
     UpdateScrollDirection();
 

--- a/src/video/vita/SDL_vitamouse.c
+++ b/src/video/vita/SDL_vitamouse.c
@@ -95,7 +95,7 @@ void VITA_PollMouse(void)
                 }
 
                 if (m_reports[i].tilt != 0 || m_reports[i].wheel != 0) {
-                    SDL_SendMouseWheel(0, Vita_Window, mouseID, m_reports[i].tilt, m_reports[i].wheel, SDL_MOUSEWHEEL_NORMAL);
+                    SDL_SendMouseWheel(0, Vita_Window, mouseID, m_reports[i].tilt, m_reports[i].wheel, SDL_MOUSEWHEEL_NORMAL, SDL_MOUSEWHEEL_SOURCE_WHEEL);
                 }
             }
         }

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -319,6 +319,7 @@ static void handle_pinch_begin(void *data, struct zwp_pointer_gesture_pinch_v1 *
     SDL_WindowData *wind = Wayland_GetWindowDataForOwnedSurface(surface);
     if (wind) {
         SDL_WaylandSeat *seat = (SDL_WaylandSeat *)data;
+        seat->pointer.gesture_type = WAYLAND_GESTURE_TYPE_PINCH;
         seat->pointer.gesture_focus = wind;
 
         const Uint64 timestamp = Wayland_GetPointerTimestamp(seat, time);
@@ -356,13 +357,52 @@ static const struct zwp_pointer_gesture_pinch_v1_listener gesture_pinch_listener
     handle_pinch_end
 };
 
+static void handle_hold_begin(void *data, struct zwp_pointer_gesture_hold_v1 *zwp_pointer_gesture_hold_v1, uint32_t serial, uint32_t time, struct wl_surface *surface, uint32_t fingers)
+{
+    if (!surface) {
+        return;
+    }
+
+    SDL_WindowData *wind = Wayland_GetWindowDataForOwnedSurface(surface);
+    if (wind) {
+        SDL_WaylandSeat *seat = (SDL_WaylandSeat *)data;
+        seat->pointer.gesture_type = WAYLAND_GESTURE_TYPE_HOLD;
+        seat->pointer.gesture_focus = wind;
+
+        const Uint64 timestamp = Wayland_GetPointerTimestamp(seat, time);
+        SDL_SendHold(SDL_EVENT_HOLD_BEGIN, timestamp, wind->sdlwindow, fingers);
+    }
+}
+
+static void handle_hold_end(void *data, struct zwp_pointer_gesture_hold_v1 *zwp_pointer_gesture_hold_v1, uint32_t serial, uint32_t time, int32_t cancelled)
+{
+    SDL_WaylandSeat *seat = (SDL_WaylandSeat *)data;
+
+    if (seat->pointer.gesture_focus) {
+        const Uint64 timestamp = Wayland_GetPointerTimestamp(seat, time);
+        SDL_SendHold(SDL_EVENT_HOLD_END, timestamp, seat->pointer.gesture_focus->sdlwindow, 0);
+
+        seat->pointer.gesture_focus = NULL;
+    }
+}
+
+static const struct zwp_pointer_gesture_hold_v1_listener gesture_hold_listener = {
+    handle_hold_begin,
+    handle_hold_end
+};
+
 static void Wayland_SeatCreatePointerGestures(SDL_WaylandSeat *seat)
 {
-    if (seat->display->zwp_pointer_gestures) {
-        if (seat->pointer.wl_pointer && !seat->pointer.gesture_pinch) {
+    if (seat->display->zwp_pointer_gestures && seat->pointer.wl_pointer) {
+        if (!seat->pointer.gesture_pinch) {
             seat->pointer.gesture_pinch = zwp_pointer_gestures_v1_get_pinch_gesture(seat->display->zwp_pointer_gestures, seat->pointer.wl_pointer);
             zwp_pointer_gesture_pinch_v1_set_user_data(seat->pointer.gesture_pinch, seat);
             zwp_pointer_gesture_pinch_v1_add_listener(seat->pointer.gesture_pinch, &gesture_pinch_listener, seat);
+        }
+        if (!seat->pointer.gesture_hold) {
+            seat->pointer.gesture_hold = zwp_pointer_gestures_v1_get_hold_gesture(seat->display->zwp_pointer_gestures, seat->pointer.wl_pointer);
+            zwp_pointer_gesture_hold_v1_set_user_data(seat->pointer.gesture_hold, seat);
+            zwp_pointer_gesture_hold_v1_add_listener(seat->pointer.gesture_hold, &gesture_hold_listener, seat);
         }
     }
 }
@@ -2436,6 +2476,10 @@ static void Wayland_SeatDestroyPointer(SDL_WaylandSeat *seat)
 
     if (seat->pointer.gesture_pinch) {
         zwp_pointer_gesture_pinch_v1_destroy(seat->pointer.gesture_pinch);
+    }
+
+    if (seat->pointer.gesture_hold) {
+        zwp_pointer_gesture_hold_v1_destroy(seat->pointer.gesture_hold);
     }
 
     if (seat->pointer.wl_pointer) {

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -1086,7 +1086,7 @@ static void pointer_handle_axis_common_v1(SDL_WaylandSeat *seat,
         x /= WAYLAND_WHEEL_AXIS_UNIT;
         y /= WAYLAND_WHEEL_AXIS_UNIT;
 
-        SDL_SendMouseWheel(nsTimestamp, window->sdlwindow, seat->pointer.sdl_id, x, y, SDL_MOUSEWHEEL_NORMAL);
+        SDL_SendMouseWheel(nsTimestamp, window->sdlwindow, seat->pointer.sdl_id, x, y, SDL_MOUSEWHEEL_NORMAL, SDL_MOUSEWHEEL_SOURCE_WHEEL);
     }
 }
 
@@ -1249,8 +1249,19 @@ static void pointer_dispatch_axis(SDL_WaylandSeat *seat)
         break;
     }
 
+    // Treat continuous sources as a finger if an axis stop event was received at any point.
+    if (seat->pointer.pending_frame.have_stop && seat->pointer.pending_frame.axis.source == WL_POINTER_AXIS_SOURCE_CONTINUOUS) {
+        seat->pointer.continuous_axis_stop_received = true;
+    }
+
+    SDL_MouseWheelSource source = SDL_MOUSEWHEEL_SOURCE_WHEEL;
+    if (seat->pointer.pending_frame.axis.source == WL_POINTER_AXIS_SOURCE_FINGER ||
+        (seat->pointer.pending_frame.axis.source == WL_POINTER_AXIS_SOURCE_CONTINUOUS && seat->pointer.continuous_axis_stop_received)) {
+        source = SDL_MOUSEWHEEL_SOURCE_FINGER;
+    }
+
     SDL_SendMouseWheel(seat->pointer.pending_frame.timestamp_ns,
-                       seat->pointer.focus->sdlwindow, seat->pointer.sdl_id, x, y, direction);
+                       seat->pointer.focus->sdlwindow, seat->pointer.sdl_id, x, y, direction, source);
 }
 
 static void pointer_handle_frame(void *data, struct wl_pointer *pointer)
@@ -1310,16 +1321,27 @@ static void pointer_handle_frame(void *data, struct wl_pointer *pointer)
     SDL_zero(seat->pointer.pending_frame);
 }
 
-static void pointer_handle_axis_source(void *data, struct wl_pointer *pointer,
-                                       uint32_t axis_source)
+static void pointer_handle_axis_source(void *data, struct wl_pointer *pointer, uint32_t axis_source)
 {
-    // unimplemented
+    SDL_WaylandSeat *seat = data;
+    seat->pointer.pending_frame.axis.source = axis_source;
 }
 
-static void pointer_handle_axis_stop(void *data, struct wl_pointer *pointer,
-                                     uint32_t time, uint32_t axis)
+static void pointer_handle_axis_stop(void *data, struct wl_pointer *pointer, uint32_t time, uint32_t axis)
 {
-    // unimplemented
+    SDL_WaylandSeat *seat = data;
+    seat->pointer.pending_frame.timestamp_ns = Wayland_GetPointerTimestamp(seat, time);
+    seat->pointer.pending_frame.have_axis = true;
+    seat->pointer.pending_frame.have_stop = true;
+
+    switch (axis) {
+    case WL_POINTER_AXIS_VERTICAL_SCROLL:
+        seat->pointer.pending_frame.axis.y = 0.0f;
+        break;
+    case WL_POINTER_AXIS_HORIZONTAL_SCROLL:
+        seat->pointer.pending_frame.axis.x = 0.0f;
+        break;
+    }
 }
 
 static void pointer_handle_axis_discrete(void *data, struct wl_pointer *pointer,

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -1091,7 +1091,7 @@ static void pointer_handle_axis_common_v1(SDL_WaylandSeat *seat,
         x /= WAYLAND_WHEEL_AXIS_UNIT;
         y /= WAYLAND_WHEEL_AXIS_UNIT;
 
-        SDL_SendMouseWheel(nsTimestamp, window->sdlwindow, seat->pointer.sdl_id, x, y, SDL_MOUSEWHEEL_NORMAL);
+        SDL_SendMouseWheel(nsTimestamp, window->sdlwindow, seat->pointer.sdl_id, x, y, SDL_MOUSEWHEEL_NORMAL, SDL_MOUSEWHEEL_SOURCE_WHEEL);
     }
 }
 
@@ -1254,8 +1254,19 @@ static void pointer_dispatch_axis(SDL_WaylandSeat *seat)
         break;
     }
 
+    // Treat continuous sources as a finger if an axis stop event was received at any point.
+    if (seat->pointer.pending_frame.have_stop && seat->pointer.pending_frame.axis.source == WL_POINTER_AXIS_SOURCE_CONTINUOUS) {
+        seat->pointer.continuous_axis_stop_received = true;
+    }
+
+    SDL_MouseWheelSource source = SDL_MOUSEWHEEL_SOURCE_WHEEL;
+    if (seat->pointer.pending_frame.axis.source == WL_POINTER_AXIS_SOURCE_FINGER ||
+        (seat->pointer.pending_frame.axis.source == WL_POINTER_AXIS_SOURCE_CONTINUOUS && seat->pointer.continuous_axis_stop_received)) {
+        source = SDL_MOUSEWHEEL_SOURCE_FINGER;
+    }
+
     SDL_SendMouseWheel(seat->pointer.pending_frame.timestamp_ns,
-                       seat->pointer.focus->sdlwindow, seat->pointer.sdl_id, x, y, direction);
+                       seat->pointer.focus->sdlwindow, seat->pointer.sdl_id, x, y, direction, source);
 }
 
 static void pointer_handle_frame(void *data, struct wl_pointer *pointer)
@@ -1315,16 +1326,27 @@ static void pointer_handle_frame(void *data, struct wl_pointer *pointer)
     SDL_zero(seat->pointer.pending_frame);
 }
 
-static void pointer_handle_axis_source(void *data, struct wl_pointer *pointer,
-                                       uint32_t axis_source)
+static void pointer_handle_axis_source(void *data, struct wl_pointer *pointer, uint32_t axis_source)
 {
-    // unimplemented
+    SDL_WaylandSeat *seat = data;
+    seat->pointer.pending_frame.axis.source = axis_source;
 }
 
-static void pointer_handle_axis_stop(void *data, struct wl_pointer *pointer,
-                                     uint32_t time, uint32_t axis)
+static void pointer_handle_axis_stop(void *data, struct wl_pointer *pointer, uint32_t time, uint32_t axis)
 {
-    // unimplemented
+    SDL_WaylandSeat *seat = data;
+    seat->pointer.pending_frame.timestamp_ns = Wayland_GetPointerTimestamp(seat, time);
+    seat->pointer.pending_frame.have_axis = true;
+    seat->pointer.pending_frame.have_stop = true;
+
+    switch (axis) {
+    case WL_POINTER_AXIS_VERTICAL_SCROLL:
+        seat->pointer.pending_frame.axis.y = 0.0f;
+        break;
+    case WL_POINTER_AXIS_HORIZONTAL_SCROLL:
+        seat->pointer.pending_frame.axis.x = 0.0f;
+        break;
+    }
 }
 
 static void pointer_handle_axis_discrete(void *data, struct wl_pointer *pointer,

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -319,6 +319,7 @@ static void handle_pinch_begin(void *data, struct zwp_pointer_gesture_pinch_v1 *
     SDL_WindowData *wind = Wayland_GetWindowDataForOwnedSurface(surface);
     if (wind) {
         SDL_WaylandSeat *seat = (SDL_WaylandSeat *)data;
+        seat->pointer.gesture_type = WAYLAND_GESTURE_TYPE_PINCH;
         seat->pointer.gesture_focus = wind;
 
         const Uint64 timestamp = Wayland_GetPointerTimestamp(seat, time);
@@ -356,13 +357,52 @@ static const struct zwp_pointer_gesture_pinch_v1_listener gesture_pinch_listener
     handle_pinch_end
 };
 
+static void handle_hold_begin(void *data, struct zwp_pointer_gesture_hold_v1 *zwp_pointer_gesture_hold_v1, uint32_t serial, uint32_t time, struct wl_surface *surface, uint32_t fingers)
+{
+    if (!surface) {
+        return;
+    }
+
+    SDL_WindowData *wind = Wayland_GetWindowDataForOwnedSurface(surface);
+    if (wind) {
+        SDL_WaylandSeat *seat = (SDL_WaylandSeat *)data;
+        seat->pointer.gesture_type = WAYLAND_GESTURE_TYPE_HOLD;
+        seat->pointer.gesture_focus = wind;
+
+        const Uint64 timestamp = Wayland_GetPointerTimestamp(seat, time);
+        SDL_SendHold(SDL_EVENT_HOLD_BEGIN, timestamp, wind->sdlwindow, fingers);
+    }
+}
+
+static void handle_hold_end(void *data, struct zwp_pointer_gesture_hold_v1 *zwp_pointer_gesture_hold_v1, uint32_t serial, uint32_t time, int32_t cancelled)
+{
+    SDL_WaylandSeat *seat = (SDL_WaylandSeat *)data;
+
+    if (seat->pointer.gesture_focus) {
+        const Uint64 timestamp = Wayland_GetPointerTimestamp(seat, time);
+        SDL_SendHold(SDL_EVENT_HOLD_END, timestamp, seat->pointer.gesture_focus->sdlwindow, 0);
+
+        seat->pointer.gesture_focus = NULL;
+    }
+}
+
+static const struct zwp_pointer_gesture_hold_v1_listener gesture_hold_listener = {
+    handle_hold_begin,
+    handle_hold_end
+};
+
 static void Wayland_SeatCreatePointerGestures(SDL_WaylandSeat *seat)
 {
-    if (seat->display->zwp_pointer_gestures) {
-        if (seat->pointer.wl_pointer && !seat->pointer.gesture_pinch) {
+    if (seat->display->zwp_pointer_gestures && seat->pointer.wl_pointer) {
+        if (!seat->pointer.gesture_pinch) {
             seat->pointer.gesture_pinch = zwp_pointer_gestures_v1_get_pinch_gesture(seat->display->zwp_pointer_gestures, seat->pointer.wl_pointer);
             zwp_pointer_gesture_pinch_v1_set_user_data(seat->pointer.gesture_pinch, seat);
             zwp_pointer_gesture_pinch_v1_add_listener(seat->pointer.gesture_pinch, &gesture_pinch_listener, seat);
+        }
+        if (!seat->pointer.gesture_hold) {
+            seat->pointer.gesture_hold = zwp_pointer_gestures_v1_get_hold_gesture(seat->display->zwp_pointer_gestures, seat->pointer.wl_pointer);
+            zwp_pointer_gesture_hold_v1_set_user_data(seat->pointer.gesture_hold, seat);
+            zwp_pointer_gesture_hold_v1_add_listener(seat->pointer.gesture_hold, &gesture_hold_listener, seat);
         }
     }
 }
@@ -2452,6 +2492,10 @@ static void Wayland_SeatDestroyPointer(SDL_WaylandSeat *seat)
 
     if (seat->pointer.gesture_pinch) {
         zwp_pointer_gesture_pinch_v1_destroy(seat->pointer.gesture_pinch);
+    }
+
+    if (seat->pointer.gesture_hold) {
+        zwp_pointer_gesture_hold_v1_destroy(seat->pointer.gesture_hold);
     }
 
     if (seat->pointer.wl_pointer) {

--- a/src/video/wayland/SDL_waylandevents_c.h
+++ b/src/video/wayland/SDL_waylandevents_c.h
@@ -197,6 +197,7 @@ typedef struct SDL_WaylandSeat
         SDL_MouseButtonFlags buttons_pressed;
         SDL_Point last_motion;
         bool is_confined;
+        bool continuous_axis_stop_received;
 
         SDL_MouseID sdl_id;
 
@@ -206,6 +207,7 @@ typedef struct SDL_WaylandSeat
             bool have_absolute;
             bool have_relative;
             bool have_axis;
+            bool have_stop;
 
             Uint32 buttons_pressed;
             Uint32 buttons_released;
@@ -233,6 +235,7 @@ typedef struct SDL_WaylandSeat
                 float y;
 
                 SDL_MouseWheelDirection direction;
+                enum wl_pointer_axis_source source;
             } axis;
 
             struct wl_surface *enter_surface;

--- a/src/video/wayland/SDL_waylandevents_c.h
+++ b/src/video/wayland/SDL_waylandevents_c.h
@@ -185,11 +185,17 @@ typedef struct SDL_WaylandSeat
         struct zwp_locked_pointer_v1 *locked_pointer;
         struct zwp_confined_pointer_v1 *confined_pointer;
         struct zwp_pointer_gesture_pinch_v1 *gesture_pinch;
+        struct zwp_pointer_gesture_hold_v1 *gesture_hold;
 
         SDL_WindowData *focus;
         struct wl_surface *focus_surface;
 
         // According to the spec, a seat can only have one active gesture of any type at a time.
+        enum Wayland_GestureType
+        {
+            WAYLAND_GESTURE_TYPE_PINCH,
+            WAYLAND_GESTURE_TYPE_HOLD
+        } gesture_type;
         SDL_WindowData *gesture_focus;
 
         Uint64 highres_timestamp_ns;

--- a/src/video/wayland/SDL_waylandevents_c.h
+++ b/src/video/wayland/SDL_waylandevents_c.h
@@ -197,6 +197,7 @@ typedef struct SDL_WaylandSeat
         SDL_MouseButtonFlags buttons_pressed;
         SDL_Point last_motion;
         bool is_confined;
+        bool continuous_axis_stop_received;
 
         SDL_MouseID sdl_id;
 
@@ -207,6 +208,7 @@ typedef struct SDL_WaylandSeat
             bool have_relative;
             bool have_warp;
             bool have_axis;
+            bool have_stop;
 
             Uint32 buttons_pressed;
             Uint32 buttons_released;
@@ -234,6 +236,7 @@ typedef struct SDL_WaylandSeat
                 float y;
 
                 SDL_MouseWheelDirection direction;
+                enum wl_pointer_axis_source source;
             } axis;
 
             struct wl_surface *enter_surface;

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -719,11 +719,11 @@ static void WIN_HandleRawMouseInput(Uint64 timestamp, SDL_VideoData *data, HANDL
         if (rawmouse->usButtonFlags & RI_MOUSE_WHEEL) {
             SHORT amount = (SHORT)rawmouse->usButtonData;
             float fAmount = (float)amount / WHEEL_DELTA;
-            SDL_SendMouseWheel(timestamp, window, mouseID, 0.0f, fAmount, SDL_MOUSEWHEEL_NORMAL);
+            SDL_SendMouseWheel(timestamp, window, mouseID, 0.0f, fAmount, SDL_MOUSEWHEEL_NORMAL, SDL_MOUSEWHEEL_SOURCE_WHEEL);
         } else if (rawmouse->usButtonFlags & RI_MOUSE_HWHEEL) {
             SHORT amount = (SHORT)rawmouse->usButtonData;
             float fAmount = (float)amount / WHEEL_DELTA;
-            SDL_SendMouseWheel(timestamp, window, mouseID, fAmount, 0.0f, SDL_MOUSEWHEEL_NORMAL);
+            SDL_SendMouseWheel(timestamp, window, mouseID, fAmount, 0.0f, SDL_MOUSEWHEEL_NORMAL, SDL_MOUSEWHEEL_SOURCE_WHEEL);
         }
 
         /* Invalidate the mouse button flags. If we don't do this then disabling raw input
@@ -1529,9 +1529,9 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
             short amount = GET_WHEEL_DELTA_WPARAM(wParam);
             float fAmount = (float)amount / WHEEL_DELTA;
             if (msg == WM_MOUSEWHEEL) {
-                SDL_SendMouseWheel(WIN_GetEventTimestamp(), data->window, SDL_GLOBAL_MOUSE_ID, 0.0f, fAmount, SDL_MOUSEWHEEL_NORMAL);
+                SDL_SendMouseWheel(WIN_GetEventTimestamp(), data->window, SDL_GLOBAL_MOUSE_ID, 0.0f, fAmount, SDL_MOUSEWHEEL_NORMAL, SDL_MOUSEWHEEL_SOURCE_WHEEL);
             } else {
-                SDL_SendMouseWheel(WIN_GetEventTimestamp(), data->window, SDL_GLOBAL_MOUSE_ID, fAmount, 0.0f, SDL_MOUSEWHEEL_NORMAL);
+                SDL_SendMouseWheel(WIN_GetEventTimestamp(), data->window, SDL_GLOBAL_MOUSE_ID, fAmount, 0.0f, SDL_MOUSEWHEEL_NORMAL, SDL_MOUSEWHEEL_SOURCE_WHEEL);
             }
         }
     } break;

--- a/src/video/windows/SDL_windowsgameinput.cpp
+++ b/src/video/windows/SDL_windowsgameinput.cpp
@@ -318,7 +318,7 @@ static void GAMEINPUT_HandleMouseDelta(WIN_GameInputData *data, SDL_Window *wind
         if (delta.wheelX || delta.wheelY) {
             float fAmountX = (float)delta.wheelX / WHEEL_DELTA;
             float fAmountY = (float)delta.wheelY / WHEEL_DELTA;
-            SDL_SendMouseWheel(timestamp, SDL_GetMouseFocus(), device->instance_id, fAmountX, fAmountY, SDL_MOUSEWHEEL_NORMAL);
+            SDL_SendMouseWheel(timestamp, SDL_GetMouseFocus(), device->instance_id, fAmountX, fAmountY, SDL_MOUSEWHEEL_NORMAL, SDL_MOUSEWHEEL_SOURCE_WHEEL);
         }
     }
 }

--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -1147,7 +1147,7 @@ void X11_HandleButtonPress(SDL_VideoDevice *_this, SDL_WindowData *windowdata, S
     }
 
     if (X11_IsWheelEvent(button, &xticks, &yticks)) {
-        SDL_SendMouseWheel(timestamp, window, mouseID, (float)-xticks, (float)yticks, SDL_MOUSEWHEEL_NORMAL);
+        SDL_SendMouseWheel(timestamp, window, mouseID, (float)-xticks, (float)yticks, SDL_MOUSEWHEEL_NORMAL, SDL_MOUSEWHEEL_SOURCE_WHEEL);
     } else {
         if (button > 7) {
             /* X button values 4-7 are used for scrolling, so X1 is 8, X2 is 9, ...

--- a/src/video/x11/SDL_x11xinput2.c
+++ b/src/video/x11/SDL_x11xinput2.c
@@ -66,6 +66,7 @@ typedef struct
     int scroll_type;
     double prev_value;
     double increment;
+    SDL_MouseWheelSource source;
     bool prev_value_valid;
 } SDL_XInput2ScrollInfo;
 
@@ -179,8 +180,17 @@ static void xinput2_parse_scrollable_valuators(const XIDeviceEvent *xev)
                             const double x = info->scroll_type == XIScrollTypeHorizontal ? delta : 0;
                             const double y = info->scroll_type == XIScrollTypeVertical ? delta : 0;
 
+                            /* A terminating 0,0 event is sent when a scroll event with a finger source ends, so we know
+                             * that this is a finger scroll and can be used for kinetic scrolling once the event arrives.
+                             *
+                             * https://who-t.blogspot.com/2015/03/libinput-scroll-sources.html
+                             */
+                            if (x == 0 && y == 0) {
+                                sd->scroll_info[k].source = SDL_MOUSEWHEEL_SOURCE_FINGER;
+                            }
+
                             SDL_Mouse *mouse = SDL_GetMouse();
-                            SDL_SendMouseWheel(xev->time, mouse->focus, (SDL_MouseID)xev->sourceid, (float)-x, (float)y, SDL_MOUSEWHEEL_NORMAL);
+                            SDL_SendMouseWheel(xev->time, mouse->focus, (SDL_MouseID)xev->sourceid, (float)-x, (float)y, SDL_MOUSEWHEEL_NORMAL, sd->scroll_info[k].source);
                         }
                         info->prev_value = current_val;
                         info->prev_value_valid = true;

--- a/test/testmouse.c
+++ b/test/testmouse.c
@@ -153,6 +153,11 @@ static void loop(void *arg)
             }
             break;
 
+        case SDL_EVENT_HOLD_BEGIN:
+            /* Halt kinetic scrolling on a hold event */
+            kinetic_deceleration_deadline = 0;
+            break;
+
         case SDL_EVENT_MOUSE_MOTION:
             if (!active) {
                 break;

--- a/test/testmouse.c
+++ b/test/testmouse.c
@@ -55,6 +55,8 @@ static bool wheel_x_active = false;
 static bool wheel_y_active = false;
 static float wheel_x = SCREEN_WIDTH * 0.5f;
 static float wheel_y = SCREEN_HEIGHT * 0.5f;
+static float vx, vy;
+static Uint64 kinetic_deceleration_deadline;
 
 struct mouse_loop_data {
     bool done;
@@ -131,12 +133,23 @@ static void loop(void *arg)
             if (event.wheel.x != 0.0f) {
                 wheel_x_active = true;
                 /* "positive to the right and negative to the left"  */
-                wheel_x += event.wheel.x * 10.0f;
+                vx = event.wheel.x * 10.0f;
+                wheel_x += vx;
             }
             if (event.wheel.y != 0.0f) {
                 wheel_y_active = true;
                 /* "positive away from the user and negative towards the user" */
-                wheel_y -= event.wheel.y * 10.0f;
+                vy = event.wheel.y * 10.0f;
+                wheel_y -= vy;
+            }
+
+            /* Start a kinetic scroll if a finger was lifted while an axis has a velocity > 2.0. */
+            if (event.wheel.source == SDL_MOUSEWHEEL_SOURCE_FINGER &&
+                event.wheel.x == 0.0f && event.wheel.y == 0.0f &&
+                (SDL_fabsf(vx) > 2.0f || SDL_fabsf(vy) > 2.0f)) {
+                kinetic_deceleration_deadline = SDL_GetTicks() + 16;
+            } else {
+                kinetic_deceleration_deadline = 0;
             }
             break;
 
@@ -250,6 +263,25 @@ static void loop(void *arg)
 
         default:
             break;
+        }
+    }
+
+    /* Continue scrolling if a kinetic scroll is active. */
+    if (kinetic_deceleration_deadline) {
+        const Uint64 now = SDL_GetTicks();
+        while (now >= kinetic_deceleration_deadline) {
+            /* Decelerate the scroll over time. */
+            vx *= .95f;
+            vy *= .95f;
+            wheel_x += vx;
+            wheel_y -= vy;
+
+            kinetic_deceleration_deadline += 16;
+        }
+
+        /* Stop the scroll below a certain threshold. */
+        if (SDL_fabsf(vx) < 0.05f && SDL_fabsf(vy) < 0.05f) {
+            kinetic_deceleration_deadline = 0;
         }
     }
 


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

This adds the source of a scroll event, in particular if the source of the scroll was a finger, notes that a scroll event with an x/y of 0,0 indicates that the scroll ended due to the finger being lifted, and adds a 'hold' gesture to indicate that there are motionless fingers on a trackpad.

This allows for implementing client-side kinetic scrolling via a 'flick' gesture, and stopping it when a finger is again placed on the trackpad. A basic demonstration of this functionality was added to testmouse.

This information is currently passed through on X11 (although XInput2 lacks the hold gesture) and Wayland. There is probably a way to get this information on Apple platforms, but I haven't looked into it yet, and Macs already have native kinetic scrolling that can be enabled via a hint. No idea about Windows, as kinetic scrolling there seems to be implemented within third-party drivers.

As mentioned, to indicate finger lift, a mouse wheel event with x and y values of 0.0 is sent (libinput does the same to indicate that a kinetic scroll should be started). It's unlikely that sending zero scroll values would cause problems in existing software, as they already have to contend with either axis potentially being zero, but it is a slight behavior change, so maybe a separate SDL_EVENT_MOUSE_WHEEL_STOP (SDL_EVENT_MOUSE_WHEEL_FINGER_LIFTED?)  event would be better suited for this?

Fixes #15955