### PR TITLE
ci: treat CMake deprecated and development warnings as errors

### DIFF
--- a/.github/workflows/generic.yml
+++ b/.github/workflows/generic.yml
@@ -219,7 +219,7 @@ jobs:
         run: |
           ${{ matrix.platform.source-cmd }}
           ${{ matrix.platform.cmake-config-emulator }} cmake -S . -B build -G "${{ matrix.platform.cmake-generator }}" \
-            -Wdeprecated -Wdev -Werror \
+            -Wdeprecated -Wdev -Werror=dev -Werror=deprecated \
             ${{ matrix.platform.cmake-toolchain-file != '' && format('-DCMAKE_TOOLCHAIN_FILE={0}', matrix.platform.cmake-toolchain-file) || '' }} \
             -DSDL_WERROR=${{ matrix.platform.werror }} \
             -DSDL_EXAMPLES=${{ matrix.platform.build-tests }} \


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

I'm not 100% sure we're not using any deprecated feature accidentally (e.g. through CMake toolchain files)



## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
Fixes #16007
