### PR TITLE
SDL_report_descriptor: Parse and store Usage attached to Collection items to enable detecting Gamepads

### DIFF
--- a/src/joystick/hidapi/SDL_report_descriptor.c
+++ b/src/joystick/hidapi/SDL_report_descriptor.c
@@ -107,6 +107,9 @@ typedef struct
     int collection_depth;
     DescriptorGlobalState global;
     DescriptorLocalState local;
+    int collection_maxcount;
+    int collection_count;
+    DescriptorCollection *collections;
     int field_maxcount;
     int field_count;
     int field_offset;
@@ -234,6 +237,30 @@ static bool AddUsage(DescriptorContext *ctx, Uint32 usage)
     return true;
 }
 
+static bool AddCollection(DescriptorContext *ctx, Uint8 type)
+{
+    if (ctx->collection_count == ctx->collection_maxcount) {
+        int collection_maxcount = ctx->collection_maxcount + 4;
+        DescriptorCollection *collections = (DescriptorCollection *)SDL_realloc(ctx->collections, collection_maxcount * sizeof(*collections));
+        if (!collections) {
+            return false;
+        }
+        ctx->collections = collections;
+        ctx->collection_maxcount = collection_maxcount;
+    }
+
+    // The Usage applied to a collection is the first Usage local item that
+    // precedes the Collection main item, per the HID Usage Tables spec.
+    Uint32 usage = (ctx->local.usage_count > 0) ? ctx->local.usages[0] : 0;
+
+    DescriptorCollection *collection = &ctx->collections[ctx->collection_count++];
+    collection->usage = usage;
+    collection->type = type;
+
+    DebugDescriptor(ctx, "Adding report %d collection 0x%.8x type 0x%.8x", (Uint8)ctx->global.report_id, collection->usage, collection->type);
+    return true;
+}
+
 static bool AddInputField(DescriptorContext *ctx, Uint32 usage, int bit_size)
 {
     if (ctx->field_count == ctx->field_maxcount) {
@@ -340,6 +367,9 @@ static bool ParseMainItem(DescriptorContext *ctx, int tag, size_t size, const Ui
             break;
         default:
             break;
+        }
+        if (!AddCollection(ctx, *data)) {
+            return false;
         }
         ++ctx->collection_depth;
         break;
@@ -511,6 +541,7 @@ static bool ParseDescriptor(DescriptorContext *ctx, const Uint8 *descriptor, siz
 static void CleanupContext(DescriptorContext *ctx)
 {
     SDL_free(ctx->local.usages);
+    SDL_free(ctx->collections);
     SDL_free(ctx->fields);
 }
 
@@ -525,6 +556,9 @@ SDL_ReportDescriptor *SDL_ParseReportDescriptor(const Uint8 *descriptor, size_t 
             result->field_count = ctx.field_count;
             result->fields = ctx.fields;
             ctx.fields = NULL;
+            result->collection_count = ctx.collection_count;
+            result->collections = ctx.collections;
+            ctx.collections = NULL;
         }
     }
     CleanupContext(&ctx);
@@ -547,10 +581,27 @@ bool SDL_DescriptorHasUsage(SDL_ReportDescriptor *descriptor, Uint16 usage_page,
     return false;
 }
 
+bool SDL_DescriptorHasCollectionUsage(SDL_ReportDescriptor *descriptor, Uint16 usage_page, Uint16 usage, Uint8 type)
+{
+    if (!descriptor) {
+        return false;
+    }
+
+    Uint32 full_usage = (((Uint32)usage_page << 16) | usage);
+    for (int i = 0; i < descriptor->collection_count; ++i) {
+        if (descriptor->collections[i].usage == full_usage &&
+            descriptor->collections[i].type == type) {
+            return true;
+        }
+    }
+    return false;
+}
+
 void SDL_DestroyDescriptor(SDL_ReportDescriptor *descriptor)
 {
     if (descriptor) {
         SDL_free(descriptor->fields);
+        SDL_free(descriptor->collections);
         SDL_free(descriptor);
     }
 }

--- a/src/joystick/hidapi/SDL_report_descriptor.h
+++ b/src/joystick/hidapi/SDL_report_descriptor.h
@@ -33,12 +33,22 @@ typedef struct
 
 typedef struct
 {
+	Uint32 usage;
+	Uint8  type;         /* collection type byte: 0=Physical, 1=Application,
+	                        2=Logical, 3=Report, 4=NamedArray, ... */
+} DescriptorCollection;
+
+typedef struct
+{
 	int field_count;
 	DescriptorInputField *fields;
+	int collection_count;
+	DescriptorCollection *collections;
 } SDL_ReportDescriptor;
 
 extern SDL_ReportDescriptor *SDL_ParseReportDescriptor(const Uint8 *descriptor, size_t descriptor_size);
 extern bool SDL_DescriptorHasUsage(SDL_ReportDescriptor *descriptor, Uint16 usage_page, Uint16 usage);
+extern bool SDL_DescriptorHasCollectionUsage(SDL_ReportDescriptor *descriptor, Uint16 usage_page, Uint16 usage, Uint8 type);
 extern void SDL_DestroyDescriptor(SDL_ReportDescriptor *descriptor);
 extern bool SDL_ReadReportData(const Uint8 *data, size_t size, int bit_offset, int bit_size, Uint32 *value);
 

--- a/test/testdescriptor.c
+++ b/test/testdescriptor.c
@@ -47,9 +47,28 @@
 #endif
 
 #include <SDL3/SDL_main.h>
+#include "joystick/usb_ids.h"
 
 #include "../src/joystick/hidapi/SDL_report_descriptor.h"
 #include "../src/joystick/hidapi/SDL_report_descriptor.c"
+
+bool IsGamepad(SDL_ReportDescriptor *descriptor)
+{
+    if ((SDL_DescriptorHasCollectionUsage(descriptor, USB_USAGEPAGE_GENERIC_DESKTOP, USB_USAGE_GENERIC_JOYSTICK, 0x1)
+        || SDL_DescriptorHasCollectionUsage(descriptor, USB_USAGEPAGE_GENERIC_DESKTOP, USB_USAGE_GENERIC_GAMEPAD, 0x1))
+        // Something in parsing is still not right in the parsing, the block
+        // below makes some devices to be misdetected.
+#if 0
+        && !SDL_DescriptorHasCollectionUsage(descriptor, USB_USAGEPAGE_GENERIC_DESKTOP, USB_USAGE_GENERIC_KEYBOARD, 0x1)
+        && !SDL_DescriptorHasCollectionUsage(descriptor, USB_USAGEPAGE_GENERIC_DESKTOP, USB_USAGE_GENERIC_MOUSE, 0x1)) {
+#else
+        ) {
+#endif
+        return true;
+    }
+
+    return false;
+}
 
 int main(int argc, char *argv[])
 {
@@ -71,6 +90,10 @@ int main(int argc, char *argv[])
         SDL_Log("Couldn't parse %s: %s", file, SDL_GetError());
         return 3;
     }
+
+    bool is_gamepad = IsGamepad(sdl_descriptor);
+    SDL_Log("Is device \"%s\" a gamepad? %s", file, is_gamepad ? "YES" : "NO");
+
     SDL_DestroyDescriptor(sdl_descriptor);
     return 0;
 }


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

For the sake of transparency, an LLM helped me to explore the problem, but the code has been hand-crafted (given also the `AGENTS.md` file in the SDL project).

<!--- Provide a general summary of your changes in the Title above -->
This is a prototype of how Gamepads could be detected by parsing the HID report descriptor

## Description

We are investigating how to detect gamepads starting from their HID report descriptor, mainly because we would like to give hidraw uaccess ot all gamepdas, but only to gamepads.

The changes are for exploration only at the current stage.

The proposed changes seem to work for a restricted set of devices:

```
$ find ../HID-report-descriptor/data -name "*.rdesc" |
    while read file;
    do
        ./build/test/testdescriptor "$file"
    done 2>&1 \
        | grep gamepad | sort
Is device "../HID-report-descriptor/data/fanatec_handbrake_hid_report_descriptor.rdesc" a gamepad? YES
Is device "../HID-report-descriptor/data/heusinkveld_pedals_hid_report_descriptor.rdesc" a gamepad? YES
Is device "../HID-report-descriptor/data/ps3_hid_report_descriptor.rdesc" a gamepad? YES
Is device "../HID-report-descriptor/data/steam_deck_kb_hid_report_descriptor.rdesc" a gamepad? NO
Is device "../HID-report-descriptor/data/steam_deck_lcd_js_hid_report_descriptor.rdesc" a gamepad? NO
Is device "../HID-report-descriptor/data/steam_deck_mouse_hid_report_descriptor.rdesc" a gamepad? NO
Is device "../HID-report-descriptor/data/steam_deck_oled_js_hid_report_descriptor.rdesc" a gamepad? NO
Is device "../HID-report-descriptor/data/thinkpad_usb_keyboard_hid_report_descriptor.rdesc" a gamepad? NO
Is device "../HID-report-descriptor/data/thinkpad_usb_trackpoint_hid_report_descriptor.rdesc" a gamepad? NO
Is device "../HID-report-descriptor/data/vrs_pedals_hid_report_descriptor.rdesc" a gamepad? YES
Is device "../HID-report-descriptor/data/xbox_one_elite_2_hid_report_descriptor.rdesc" a gamepad? YES
Is device "../HID-report-descriptor/data/xpadneo09_xb1s_hid_report_descriptor.rdesc" a gamepad? YES
```

However the parsing might be incomplete and detection could fail for other devices.