### PR TITLE
Add "_FIRST/_LAST" fields to event type subsections in SDL_events.h

### DIFF
--- a/include/SDL3/SDL_events.h
+++ b/include/SDL3/SDL_events.h
@@ -180,6 +180,8 @@ typedef enum SDL_EventType
     SDL_EVENT_TEXT_EDITING_CANDIDATES, /**< Keyboard text editing candidates */
     SDL_EVENT_SCREEN_KEYBOARD_SHOWN,   /**< The on-screen keyboard has been shown */
     SDL_EVENT_SCREEN_KEYBOARD_HIDDEN,  /**< The on-screen keyboard has been hidden */
+    SDL_EVENT_KEYBOARD_FIRST = SDL_EVENT_KEY_DOWN,
+    SDL_EVENT_KEYBOARD_LAST = SDL_EVENT_SCREEN_KEYBOARD_HIDDEN,
 
     /* Mouse events */
     SDL_EVENT_MOUSE_MOTION    = 0x400, /**< Mouse moved */
@@ -188,6 +190,8 @@ typedef enum SDL_EventType
     SDL_EVENT_MOUSE_WHEEL,             /**< Mouse wheel motion */
     SDL_EVENT_MOUSE_ADDED,             /**< A new mouse has been inserted into the system */
     SDL_EVENT_MOUSE_REMOVED,           /**< A mouse has been removed */
+    SDL_EVENT_MOUSE_FIRST = SDL_EVENT_MOUSE_MOTION,
+    SDL_EVENT_MOUSE_LAST = SDL_EVENT_MOUSE_REMOVED,
 
     /* Joystick events */
     SDL_EVENT_JOYSTICK_AXIS_MOTION  = 0x600, /**< Joystick axis motion */
@@ -199,6 +203,8 @@ typedef enum SDL_EventType
     SDL_EVENT_JOYSTICK_REMOVED,              /**< An opened joystick has been removed */
     SDL_EVENT_JOYSTICK_BATTERY_UPDATED,      /**< Joystick battery level change */
     SDL_EVENT_JOYSTICK_UPDATE_COMPLETE,      /**< Joystick update is complete */
+    SDL_EVENT_JOYSTICK_FIRST = SDL_EVENT_JOYSTICK_AXIS_MOTION,
+    SDL_EVENT_JOYSTICK_LAST = SDL_EVENT_JOYSTICK_UPDATE_COMPLETE,
 
     /* Gamepad events */
     SDL_EVENT_GAMEPAD_AXIS_MOTION  = 0x650, /**< Gamepad axis motion */
@@ -215,22 +221,30 @@ typedef enum SDL_EventType
     SDL_EVENT_GAMEPAD_STEAM_HANDLE_UPDATED,  /**< Gamepad Steam handle has changed */
     SDL_EVENT_GAMEPAD_CAPSENSE_TOUCH,       /**< Gamepad capsense was touched */
     SDL_EVENT_GAMEPAD_CAPSENSE_RELEASE,     /**< Gamepad capsense was released */
+    SDL_EVENT_GAMEPAD_FIRST = SDL_EVENT_GAMEPAD_AXIS_MOTION,
+    SDL_EVENT_GAMEPAD_LAST = SDL_EVENT_GAMEPAD_CAPSENSE_RELEASE,
 
     /* Touch events */
     SDL_EVENT_FINGER_DOWN      = 0x700,
     SDL_EVENT_FINGER_UP,
     SDL_EVENT_FINGER_MOTION,
     SDL_EVENT_FINGER_CANCELED,
+    SDL_EVENT_FINGER_FIRST = SDL_EVENT_FINGER_DOWN,
+    SDL_EVENT_FINGER_LAST = SDL_EVENT_FINGER_CANCELED,
 
     /* Pinch events */
     SDL_EVENT_PINCH_BEGIN      = 0x710,     /**< Pinch gesture started */
     SDL_EVENT_PINCH_UPDATE,                 /**< Pinch gesture updated */
     SDL_EVENT_PINCH_END,                    /**< Pinch gesture ended */
+    SDL_EVENT_PINCH_FIRST = SDL_EVENT_PINCH_BEGIN,
+    SDL_EVENT_PINCH_LAST = SDL_EVENT_PINCH_END,
 
     /* 0x800, 0x801, and 0x802 were the Gesture events from SDL2. Do not reuse these values! sdl2-compat needs them! */
 
     /* Clipboard events */
     SDL_EVENT_CLIPBOARD_UPDATE = 0x900, /**< The clipboard changed */
+    SDL_EVENT_CLIPBOARD_FIRST = SDL_EVENT_CLIPBOARD_UPDATE,
+    SDL_EVENT_CLIPBOARD_LAST = SDL_EVENT_CLIPBOARD_UPDATE,
 
     /* Drag and drop events */
     SDL_EVENT_DROP_FILE        = 0x1000, /**< The system requests a file open */
@@ -238,14 +252,20 @@ typedef enum SDL_EventType
     SDL_EVENT_DROP_BEGIN,                /**< A new set of drops is beginning (NULL filename) */
     SDL_EVENT_DROP_COMPLETE,             /**< Current set of drops is now complete (NULL filename) */
     SDL_EVENT_DROP_POSITION,             /**< Position while moving over the window */
+    SDL_EVENT_DROP_FIRST = SDL_EVENT_DROP_FILE,
+    SDL_EVENT_DROP_LAST = SDL_EVENT_DROP_POSITION,
 
     /* Audio hotplug events */
     SDL_EVENT_AUDIO_DEVICE_ADDED = 0x1100,  /**< A new audio device is available */
     SDL_EVENT_AUDIO_DEVICE_REMOVED,         /**< An audio device has been removed. */
     SDL_EVENT_AUDIO_DEVICE_FORMAT_CHANGED,  /**< An audio device's format has been changed by the system. */
+    SDL_EVENT_AUDIO_DEVICE_FIRST = SDL_EVENT_AUDIO_DEVICE_ADDED,
+    SDL_EVENT_AUDIO_DEVICE_LAST = SDL_EVENT_AUDIO_DEVICE_FORMAT_CHANGED,
 
     /* Sensor events */
     SDL_EVENT_SENSOR_UPDATE = 0x1200,     /**< A sensor was updated */
+    SDL_EVENT_SENSOR_FIRST = SDL_EVENT_SENSOR_UPDATE,
+    SDL_EVENT_SENSOR_LAST = SDL_EVENT_SENSOR_UPDATE,
 
     /* Pressure-sensitive pen events */
     SDL_EVENT_PEN_PROXIMITY_IN = 0x1300,  /**< Pressure-sensitive pen has become available */
@@ -256,20 +276,28 @@ typedef enum SDL_EventType
     SDL_EVENT_PEN_BUTTON_UP,              /**< Pressure-sensitive pen button released */
     SDL_EVENT_PEN_MOTION,                 /**< Pressure-sensitive pen is moving on the tablet */
     SDL_EVENT_PEN_AXIS,                   /**< Pressure-sensitive pen angle/pressure/etc changed */
+    SDL_EVENT_PEN_FIRST = SDL_EVENT_PEN_PROXIMITY_IN,
+    SDL_EVENT_PEN_LAST = SDL_EVENT_PEN_AXIS,
 
     /* Camera hotplug events */
     SDL_EVENT_CAMERA_DEVICE_ADDED = 0x1400,  /**< A new camera device is available */
     SDL_EVENT_CAMERA_DEVICE_REMOVED,         /**< A camera device has been removed. */
     SDL_EVENT_CAMERA_DEVICE_APPROVED,        /**< A camera device has been approved for use by the user. */
     SDL_EVENT_CAMERA_DEVICE_DENIED,          /**< A camera device has been denied for use by the user. */
+    SDL_EVENT_CAMERA_DEVICE_FIRST = SDL_EVENT_CAMERA_DEVICE_ADDED,
+    SDL_EVENT_CAMERA_DEVICE_LAST = SDL_EVENT_CAMERA_DEVICE_DENIED,
 
     /* Notification events */
     SDL_EVENT_NOTIFICATION_ACTION_INVOKED = 0x1500, /**< A user response to a system notification was received. */
+    SDL_EVENT_NOTIFICATION_FIRST = SDL_EVENT_NOTIFICATION_ACTION_INVOKED,
+    SDL_EVENT_NOTIFICATION_LAST = SDL_EVENT_NOTIFICATION_ACTION_INVOKED,
 
     /* Render events */
     SDL_EVENT_RENDER_TARGETS_RESET = 0x2000, /**< The render targets have been reset and their contents need to be updated */
     SDL_EVENT_RENDER_DEVICE_RESET, /**< The device has been reset and all textures need to be recreated */
     SDL_EVENT_RENDER_DEVICE_LOST, /**< The device has been lost and can't be recovered. */
+    SDL_EVENT_RENDER_FIRST = SDL_EVENT_RENDER_TARGETS_RESET,
+    SDL_EVENT_RENDER_LAST = SDL_EVENT_RENDER_DEVICE_LOST,
 
     /* Reserved events for private platforms */
     SDL_EVENT_PRIVATE0 = 0x4000,


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->
Added fields `SDL_{SUBSECTION}_FIRST/_LAST` that are missing from SDL_EventType enum.

## Description
<!--- Describe your changes in detail -->
Basically, the [SDL_EventType](https://wiki.libsdl.org/SDL3/SDL_EventType#mapping-sdl-event-types-to-structs) documentation  for SDL3 says:

> There are `_FIRST` and `_LAST` fields for each subsection of events, like `SDL_EVENT_DISPLAY_FIRST` and `SDL_EVENT_DISPLAY_LAST`. These are not listed in this table, as they are never sent as events and are only used to provide logical groupings.

However, the `SDL3/SDL_events.h` file reveals that this is only true for the Display events and Window events.

From this, we have two ways to solve this issue:

1. Remove the `_FIRST/_LAST` fields for Display and Window events and remove the documentation for these fields.
2. Add the missing fields in the enum.

I chose the second option because I think it's cool to have this, but it's open for discussion.
