### PR TITLE
Cygwin: Fix SDL_GetPlatform

### DIFF
--- a/src/SDL.c
+++ b/src/SDL.c
@@ -813,10 +813,10 @@ const char *SDL_GetPlatform(void)
     return "RISC OS";
 #elif defined(SDL_PLATFORM_SOLARIS)
     return "Solaris";
-#elif defined(SDL_PLATFORM_WIN32)
-    return "Windows";
 #elif defined(SDL_PLATFORM_CYGWIN)
     return "Cygwin";
+#elif defined(SDL_PLATFORM_WIN32)
+    return "Windows";
 #elif defined(SDL_PLATFORM_WINGDK)
     return "WinGDK";
 #elif defined(SDL_PLATFORM_XBOXONE)


### PR DESCRIPTION
[sdl-ci-filter cygwin]

- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

SDL_GetPlatform was returning "This system is running Windows" This change makes it return "This system is running Cygwin".

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
