### PR TITLE
wayland: Fix maximized check when setting the window size

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -3296,7 +3296,7 @@ void Wayland_SetWindowSize(SDL_VideoDevice *_this, SDL_Window *window)
      */
     FlushPendingEvents(window);
 
-    const bool resizable_state = !(window->flags & (SDL_WINDOW_MAXIMIZED || SDL_WINDOW_FULLSCREEN));
+    const bool resizable_state = !(window->flags & (SDL_WINDOW_MAXIMIZED | SDL_WINDOW_FULLSCREEN));
 
     /* Maximized and fullscreen windows don't get resized, and the new size is ignored
      * if this is just to recalculate the min/max or aspect limits on a tiled window.


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").


## Description

`Wayland_SetWindowSize` computes `resizable_state` with a logical OR inside the flag mask:

```c
const bool resizable_state = !(window->flags & (SDL_WINDOW_MAXIMIZED || SDL_WINDOW_FULLSCREEN));
```

`SDL_WINDOW_MAXIMIZED || SDL_WINDOW_FULLSCREEN` evaluates to `1`, so the mask only checks `SDL_WINDOW_FULLSCREEN` (`0x1`) and the maximized bit (`0x80`) is dropped. A maximized, non-fullscreen window is then treated as resizable, so a programmatic size change overwrites the requested dimensions and commits a size that differs from the maximized configure.

Fixed by changing the `||` to a bitwise `|` so both flags are masked.

## Existing Issue(s)

None.