### PR TITLE
SDL_dbustray: fix crash in TrayHandleGetAllProps when tray->menu unavailable

### DIFF
--- a/src/tray/unix/SDL_dbustray.c
+++ b/src/tray/unix/SDL_dbustray.c
@@ -88,7 +88,7 @@ static DBusHandlerResult TrayHandleGetAllProps(SDL_Tray *tray, SDL_TrayDBus *tra
     dbus_uint32_t uint32_val;
     dbus_bool_t bool_value;
 
-    menu_dbus = (SDL_TrayMenuDBus *)tray->menu->internal;
+    menu_dbus = tray->menu ? (SDL_TrayMenuDBus *)tray->menu->internal : NULL;
 
     empty = "";
     driver->dbus->message_iter_init(msg, &iter);
@@ -149,7 +149,7 @@ static DBusHandlerResult TrayHandleGetAllProps(SDL_Tray *tray, SDL_TrayDBus *tra
     driver->dbus->message_iter_close_container(&dict_iter, &entry_iter);
 
     key = "ItemIsMenu";
-    menu_dbus = (SDL_TrayMenuDBus *)tray->menu->internal;
+    menu_dbus = tray->menu ? (SDL_TrayMenuDBus *)tray->menu->internal : NULL;
     if (menu_dbus && menu_dbus->menu_path) {
         bool_value = TRUE;
     } else {


### PR DESCRIPTION

- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

A crash may happen in the function `TrayHandleGetAllProps()` in SDL_dbustray.c when it tries to access `tray->menu->internal`. I created a try icon without a menu. This extra check allows it to proceed without crashing, and I can see the tray icon is created correctly on my system.

I suspect that a similar change may also be necessary in `TrayHandleGetProp()` in the same file, but I'm not sure how to ensure that function gets called so that I could test it.

In case it's relevant, I'm on Fedora Linux 44 with KDE Plasma 6.7.2.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->

None found.