### PR TITLE
[Video/KMSDRM]: Prefer largest compatible refresh rate by default.

### DIFF
--- a/src/video/kmsdrm/SDL_kmsdrmvulkan.c
+++ b/src/video/kmsdrm/SDL_kmsdrmvulkan.c
@@ -156,6 +156,19 @@ char const * const *KMSDRM_Vulkan_GetInstanceExtensions(SDL_VideoDevice *_this, 
     return extensionsForKMSDRM;
 }
 
+static int SDLCALL display_mode_comparator(const void *a_opaque, const void *b_opaque)
+{
+    const VkDisplayModePropertiesKHR *a = a_opaque;
+    const VkDisplayModePropertiesKHR *b = b_opaque;
+
+    if (a->parameters.refreshRate > b->parameters.refreshRate)
+        return -1;
+    else if (a->parameters.refreshRate < b->parameters.refreshRate)
+        return 1;
+    else
+        return 0;
+}
+
 /***********************************************************************/
 // First thing to know is that we don't call vkCreateInstance() here.
 // Instead, programs using SDL and Vulkan create their Vulkan instance
@@ -341,6 +354,9 @@ bool KMSDRM_Vulkan_CreateSurface(SDL_VideoDevice *_this,
     vkGetDisplayModePropertiesKHR(gpu,
                                   display,
                                   &mode_count, mode_props);
+
+    /* Sort the modes so that larger refresh rates come first. */
+    SDL_qsort(mode_props, mode_count, sizeof(*mode_props), display_mode_comparator);
 
     /* Get a video mode equal to the window size among the predefined ones,
        if possible.


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

When creating a KHR_display surface, SDL would just pick the first mode that fits the resolution, but this does not work well when refresh rates are reported in unexpected order. Sort the modes such that we pick largest refresh by default.

This could potentially be refined by checking the intended refresh rate of the fullscreen mode as well, but the existing code does not consider that at all, and this is at least better in isolation.

Fixes an issue on my TV where it would pick 60 Hz 4K instead of 120 Hz 4K without any workaround aside from this patch.
