### PR TITLE
Avoid RLE for software render alpha subrect copies

### DIFF
--- a/src/render/software/SDL_render_sw.c
+++ b/src/render/software/SDL_render_sw.c
@@ -356,6 +356,15 @@ static bool Blit_to_Screen(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *sur
     return result;
 }
 
+static void PrepTextureForSubrectCopy(SDL_Texture *texture, SDL_Surface *surface, const SDL_Rect *srcrect)
+{
+    if (texture->access == SDL_TEXTUREACCESS_STATIC &&
+        SDL_ISPIXELFORMAT_ALPHA(surface->format) &&
+        (srcrect->x != 0 || srcrect->y != 0 || srcrect->w != surface->w || srcrect->h != surface->h)) {
+        SDL_SetSurfaceRLE(surface, false);
+    }
+}
+
 static bool SW_RenderCopyEx(SDL_Renderer *renderer, SDL_Surface *surface, SDL_Texture *texture,
                             const SDL_Rect *srcrect, const SDL_Rect *final_rect,
                             const double angle, const SDL_FPoint *center, const SDL_FlipMode flip, float scale_x, float scale_y, const SDL_ScaleMode scaleMode)
@@ -857,6 +866,7 @@ static bool SW_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd, v
 
             SetDrawState(surface, &drawstate);
 
+            PrepTextureForSubrectCopy(texture, src, srcrect);
             PrepTextureForCopy(cmd, &drawstate);
 
             // Apply viewport

--- a/src/render/software/SDL_render_sw.c
+++ b/src/render/software/SDL_render_sw.c
@@ -674,7 +674,8 @@ static void PrepTextureForCopy(const SDL_RenderCommand *cmd, SW_DrawStateCache *
     SDL_Texture *texture = cmd->data.draw.texture;
     SDL_Surface *surface = (SDL_Surface *)texture->internal;
 
-    if (srcrect &&
+    if (SDL_SurfaceHasRLE(surface) &&
+        srcrect &&
         texture->access == SDL_TEXTUREACCESS_STATIC &&
         SDL_ISPIXELFORMAT_ALPHA(surface->format) &&
         (srcrect->x != 0 || srcrect->y != 0 || srcrect->w != surface->w || srcrect->h != surface->h)) {

--- a/src/render/software/SDL_render_sw.c
+++ b/src/render/software/SDL_render_sw.c
@@ -356,15 +356,6 @@ static bool Blit_to_Screen(SDL_Surface *src, SDL_Rect *srcrect, SDL_Surface *sur
     return result;
 }
 
-static void PrepTextureForSubrectCopy(SDL_Texture *texture, SDL_Surface *surface, const SDL_Rect *srcrect)
-{
-    if (texture->access == SDL_TEXTUREACCESS_STATIC &&
-        SDL_ISPIXELFORMAT_ALPHA(surface->format) &&
-        (srcrect->x != 0 || srcrect->y != 0 || srcrect->w != surface->w || srcrect->h != surface->h)) {
-        SDL_SetSurfaceRLE(surface, false);
-    }
-}
-
 static bool SW_RenderCopyEx(SDL_Renderer *renderer, SDL_Surface *surface, SDL_Texture *texture,
                             const SDL_Rect *srcrect, const SDL_Rect *final_rect,
                             const double angle, const SDL_FPoint *center, const SDL_FlipMode flip, float scale_x, float scale_y, const SDL_ScaleMode scaleMode)
@@ -673,7 +664,7 @@ static bool SW_QueueGeometry(SDL_Renderer *renderer, SDL_RenderCommand *cmd, SDL
     return true;
 }
 
-static void PrepTextureForCopy(const SDL_RenderCommand *cmd, SW_DrawStateCache *drawstate)
+static void PrepTextureForCopy(const SDL_RenderCommand *cmd, SW_DrawStateCache *drawstate, const SDL_Rect *srcrect)
 {
     const Uint8 r = drawstate->color.r;
     const Uint8 g = drawstate->color.g;
@@ -682,6 +673,13 @@ static void PrepTextureForCopy(const SDL_RenderCommand *cmd, SW_DrawStateCache *
     const SDL_BlendMode blend = cmd->data.draw.blend;
     SDL_Texture *texture = cmd->data.draw.texture;
     SDL_Surface *surface = (SDL_Surface *)texture->internal;
+
+    if (srcrect &&
+        texture->access == SDL_TEXTUREACCESS_STATIC &&
+        SDL_ISPIXELFORMAT_ALPHA(surface->format) &&
+        (srcrect->x != 0 || srcrect->y != 0 || srcrect->w != surface->w || srcrect->h != surface->h)) {
+        SDL_SetSurfaceRLE(surface, false);
+    }
 
     // !!! FIXME: we can probably avoid some of these calls.
     SDL_SetSurfaceColorMod(surface, r, g, b);
@@ -866,8 +864,7 @@ static bool SW_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd, v
 
             SetDrawState(surface, &drawstate);
 
-            PrepTextureForSubrectCopy(texture, src, srcrect);
-            PrepTextureForCopy(cmd, &drawstate);
+            PrepTextureForCopy(cmd, &drawstate, srcrect);
 
             // Apply viewport
             if (drawstate.viewport && (drawstate.viewport->x || drawstate.viewport->y)) {
@@ -922,7 +919,7 @@ static bool SW_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd, v
         {
             CopyExData *copydata = (CopyExData *)(((Uint8 *)vertices) + cmd->data.draw.first);
             SetDrawState(surface, &drawstate);
-            PrepTextureForCopy(cmd, &drawstate);
+            PrepTextureForCopy(cmd, &drawstate, &copydata->srcrect);
 
             // Apply viewport
             if (drawstate.viewport &&
@@ -953,7 +950,7 @@ static bool SW_RunCommandQueue(SDL_Renderer *renderer, SDL_RenderCommand *cmd, v
 
                 GeometryCopyData *ptr = (GeometryCopyData *)verts;
 
-                PrepTextureForCopy(cmd, &drawstate);
+                PrepTextureForCopy(cmd, &drawstate, NULL);
 
                 // Apply viewport
                 if (drawstate.viewport && (drawstate.viewport->x || drawstate.viewport->y)) {


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
Add a software-renderer copy preparation step that disables surface RLE when all of these are true:

- the texture is static
- the texture format has alpha
- the source rectangle is smaller than, or offset within, the full texture

Whole texture alpha copies can still use RLE.

## Existing Issue(s)
This resolves #15958 

## Benchmark 
I compared unmodified SDL against this branch with a small benchmark. The benchmark creates an alpha texture atlas in memory, uses the software renderer, and renders 768 transparent 16x16 subrect copies per frame for 1000 frames.

Unmodified SDL:
frames=1000
copies_per_frame=768
seconds=1.805
fps=553.91

With my fix:
frames=1000
copies_per_frame=768
seconds=0.406
fps=2464.84
