### PR TITLE
IsEqualGUID uses memcmp behind the scenes, thwarting a NOLIBC build

### DIFF
--- a/src/notification/windows/SDL_windowsnotification.c
+++ b/src/notification/windows/SDL_windowsnotification.c
@@ -120,9 +120,9 @@ static HRESULT STDMETHODCALLTYPE Impl_OnActivated_QueryInterface(__FITypedEventH
     if (ppvObject == NULL) {
         return E_POINTER;
     }
-    if (IsEqualGUID(riid, &IID_IToastActivatedEventHandler) ||
-        IsEqualGUID(riid, &IID_IAgileObject) ||
-        IsEqualGUID(riid, &IID_IUnknown)) {
+    if (WIN_IsEqualGUID(riid, &IID_IToastActivatedEventHandler) ||
+        WIN_IsEqualGUID(riid, &IID_IAgileObject) ||
+        WIN_IsEqualGUID(riid, &IID_IUnknown)) {
         *ppvObject = _this;
         _this->lpVtbl->AddRef(_this);
         return S_OK;
@@ -185,9 +185,9 @@ static HRESULT STDMETHODCALLTYPE Impl_OnDismissed_QueryInterface(__FITypedEventH
     if (ppvObject == NULL) {
         return E_POINTER;
     }
-    if (IsEqualGUID(riid, &IID_IToastDismissedEventHandler) ||
-        IsEqualGUID(riid, &IID_IAgileObject) ||
-        IsEqualGUID(riid, &IID_IUnknown)) {
+    if (WIN_IsEqualGUID(riid, &IID_IToastDismissedEventHandler) ||
+        WIN_IsEqualGUID(riid, &IID_IAgileObject) ||
+        WIN_IsEqualGUID(riid, &IID_IUnknown)) {
         *ppvObject = _this;
         _this->lpVtbl->AddRef(_this);
         return S_OK;


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
