### PR TITLE
fix: SDL_RenderTextureTiled on Metal - infinite loop + memory allocs on an out of bounds src rect

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -4455,6 +4455,10 @@ static bool SDL_RenderTextureTiled_Iterate(SDL_Renderer *renderer, SDL_Texture *
 {
     float tile_width = srcrect->w * scale;
     float tile_height = srcrect->h * scale;
+    if (tile_width <= 0.0f || tile_height <= 0.0f) {
+        return true;
+    }
+
     float float_rows, float_cols;
     float remaining_w = SDL_modff(dstrect->w / tile_width, &float_cols);
     float remaining_h = SDL_modff(dstrect->h / tile_height, &float_rows);
@@ -4535,7 +4539,7 @@ bool SDL_RenderTextureTiled(SDL_Renderer *renderer, SDL_Texture *texture, const 
     real_srcrect.w = (float)texture->w;
     real_srcrect.h = (float)texture->h;
     if (srcrect) {
-        if (!SDL_GetRectIntersectionFloat(srcrect, &real_srcrect, &real_srcrect)) {
+        if (!SDL_GetRectIntersectionFloat(srcrect, &real_srcrect, &real_srcrect) || real_srcrect.w == 0.0f || real_srcrect.h == 0.0f) {
             return true;
         }
     }


### PR DESCRIPTION

- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Adds source rect area sanity check to  `SDL_RenderTextureTiled` and `SDL_RenderTextureTiled_Iterate`.

## Description
I had an occasional hard-to-repro freeze in my game where my main process would hit an infinite loop and allocate 25+ GB of RAM. I messed up some arithmetic on a timer value for an animation, and I was passing a bogus source rect for my texture to `SDL_RenderTextureTiled`, one which had no area because it was out of bounds, but which still _touched_ the edge of the texture, so passed through the existing checks.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. --> 