### PR TITLE
cocoa: fix destroyed windows lingering on screen when the app stops pumping

### DIFF
--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -1752,6 +1752,14 @@ static int SetupWindowData(_THIS, SDL_Window * window, NSWindow *nswindow, NSVie
      * necessary. */
     nswindow.releasedWhenClosed = NO;
 
+    /* Disable AppKit's implicit window show/hide animations. Ordering a
+     * window out (SDL_HideWindow, SDL_DestroyWindow) starts an ~250ms
+     * transform animation that only progresses while the main runloop is
+     * being serviced; if the app stops pumping events after destroying the
+     * window, the animation never runs and the window server keeps the dead
+     * window on screen indefinitely (see #10081). */
+    nswindow.animationBehavior = NSWindowAnimationBehaviorNone;
+
     /* Prevents the window's "window device" from being destroyed when it is
      * hidden. See http://www.mikeash.com/pyblog/nsopenglcontext-and-one-shot.html
      */
@@ -2401,6 +2409,12 @@ void Cocoa_DestroyWindow(_THIS, SDL_Window * window)
             /* Release the content view to avoid further updateLayer callbacks */
             [data.nswindow setContentView:nil];
             [data.nswindow close];
+
+            /* AppKit defers the window server side of the close to the next
+             * main runloop pass; give it one so the window actually leaves
+             * the screen even if the app never pumps events again (#10081).
+             * This does not dispatch NSEvents, only runloop sources. */
+            CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.020, false);
         }
 
 #ifdef SDL_VIDEO_OPENGL


### PR DESCRIPTION
## Description
I'm developing visualisations on MacOS using Jupyter notebooks and PyGame however found that when I want to close the window mid notebook it would hang and require killing the process and the jupyter notebook. Very annoying. 

Using Fable, I was able to track the PyGame issue down to https://github.com/libsdl-org/SDL/issues/10081, reporting the same issue. 

I was able to narrow down the issue to servicing a window out starts an implicit AppKit transform animation that only progresses while the main runloop is serviced, and the window server keeps compositing the window until it completes. The problem is that an app that destroys its window and then stops pumping events (like in the case of Jupyter) leaves a frozen ghost window on screen until the process exits (i.e., hangs indefinitely).

To solve this, we can disable the implicit show/hide animation at window creation, and give AppKit one short main-runloop pass after [NSWindow close] so the deferred order-out is committed even if the app never pumps again. This means that the hide and show animation on windows is removed so if maintainers wish I can see if we can condition this logic to only remove the animation on closes or hides. 

## Existing Issue(s)
Fixes #10081
