### PR TITLE
Clear SDL_PROP_WINDOW_ANDROID_WINDOW_POINTER when ANativeWindow is freed

### DIFF
--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -1315,6 +1315,7 @@ retry:
         if (data->native_window) {
             ANativeWindow_release(data->native_window);
             data->native_window = NULL;
+            SDL_SetPointerProperty(SDL_GetWindowProperties(Android_Window), SDL_PROP_WINDOW_ANDROID_WINDOW_POINTER, NULL);
         }
 
         // GL Context handling is done in the event loop because this function is run from the Java thread

--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -1313,9 +1313,9 @@ retry:
 #endif
 
         if (data->native_window) {
+            SDL_SetPointerProperty(SDL_GetWindowProperties(Android_Window), SDL_PROP_WINDOW_ANDROID_WINDOW_POINTER, NULL);
             ANativeWindow_release(data->native_window);
             data->native_window = NULL;
-            SDL_SetPointerProperty(SDL_GetWindowProperties(Android_Window), SDL_PROP_WINDOW_ANDROID_WINDOW_POINTER, NULL);
         }
 
         // GL Context handling is done in the event loop because this function is run from the Java thread


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
Clear SDL_PROP_WINDOW_ANDROID_WINDOW_POINTER such that the property does not contain a stale pointer.

## Existing Issue(s)
#16023
