### PR TITLE
testffmpeg_vulkan: fixed usage of timeline semaphores

### DIFF
--- a/src/render/vulkan/SDL_render_vulkan.c
+++ b/src/render/vulkan/SDL_render_vulkan.c
@@ -4070,6 +4070,9 @@ static void VULKAN_InvalidateCachedState(SDL_Renderer *renderer)
     VULKAN_RenderData *rendererData = (VULKAN_RenderData *)renderer->internal;
     rendererData->currentPipelineState = NULL;
     rendererData->cliprectDirty = true;
+
+    // Make sure pending drawing is submitted to the GPU
+    VULKAN_IssueBatch(rendererData);
 }
 
 static bool VULKAN_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd, void *vertices, size_t vertsize)

--- a/test/testffmpeg.c
+++ b/test/testffmpeg.c
@@ -1087,6 +1087,10 @@ static void DisplayVideoTexture(AVFrame *frame)
         return;
     }
 
+    if (BeginFrameRendering(frame) < 0) {
+        return;
+    }
+
     SDL_FRect src;
     src.x = 0.0f;
     src.y = 0.0f;
@@ -1097,6 +1101,9 @@ static void DisplayVideoTexture(AVFrame *frame)
     } else {
         SDL_RenderTexture(renderer, video_texture, &src, NULL);
     }
+    SDL_FlushRenderer(renderer);
+
+    FinishFrameRendering(frame);
 }
 
 static void DisplayVideoFrame(AVFrame *frame)
@@ -1115,10 +1122,6 @@ static void HandleVideoFrame(AVFrame *frame, double pts)
         SDL_DelayPrecise((Uint64)((pts - now) * SDL_NS_PER_SECOND));
     }
 
-    if (BeginFrameRendering(frame) < 0) {
-        return;
-    }
-
     SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
     SDL_RenderClear(renderer);
 
@@ -1128,8 +1131,6 @@ static void HandleVideoFrame(AVFrame *frame, double pts)
     MoveSprite();
 
     SDL_RenderPresent(renderer);
-
-    FinishFrameRendering(frame);
 }
 
 static AVCodecContext *OpenAudioStream(AVFormatContext *ic, int stream, const AVCodec *codec)

--- a/test/testffmpeg.c
+++ b/test/testffmpeg.c
@@ -82,6 +82,7 @@ static SDL_Renderer *renderer;
 static SDL_AudioStream *audio;
 static SDL_Texture *video_texture;
 static Uint64 video_start;
+static bool nodelay;
 static bool software_only;
 static bool has_eglCreateImage;
 #ifdef HAVE_EGL
@@ -1113,13 +1114,15 @@ static void DisplayVideoFrame(AVFrame *frame)
 
 static void HandleVideoFrame(AVFrame *frame, double pts)
 {
-    /* Quick and dirty PTS handling */
-    if (!video_start) {
-        video_start = SDL_GetTicks();
-    }
-    double now = (double)(SDL_GetTicks() - video_start) / 1000.0;
-    if (now < pts) {
-        SDL_DelayPrecise((Uint64)((pts - now) * SDL_NS_PER_SECOND));
+    if (!nodelay) {
+        /* Quick and dirty PTS handling */
+        if (!video_start) {
+            video_start = SDL_GetTicks();
+        }
+        double now = (double)(SDL_GetTicks() - video_start) / 1000.0;
+        if (now < pts) {
+            SDL_DelayPrecise((Uint64)((pts - now) * SDL_NS_PER_SECOND));
+        }
     }
 
     SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
@@ -1288,7 +1291,7 @@ static void av_log_callback(void *avcl, int level, const char *fmt, va_list vl)
 
 static void print_usage(SDLTest_CommonState *state, const char *argv0)
 {
-    static const char *options[] = { "[--verbose]", "[--sprites N]", "[--audio-codec codec]", "[--video-codec codec]", "[--software]", "video_file", NULL };
+    static const char *options[] = { "[--verbose]", "[--sprites N]", "[--audio-codec codec]", "[--video-codec codec]", "[--software]", "[--nodelay]", "video_file", NULL };
     SDLTest_CommonLogUsage(state, argv0, options);
 }
 
@@ -1345,6 +1348,9 @@ int main(int argc, char *argv[])
                 consumed = 2;
             } else if (SDL_strcmp(argv[i], "--software") == 0) {
                 software_only = true;
+                consumed = 1;
+            } else if (SDL_strcmp(argv[i], "--nodelay") == 0) {
+                nodelay = true;
                 consumed = 1;
             } else if (!file) {
                 /* We'll try to open this as a media file */
@@ -1567,7 +1573,7 @@ int main(int argc, char *argv[])
         }
 
         if (flushing && !decoded) {
-            if (SDL_GetAudioStreamQueued(audio) > 0) {
+            if (SDL_GetAudioStreamQueued(audio) > 0 && !nodelay) {
                 /* Wait a little bit for the audio to finish */
                 SDL_Delay(10);
             } else {

--- a/test/testffmpeg_vulkan.c
+++ b/test/testffmpeg_vulkan.c
@@ -198,8 +198,10 @@ static int createInstance(VulkanVideoContext *context)
         VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME,
         VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME
     };
-    VkApplicationInfo appInfo = { 0 };
-    VkInstanceCreateInfo instanceCreateInfo = { 0 };
+    VkApplicationInfo appInfo;
+    SDL_zero(appInfo);
+    VkInstanceCreateInfo instanceCreateInfo;
+    SDL_zero(instanceCreateInfo);
     VkResult result;
     char const *const *instanceExtensions = SDL_Vulkan_GetInstanceExtensions(&instanceCreateInfo.enabledExtensionCount);
 
@@ -208,7 +210,7 @@ static int createInstance(VulkanVideoContext *context)
     instanceCreateInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
     instanceCreateInfo.pApplicationInfo = &appInfo;
 
-    const char **instanceExtensionsCopy = SDL_calloc(instanceCreateInfo.enabledExtensionCount + SDL_arraysize(optional_extensions), sizeof(const char *));
+    const char **instanceExtensionsCopy = (const char **)SDL_calloc(instanceCreateInfo.enabledExtensionCount + SDL_arraysize(optional_extensions), sizeof(const char *));
     for (uint32_t i = 0; i < instanceCreateInfo.enabledExtensionCount; i++) {
         instanceExtensionsCopy[i] = instanceExtensions[i];
     }
@@ -217,7 +219,7 @@ static int createInstance(VulkanVideoContext *context)
     {
         uint32_t extensionCount;
         if (context->vkEnumerateInstanceExtensionProperties(NULL, &extensionCount, NULL) == VK_SUCCESS && extensionCount > 0) {
-            VkExtensionProperties *extensionProperties = SDL_calloc(extensionCount, sizeof(VkExtensionProperties));
+            VkExtensionProperties *extensionProperties = (VkExtensionProperties *)SDL_calloc(extensionCount, sizeof(VkExtensionProperties));
             if (context->vkEnumerateInstanceExtensionProperties(NULL, &extensionCount, extensionProperties) == VK_SUCCESS) {
                 for (uint32_t i = 0; i < SDL_arraysize(optional_extensions); ++i) {
                     for (uint32_t j = 0; j < extensionCount; ++j) {
@@ -257,14 +259,14 @@ static int createSurface(VulkanVideoContext *context, SDL_Window *window)
 }
 
 // Use the same queue scoring algorithm as ffmpeg to make sure we get the same device configuration
-static int selectQueueFamily(VkQueueFamilyProperties *queueFamiliesProperties, uint32_t queueFamiliesCount, VkQueueFlagBits flags, int *queueCount)
+static int selectQueueFamily(VkQueueFamilyProperties *queueFamiliesProperties, uint32_t queueFamiliesCount, VkQueueFlags flags, int *queueCount)
 {
     uint32_t queueFamilyIndex;
     uint32_t selectedQueueFamilyIndex = queueFamiliesCount;
     uint32_t min_score = ~0u;
 
     for (queueFamilyIndex = 0; queueFamilyIndex < queueFamiliesCount; ++queueFamilyIndex) {
-        VkQueueFlagBits current_flags = queueFamiliesProperties[queueFamilyIndex].queueFlags;
+        VkQueueFlags current_flags = queueFamiliesProperties[queueFamilyIndex].queueFlags;
         if (current_flags & flags) {
             uint32_t score = av_popcount(current_flags) + queueFamiliesProperties[queueFamilyIndex].timestampValidBits;
             if (score < min_score) {
@@ -404,7 +406,7 @@ static int findPhysicalDevice(VulkanVideoContext *context)
         if (deviceExtensionsAllocatedSize < deviceExtensionCount) {
             SDL_free(deviceExtensions);
             deviceExtensionsAllocatedSize = deviceExtensionCount;
-            deviceExtensions = SDL_malloc(sizeof(VkExtensionProperties) * deviceExtensionsAllocatedSize);
+            deviceExtensions = (VkExtensionProperties *)SDL_malloc(sizeof(VkExtensionProperties) * deviceExtensionsAllocatedSize);
             if (!deviceExtensions) {
                 SDL_free(physicalDevices);
                 SDL_free(queueFamiliesProperties);
@@ -556,7 +558,8 @@ static int createDevice(VulkanVideoContext *context)
         VK_KHR_VIDEO_DECODE_H265_EXTENSION_NAME,
         VK_KHR_VIDEO_DECODE_AV1_EXTENSION_NAME
     };
-    VkDeviceCreateInfo deviceCreateInfo = { 0 };
+    VkDeviceCreateInfo deviceCreateInfo;
+    SDL_zero(deviceCreateInfo);
     VkDeviceQueueCreateInfo *queueCreateInfos = NULL;
     uint32_t queueCreateInfoCount = 0;
     VulkanDeviceFeatures supported_features;
@@ -582,7 +585,7 @@ static int createDevice(VulkanVideoContext *context)
     deviceCreateInfo.enabledExtensionCount = SDL_arraysize(deviceExtensionNames);
     deviceCreateInfo.pNext = &context->features.device_features;
 
-    const char **deviceExtensionsCopy = SDL_calloc(deviceCreateInfo.enabledExtensionCount + SDL_arraysize(optional_extensions), sizeof(const char *));
+    const char **deviceExtensionsCopy = (const char **)SDL_calloc(deviceCreateInfo.enabledExtensionCount + SDL_arraysize(optional_extensions), sizeof(const char *));
     for (uint32_t i = 0; i < deviceCreateInfo.enabledExtensionCount; i++) {
         deviceExtensionsCopy[i] = deviceExtensionNames[i];
     }
@@ -591,7 +594,7 @@ static int createDevice(VulkanVideoContext *context)
     {
         uint32_t extensionCount;
         if (context->vkEnumerateDeviceExtensionProperties(context->physicalDevice, NULL, &extensionCount, NULL) == VK_SUCCESS && extensionCount > 0) {
-            VkExtensionProperties *extensionProperties = SDL_calloc(extensionCount, sizeof(VkExtensionProperties));
+            VkExtensionProperties *extensionProperties = (VkExtensionProperties *)SDL_calloc(extensionCount, sizeof(VkExtensionProperties));
             if (context->vkEnumerateDeviceExtensionProperties(context->physicalDevice, NULL, &extensionCount, extensionProperties) == VK_SUCCESS) {
                 for (uint32_t i = 0; i < SDL_arraysize(optional_extensions); ++i) {
                     for (uint32_t j = 0; j < extensionCount; ++j) {
@@ -626,7 +629,8 @@ static int createDevice(VulkanVideoContext *context)
     context->vkGetDeviceQueue(context->device, context->graphicsQueueFamilyIndex, 0, &context->graphicsQueue);
 
     // Create a command pool
-    VkCommandPoolCreateInfo commandPoolCreateInfo = { 0 };
+    VkCommandPoolCreateInfo commandPoolCreateInfo;
+    SDL_zero(commandPoolCreateInfo);
     commandPoolCreateInfo.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
     commandPoolCreateInfo.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     commandPoolCreateInfo.queueFamilyIndex = context->graphicsQueueFamilyIndex;
@@ -650,7 +654,7 @@ done:
 
 VulkanVideoContext *CreateVulkanVideoContext(SDL_Window *window)
 {
-    VulkanVideoContext *context = SDL_calloc(1, sizeof(*context));
+    VulkanVideoContext *context = (VulkanVideoContext *)SDL_calloc(1, sizeof(*context));
     if (!context) {
         return NULL;
     }
@@ -727,7 +731,8 @@ static int CreateCommandBuffers(VulkanVideoContext *context, SDL_Renderer *rende
         }
         context->commandBuffers = commandBuffers;
 
-        VkCommandBufferAllocateInfo commandBufferAllocateInfo = { 0 };
+        VkCommandBufferAllocateInfo commandBufferAllocateInfo;
+        SDL_zero(commandBufferAllocateInfo);
         commandBufferAllocateInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
         commandBufferAllocateInfo.commandPool = context->commandPool;
         commandBufferAllocateInfo.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
@@ -755,13 +760,15 @@ int BeginVulkanFrameRendering(VulkanVideoContext *context, AVFrame *frame, SDL_R
 
     vk->lock_frame(frames, pVkFrame);
 
-    VkTimelineSemaphoreSubmitInfo timeline = { 0 };
+    VkTimelineSemaphoreSubmitInfo timeline;
+    SDL_zero(timeline);
     timeline.sType = VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO;
     timeline.waitSemaphoreValueCount = 1;
     timeline.pWaitSemaphoreValues = pVkFrame->sem_value;
 
     VkPipelineStageFlags pipelineStageMask = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
-    VkSubmitInfo submitInfo = { 0 };
+    VkSubmitInfo submitInfo;
+    SDL_zero(submitInfo);
     submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
     submitInfo.waitSemaphoreCount = 1;
     submitInfo.pWaitSemaphores = pVkFrame->sem;
@@ -771,12 +778,14 @@ int BeginVulkanFrameRendering(VulkanVideoContext *context, AVFrame *frame, SDL_R
     if (pVkFrame->layout[0] != VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL) {
         VkCommandBuffer commandBuffer = context->commandBuffers[context->commandBufferIndex];
 
-        VkCommandBufferBeginInfo beginInfo = { 0 };
+        VkCommandBufferBeginInfo beginInfo;
+        SDL_zero(beginInfo);
         beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
         beginInfo.flags = 0;
         context->vkBeginCommandBuffer(commandBuffer, &beginInfo);
 
-        VkImageMemoryBarrier2 barrier = { 0 };
+        VkImageMemoryBarrier2 barrier;
+        SDL_zero(barrier);
         barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2;
         barrier.srcAccessMask = VK_ACCESS_2_NONE;
         barrier.dstAccessMask = VK_ACCESS_2_SHADER_SAMPLED_READ_BIT;
@@ -791,7 +800,8 @@ int BeginVulkanFrameRendering(VulkanVideoContext *context, AVFrame *frame, SDL_R
         barrier.srcStageMask = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
         barrier.dstStageMask = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
 
-        VkDependencyInfo dep = { 0 };
+        VkDependencyInfo dep;
+        SDL_zero(dep);
         dep.sType = VK_STRUCTURE_TYPE_DEPENDENCY_INFO;
         dep.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
         dep.imageMemoryBarrierCount = 1;
@@ -826,12 +836,14 @@ int FinishVulkanFrameRendering(VulkanVideoContext *context, AVFrame *frame, SDL_
     // Transition the frame back to ffmpeg
     ++pVkFrame->sem_value[0];
 
-    VkTimelineSemaphoreSubmitInfo timeline = { 0 };
+    VkTimelineSemaphoreSubmitInfo timeline;
+    SDL_zero(timeline);
     timeline.sType = VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO;
     timeline.signalSemaphoreValueCount = 1;
     timeline.pSignalSemaphoreValues = pVkFrame->sem_value;
 
-    VkSubmitInfo submitInfo = { 0 };
+    VkSubmitInfo submitInfo;
+    SDL_zero(submitInfo);
     submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
     submitInfo.signalSemaphoreCount = 1;
     submitInfo.pSignalSemaphores = pVkFrame->sem;

--- a/test/testffmpeg_vulkan.c
+++ b/test/testffmpeg_vulkan.c
@@ -78,10 +78,6 @@ struct VulkanVideoContext
     VkCommandBuffer *commandBuffers;
     uint32_t commandBufferCount;
     uint32_t commandBufferIndex;
-    VkSemaphore *waitSemaphores;
-    uint32_t waitSemaphoreCount;
-    VkSemaphore *signalSemaphores;
-    uint32_t signalSemaphoreCount;
 
     const char **instanceExtensions;
     int instanceExtensionsCount;
@@ -723,44 +719,6 @@ static int CreateCommandBuffers(VulkanVideoContext *context, SDL_Renderer *rende
 {
     uint32_t commandBufferCount = (uint32_t)SDL_GetNumberProperty(SDL_GetRendererProperties(renderer), SDL_PROP_RENDERER_VULKAN_SWAPCHAIN_IMAGE_COUNT_NUMBER, 1);
 
-    if (commandBufferCount > context->waitSemaphoreCount) {
-        VkSemaphore *semaphores = (VkSemaphore *)SDL_realloc(context->waitSemaphores, commandBufferCount * sizeof(*semaphores));
-        if (!semaphores) {
-            return -1;
-        }
-        context->waitSemaphores = semaphores;
-
-        VkSemaphoreCreateInfo semaphoreCreateInfo = { 0 };
-        semaphoreCreateInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
-        while (context->waitSemaphoreCount < commandBufferCount) {
-            VkResult result = context->vkCreateSemaphore(context->device, &semaphoreCreateInfo, NULL, &context->waitSemaphores[context->waitSemaphoreCount]);
-            if (result != VK_SUCCESS) {
-                SDL_SetError("vkCreateSemaphore(): %s", getVulkanResultString(result));
-                return -1;
-            }
-            ++context->waitSemaphoreCount;
-        }
-    }
-
-    if (commandBufferCount > context->signalSemaphoreCount) {
-        VkSemaphore *semaphores = (VkSemaphore *)SDL_realloc(context->signalSemaphores, commandBufferCount * sizeof(*semaphores));
-        if (!semaphores) {
-            return -1;
-        }
-        context->signalSemaphores = semaphores;
-
-        VkSemaphoreCreateInfo semaphoreCreateInfo = { 0 };
-        semaphoreCreateInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
-        while (context->signalSemaphoreCount < commandBufferCount) {
-            VkResult result = context->vkCreateSemaphore(context->device, &semaphoreCreateInfo, NULL, &context->signalSemaphores[context->signalSemaphoreCount]);
-            if (result != VK_SUCCESS) {
-                SDL_SetError("vkCreateSemaphore(): %s", getVulkanResultString(result));
-                return -1;
-            }
-            ++context->signalSemaphoreCount;
-        }
-    }
-
     if (commandBufferCount > context->commandBufferCount) {
         uint32_t needed = (commandBufferCount - context->commandBufferCount);
         VkCommandBuffer *commandBuffers = (VkCommandBuffer *)SDL_realloc(context->commandBuffers, commandBufferCount * sizeof(*commandBuffers));
@@ -808,8 +766,6 @@ int BeginVulkanFrameRendering(VulkanVideoContext *context, AVFrame *frame, SDL_R
     submitInfo.waitSemaphoreCount = 1;
     submitInfo.pWaitSemaphores = pVkFrame->sem;
     submitInfo.pWaitDstStageMask = &pipelineStageMask;
-    submitInfo.signalSemaphoreCount = 1;
-    submitInfo.pSignalSemaphores = &context->waitSemaphores[context->commandBufferIndex];
     submitInfo.pNext = &timeline;
 
     if (pVkFrame->layout[0] != VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL) {
@@ -858,8 +814,6 @@ int BeginVulkanFrameRendering(VulkanVideoContext *context, AVFrame *frame, SDL_R
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION , "vkQueueSubmit(): %s", getVulkanResultString(result));
     }
 
-    SDL_AddVulkanRenderSemaphores(renderer, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, (Sint64)context->waitSemaphores[context->commandBufferIndex], (Sint64)context->signalSemaphores[context->commandBufferIndex]);
-
     return 0;
 }
 
@@ -877,12 +831,8 @@ int FinishVulkanFrameRendering(VulkanVideoContext *context, AVFrame *frame, SDL_
     timeline.signalSemaphoreValueCount = 1;
     timeline.pSignalSemaphoreValues = pVkFrame->sem_value;
 
-    VkPipelineStageFlags pipelineStageMask = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
     VkSubmitInfo submitInfo = { 0 };
     submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-    submitInfo.waitSemaphoreCount = 1;
-    submitInfo.pWaitSemaphores = &context->signalSemaphores[context->commandBufferIndex];
-    submitInfo.pWaitDstStageMask = &pipelineStageMask;
     submitInfo.signalSemaphoreCount = 1;
     submitInfo.pSignalSemaphores = pVkFrame->sem;
     submitInfo.pNext = &timeline;
@@ -940,20 +890,6 @@ void DestroyVulkanVideoContext(VulkanVideoContext *context)
         }
         SDL_free(context->instanceExtensions);
         SDL_free(context->deviceExtensions);
-        if (context->waitSemaphores) {
-            for (uint32_t i = 0; i < context->waitSemaphoreCount; ++i) {
-                context->vkDestroySemaphore(context->device, context->waitSemaphores[i], NULL);
-            }
-            SDL_free(context->waitSemaphores);
-            context->waitSemaphores = NULL;
-        }
-        if (context->signalSemaphores) {
-            for (uint32_t i = 0; i < context->signalSemaphoreCount; ++i) {
-                context->vkDestroySemaphore(context->device, context->signalSemaphores[i], NULL);
-            }
-            SDL_free(context->signalSemaphores);
-            context->signalSemaphores = NULL;
-        }
         if (context->commandBuffers) {
             context->vkFreeCommandBuffers(context->device, context->commandPool, context->commandBufferCount, context->commandBuffers);
             SDL_free(context->commandBuffers);


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").
