### PR TITLE
Use the modern OnBackInvokedCallback method to trap the back button on newer Android devices

### DIFF
--- a/android-project/app/src/main/AndroidManifest.xml
+++ b/android-project/app/src/main/AndroidManifest.xml
@@ -71,7 +71,7 @@
         android:icon="@mipmap/ic_launcher"
         android:allowBackup="true"
         android:theme="@style/AppTheme"
-        android:enableOnBackInvokedCallback="false"
+        android:enableOnBackInvokedCallback="true"
         android:hardwareAccelerated="true" >
 
         <!-- Example of setting SDL hints from AndroidManifest.xml:

--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -24,6 +24,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.LocaleList;
+import android.os.Looper;
 import android.os.Message;
 import android.os.ParcelFileDescriptor;
 import android.provider.DocumentsContract;
@@ -50,6 +51,8 @@ import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
+import android.window.OnBackInvokedCallback;
+import android.window.OnBackInvokedDispatcher;
 
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
@@ -611,6 +614,12 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
         if (mHasMultiWindow) {
             resumeNativeThread();
         }
+
+        if (Build.VERSION.SDK_INT >= 33) {
+            // We need to enable the back button invoke callback if we're on more modern Android.
+            boolean trapBack = SDLActivity.nativeGetHintBoolean("SDL_ANDROID_TRAP_BACK_BUTTON", false);
+            setBackButtonTrapEnabled(trapBack);        
+        }
     }
 
     public static int getNaturalOrientation() {
@@ -782,6 +791,47 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
         if (!isFinishing()) {
             super.onBackPressed();
         }
+    }
+
+    static OnBackInvokedCallback backButtonCallback = new OnBackInvokedCallback() {
+        Handler mBackKeyHandler;
+
+        @Override
+        public void onBackInvoked() {
+            if (mBackKeyHandler == null) {
+                mBackKeyHandler = new Handler(Looper.getMainLooper());
+            }
+
+            onNativeKeyDown(KeyEvent.KEYCODE_BACK);
+            mBackKeyHandler.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    onNativeKeyUp(KeyEvent.KEYCODE_BACK);
+                }
+            }, 500);
+        }
+    };
+
+    static boolean mBackKeyTrapEnabled = false;
+    public static void setBackButtonTrapEnabled(boolean enabled) {
+
+        if ( Build.VERSION.SDK_INT < 33 ) {
+            // We're old enough that we just use the old onBackPressed behavior.
+            return;
+        }
+
+        // Check so we don't register the same callback twice.
+        if (enabled == mBackKeyTrapEnabled) {
+            return;
+        }
+
+        if (enabled) {
+            mSingleton.getOnBackInvokedDispatcher().registerOnBackInvokedCallback(OnBackInvokedDispatcher.PRIORITY_DEFAULT, backButtonCallback);
+        }
+        else {
+            mSingleton.getOnBackInvokedDispatcher().unregisterOnBackInvokedCallback(backButtonCallback);
+        }
+        mBackKeyTrapEnabled = enabled;
     }
 
     // File dialog types

--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -614,12 +614,6 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
         if (mHasMultiWindow) {
             resumeNativeThread();
         }
-
-        if (Build.VERSION.SDK_INT >= 33) {
-            // We need to enable the back button invoke callback if we're on more modern Android.
-            boolean trapBack = SDLActivity.nativeGetHintBoolean("SDL_ANDROID_TRAP_BACK_BUTTON", false);
-            setBackButtonTrapEnabled(trapBack);        
-        }
     }
 
     public static int getNaturalOrientation() {

--- a/src/SDL_hints.c
+++ b/src/SDL_hints.c
@@ -155,6 +155,8 @@ bool SDL_SetHintWithPriority(const char *name, const char *value, SDL_HintPriori
     if (SDL_strcmp(name, SDL_HINT_ANDROID_ALLOW_RECREATE_ACTIVITY) == 0) {
         // Special handling for this hint, which needs to persist outside the normal application flow
         Android_SetAllowRecreateActivity(SDL_GetStringBoolean(value, false));
+    } else if (SDL_strcmp(name, SDL_HINT_ANDROID_TRAP_BACK_BUTTON) == 0) {
+        Android_JNI_SetBackButtonTrapActive(SDL_GetStringBoolean(value, false));
     }
 #endif // SDL_PLATFORM_ANDROID
 
@@ -240,6 +242,13 @@ static void SDLCALL ResetHintsCallback(void *userdata, SDL_PropertiesID hints, c
             Android_SetAllowRecreateActivity(SDL_GetStringBoolean(env, false));
         } else {
             Android_SetAllowRecreateActivity(false);
+        }
+    } else if (SDL_strcmp(name, SDL_HINT_ANDROID_TRAP_BACK_BUTTON) == 0) {
+        // Special handling for this.
+        if (env) {
+            Android_JNI_SetBackButtonTrapActive(SDL_GetStringBoolean(env, false));
+        } else {
+            Android_JNI_SetBackButtonTrapActive(false);        
         }
     }
 #endif // SDL_PLATFORM_ANDROID

--- a/src/SDL_hints.c
+++ b/src/SDL_hints.c
@@ -241,7 +241,7 @@ static void SDLCALL ResetHintsCallback(void *userdata, SDL_PropertiesID hints, c
         } else {
             Android_SetAllowRecreateActivity(false);
         }
-    } 
+    }
 #endif // SDL_PLATFORM_ANDROID
 }
 

--- a/src/SDL_hints.c
+++ b/src/SDL_hints.c
@@ -155,8 +155,6 @@ bool SDL_SetHintWithPriority(const char *name, const char *value, SDL_HintPriori
     if (SDL_strcmp(name, SDL_HINT_ANDROID_ALLOW_RECREATE_ACTIVITY) == 0) {
         // Special handling for this hint, which needs to persist outside the normal application flow
         Android_SetAllowRecreateActivity(SDL_GetStringBoolean(value, false));
-    } else if (SDL_strcmp(name, SDL_HINT_ANDROID_TRAP_BACK_BUTTON) == 0) {
-        Android_JNI_SetBackButtonTrapActive(SDL_GetStringBoolean(value, false));
     }
 #endif // SDL_PLATFORM_ANDROID
 
@@ -243,14 +241,7 @@ static void SDLCALL ResetHintsCallback(void *userdata, SDL_PropertiesID hints, c
         } else {
             Android_SetAllowRecreateActivity(false);
         }
-    } else if (SDL_strcmp(name, SDL_HINT_ANDROID_TRAP_BACK_BUTTON) == 0) {
-        // Special handling for this.
-        if (env) {
-            Android_JNI_SetBackButtonTrapActive(SDL_GetStringBoolean(env, false));
-        } else {
-            Android_JNI_SetBackButtonTrapActive(false);        
-        }
-    }
+    } 
 #endif // SDL_PLATFORM_ANDROID
 }
 

--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -101,6 +101,7 @@ static jmethodID midManualBackButton;
 static jmethodID midShowFileDialog;
 #endif // !SDL_DIALOG_DISABLED
 static jmethodID midGetPreferredLocales;
+static jmethodID midSetBackButtonTrapEnabled;
 
 #ifndef SDL_VIDEO_DISABLED
 // Video/surface method signatures
@@ -681,6 +682,7 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(nativeSetupJNI)(JNIEnv *env, jclass cl
     midShowFileDialog = (*env)->GetStaticMethodID(env, mActivityClass, "showFileDialog", "([Ljava/lang/String;ZILjava/lang/String;I)Z");
 #endif // !SDL_DIALOG_DISABLED
     midGetPreferredLocales = (*env)->GetStaticMethodID(env, mActivityClass, "getPreferredLocales", "()Ljava/lang/String;");
+    midSetBackButtonTrapEnabled = (*env)->GetStaticMethodID(env, mActivityClass, "setBackButtonTrapEnabled", "(Z)V");
 
     if (!midGetContext ||
         !midGetDeviceFormFactor ||
@@ -698,7 +700,8 @@ JNIEXPORT void JNICALL SDL_JAVA_INTERFACE(nativeSetupJNI)(JNIEnv *env, jclass cl
 #ifndef SDL_DIALOG_DISABLED
         !midShowFileDialog ||
 #endif
-        !midGetPreferredLocales) {
+        !midGetPreferredLocales ||
+        !midSetBackButtonTrapEnabled) {
         __android_log_print(ANDROID_LOG_WARN, "SDL", "Missing some core Java callbacks, do you have the latest version of SDLActivity.java?");
     }
 
@@ -3713,5 +3716,13 @@ bool Android_JNI_ShowFileDialog(
     return true;
 }
 #endif // !SDL_DIALOG_DISABLED
+
+void Android_JNI_SetBackButtonTrapActive(bool enabled)
+{
+    if (!midSetBackButtonTrapEnabled) return;
+
+    JNIEnv *env = Android_JNI_GetEnv();
+    (*env)->CallStaticVoidMethod(env, mActivityClass, midSetBackButtonTrapEnabled, enabled);
+}
 
 #endif // SDL_PLATFORM_ANDROID

--- a/src/core/android/SDL_android.c
+++ b/src/core/android/SDL_android.c
@@ -3719,7 +3719,9 @@ bool Android_JNI_ShowFileDialog(
 
 void Android_JNI_SetBackButtonTrapActive(bool enabled)
 {
-    if (!midSetBackButtonTrapEnabled) return;
+    if (!midSetBackButtonTrapEnabled) {
+        return;
+    }
 
     JNIEnv *env = Android_JNI_GetEnv();
     (*env)->CallStaticVoidMethod(env, mActivityClass, midSetBackButtonTrapEnabled, enabled);

--- a/src/core/android/SDL_android.h
+++ b/src/core/android/SDL_android.h
@@ -60,6 +60,7 @@ void Android_LockActivityMutex(void);
 void Android_UnlockActivityMutex(void);
 
 void Android_SetAllowRecreateActivity(bool enabled);
+void Android_JNI_SetBackButtonTrapActive(bool enabled);
 
 #ifndef SDL_VIDEO_DISABLED
 #include <EGL/eglplatform.h>

--- a/src/video/android/SDL_androidvideo.c
+++ b/src/video/android/SDL_androidvideo.c
@@ -82,6 +82,16 @@ static void Android_DeleteDevice(SDL_VideoDevice *device)
     SDL_free(device);
 }
 
+// Input is part of video for Android, so this goes here.
+static void SDLCALL Android_Video_InternalHintCallback(
+    void *userdata,
+    const char *name,
+    const char *oldvalue,
+    const char *newvalue)
+{
+    Android_JNI_SetBackButtonTrapActive(SDL_GetStringBoolean(newvalue, false));
+}
+
 static SDL_VideoDevice *Android_CreateDevice(void)
 {
     SDL_VideoDevice *device;
@@ -161,27 +171,6 @@ VideoBootStrap Android_bootstrap = {
     false
 };
 
-// Input is part of video for Android, so this goes here.
-static void SDLCALL Android_Video_InternalHintCallback(
-    void *userdata,
-    const char *name,
-    const char *oldvalue,
-    const char *newvalue)
-{
-    if (SDL_strcmp(name, SDL_HINT_ANDROID_TRAP_BACK_BUTTON) != 0) {
-        return;
-    }
-
-    bool oldbool = SDL_GetStringBoolean(oldvalue, false);
-    bool newbool = SDL_GetStringBoolean(newvalue, false);
-
-    if (oldbool == newbool) {
-        return;
-    }
-
-    Android_JNI_SetBackButtonTrapActive(newbool);
-}
-
 bool Android_VideoInit(SDL_VideoDevice *_this)
 {
     SDL_VideoData *videodata = _this->internal;
@@ -207,11 +196,13 @@ bool Android_VideoInit(SDL_VideoDevice *_this)
     display->current_orientation = Android_JNI_GetDisplayCurrentOrientation();
     display->content_scale = Android_ScreenDensity;
 
+    if (!SDL_AddHintCallback(SDL_HINT_ANDROID_TRAP_BACK_BUTTON, Android_Video_InternalHintCallback, 0)) {
+        SDL_Log("Error: could not add SDL_HINT_ANDROID_TRAP_BACK_BUTTON callback! Back button behavior will be handled by the system.");
+    }
+
     Android_InitTouch();
 
     Android_InitMouse();
-
-    SDL_AddHintCallback(SDL_HINT_ANDROID_TRAP_BACK_BUTTON, Android_Video_InternalHintCallback, 0);
 
     // We're done!
     return true;
@@ -219,6 +210,7 @@ bool Android_VideoInit(SDL_VideoDevice *_this)
 
 void Android_VideoQuit(SDL_VideoDevice *_this)
 {
+    SDL_RemoveHintCallback(SDL_HINT_ANDROID_TRAP_BACK_BUTTON, Android_Video_InternalHintCallback, 0);
     Android_QuitMouse();
     Android_QuitTouch();
 }

--- a/src/video/android/SDL_androidvideo.c
+++ b/src/video/android/SDL_androidvideo.c
@@ -28,6 +28,7 @@
 #include "../SDL_pixels_c.h"
 #include "../../events/SDL_events_c.h"
 #include "../../events/SDL_windowevents_c.h"
+#include "../../SDL_hints_c.h"
 
 #include "SDL_androidvideo.h"
 #include "SDL_androidgl.h"
@@ -160,6 +161,27 @@ VideoBootStrap Android_bootstrap = {
     false
 };
 
+// Input is part of video for Android, so this goes here.
+static void SDLCALL Android_Video_InternalHintCallback(
+    void *userdata,
+    const char *name,
+    const char *oldvalue,
+    const char *newvalue)
+{
+    if (SDL_strcmp(name, SDL_HINT_ANDROID_TRAP_BACK_BUTTON) != 0) {
+        return;
+    }
+
+    bool oldbool = SDL_GetStringBoolean(oldvalue, false);
+    bool newbool = SDL_GetStringBoolean(newvalue, false);
+
+    if (oldbool == newbool) {
+        return;
+    }
+
+    Android_JNI_SetBackButtonTrapActive(newbool);
+}
+
 bool Android_VideoInit(SDL_VideoDevice *_this)
 {
     SDL_VideoData *videodata = _this->internal;
@@ -188,6 +210,8 @@ bool Android_VideoInit(SDL_VideoDevice *_this)
     Android_InitTouch();
 
     Android_InitMouse();
+
+    SDL_AddHintCallback(SDL_HINT_ANDROID_TRAP_BACK_BUTTON, Android_Video_InternalHintCallback, 0);
 
     // We're done!
     return true;

--- a/src/video/android/SDL_androidvideo.c
+++ b/src/video/android/SDL_androidvideo.c
@@ -196,9 +196,7 @@ bool Android_VideoInit(SDL_VideoDevice *_this)
     display->current_orientation = Android_JNI_GetDisplayCurrentOrientation();
     display->content_scale = Android_ScreenDensity;
 
-    if (!SDL_AddHintCallback(SDL_HINT_ANDROID_TRAP_BACK_BUTTON, Android_Video_InternalHintCallback, 0)) {
-        SDL_Log("Error: could not add SDL_HINT_ANDROID_TRAP_BACK_BUTTON callback! Back button behavior will be handled by the system.");
-    }
+    SDL_AddHintCallback(SDL_HINT_ANDROID_TRAP_BACK_BUTTON, Android_Video_InternalHintCallback, 0);
 
     Android_InitTouch();
 


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
The old "disable the OnBackInvokedCallback" method of retaining `onBackPressed()` no longer works on some modern versions of Android. To avoid problematic situations with that in conjunction with `SDL_HINT_ANDROID_ALLOW_RECREATE_ACTIVITY`, this now allows the behavior to remain intact, so that `SDL_HINT_ANDROID_TRAP_BACK_BUTTON` will still function.