### PR TITLE
DOS: skip desktop mode restoration to fix crash when exiting on pure VGA

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -2093,7 +2093,11 @@ bool SDL_UpdateFullscreenMode(SDL_Window *window, SDL_FullscreenOp fullscreen, b
         if (display) {
             display->fullscreen_active = false;
 
+            // On DOS, desktop mode restoration is unnecessary
+            // VideoQuit will finally switch to text mode
+#if !defined(SDL_PLATFORM_DOS)
             SDL_SetDisplayModeForDisplay(display, NULL);
+#endif
         }
         if (commit) {
             SDL_FullscreenResult ret = SDL_FULLSCREEN_SUCCEEDED;


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

This PR fixes a crash on DOS platforms when destroying a window on pure VGA hardware (e.g., IBM ISA VGA in 86box) that occurs 100%.

Testing Env: 86box with IBM ISA VGA, CWSDPMI r7, DJGPP v2.05, GCC 12.2.0.

Crash stack trace( SDL part only, symbolized):

|i586-pc-msdosdjgpp-addr2line|function|
|----------------------------------------------|------------------------------------|
| SDL/src/video/dos/SDL_dosmodes.c:497 |DOSVESA_SetDisplayMode         |
| SDL/src/video/SDL_video.c:1553              |SDL_SetDisplayModeForDisplay |
| SDL/src/video/SDL_video.c:2098              |SDL_UpdateFullscreenMode       |
| SDL/src/video/SDL_video.c:4544               |SDL_DestroyWindow                  |

During SDL_DestroyWindow, SDL_UpdateFullscreenMode is called with SDL_FULLSCREEN_OP_LEAVE. Inside it, there is a SDL_SetDisplayModeForDisplay(display, NULL) call explicitly commented as "Restore the desktop mode". On DOS, this operation is unnecessary during window destruction, and can cause a crash on pure VGA hardware. The actual return to text mode is already handled later in DOSVESA_VideoQuit.
This fix resolves the crash on pure VGA hardware and has been verified to cause no regression on VESA-compatible hardware.