### PR TITLE
Android: restore the system bars when leaving fullscreen on API 30+

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -1012,10 +1012,22 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
                             }
                             SDLActivity.mFullscreenModeActive = true;
                         } else {
-                            int flags = View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_VISIBLE;
-                            window.getDecorView().setSystemUiVisibility(flags);
-                            window.addFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
-                            window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+                            if (Build.VERSION.SDK_INT >= 30 /* Android 11 (R) */) {
+                                // The legacy setSystemUiVisibility() flags are ignored on
+                                // API 30+, so the bars hidden by the modern enter path above
+                                // would never come back. Restore them via WindowInsetsController.
+                                final WindowInsetsController controller = window.getInsetsController();
+                                if (controller != null) {
+                                    controller.setSystemBarsBehavior(
+                                            WindowInsetsController.BEHAVIOR_DEFAULT);
+                                    controller.show(WindowInsets.Type.systemBars());
+                                }
+                            } else {
+                                int flags = View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_VISIBLE;
+                                window.getDecorView().setSystemUiVisibility(flags);
+                                window.addFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+                                window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+                            }
                             SDLActivity.mFullscreenModeActive = false;
                         }
                         if (Build.VERSION.SDK_INT >= 30 /* Android 11 (R) */) {


### PR DESCRIPTION


- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
My old PR #15867 switched the fullscreen path to WindowInsetsController.hide() for API 30+, because the legacy setSystemUiVisibility() flags are ignored on API 30+.

The leaving fullscreen path was left untouched: it still calls setSystemUiVisibility(SYSTEM_UI_FLAG_VISIBLE), which is equally ignored on API 30+. 

As a result, once fullscreen had hidden the status/navigation bars, they never came back when returning to windowed mode.

This PR fixes that issue.

## Existing Issue(s)
issue #15912
