### PR TITLE
[emscripten] Remove support for legacy webkitGetUserMedia

### DIFF
--- a/src/audio/emscripten/SDL_emscriptenaudio.c
+++ b/src/audio/emscripten/SDL_emscriptenaudio.c
@@ -333,8 +333,6 @@ static int EMSCRIPTENAUDIO_OpenDevice(_THIS, const char *devname)
 
             if ((navigator.mediaDevices !== undefined) && (navigator.mediaDevices.getUserMedia !== undefined)) {
                 navigator.mediaDevices.getUserMedia({ audio: true, video: false }).then(have_microphone).catch(no_microphone);
-            } else if (navigator.webkitGetUserMedia !== undefined) {
-                navigator.webkitGetUserMedia({ audio: true, video: false }, have_microphone, no_microphone);
             }
         }, this->spec.channels, this->spec.samples, HandleCaptureProcess, this);
     } else {
@@ -419,8 +417,6 @@ static SDL_bool EMSCRIPTENAUDIO_Init(SDL_AudioDriverImpl *impl)
     /* *INDENT-OFF* */ /* clang-format off */
     capture_available = available && MAIN_THREAD_EM_ASM_INT({
         if ((typeof(navigator.mediaDevices) !== 'undefined') && (typeof(navigator.mediaDevices.getUserMedia) !== 'undefined')) {
-            return true;
-        } else if (typeof(navigator.webkitGetUserMedia) !== 'undefined') {
             return true;
         }
         return false;


### PR DESCRIPTION
This modern navigator.mediaDevices.getUserMedia has been available since Chrome 53 / Firefox 38 / Safari 11.

See https://github.com/emscripten-core/emscripten/pull/27347
