### PR TITLE
iOS: honor SDL_HINT_MAIN_CALLBACK_RATE via CADisplayLink

### DIFF
--- a/src/main/ios/SDL_sysmain_callbacks.m
+++ b/src/main/ios/SDL_sysmain_callbacks.m
@@ -37,6 +37,19 @@
 
 static SDLIosMainCallbacksDisplayLink *globalDisplayLink;
 
+static void SDLCALL MainCallbackRateHintChanged(void *userdata, const char *name, const char *oldValue, const char *newValue)
+{
+    CADisplayLink *displayLink = (__bridge CADisplayLink *)userdata;
+    const float rate = newValue ? (float)SDL_atof(newValue) : 0.0f;
+    if (rate > 0.0f) {
+        if (@available(iOS 15.0, tvOS 15.0, *)) {
+            displayLink.preferredFrameRateRange = CAFrameRateRangeMake((rate * 2) / 3, rate, rate);
+        } else {
+            displayLink.preferredFramesPerSecond = (NSInteger)rate;
+        }
+    }
+}
+
 @implementation SDLIosMainCallbacksDisplayLink
 
 - (instancetype)init:(SDL_AppIterate_func)_appiter quitfunc:(SDL_AppQuit_func)_appquit;
@@ -83,6 +96,7 @@ int SDL_EnterAppMainCallbacks(int argc, char *argv[], SDL_AppInit_func appinit, 
         if (globalDisplayLink == nil) {
             rc = SDL_APP_FAILURE;
         } else {
+            SDL_AddHintCallback(SDL_HINT_MAIN_CALLBACK_RATE, MainCallbackRateHintChanged, (__bridge void *)globalDisplayLink.displayLink);
             return 0;  // this will fall all the way out of SDL_main, where UIApplicationMain will keep running the RunLoop.
         }
     }
@@ -95,5 +109,6 @@ int SDL_EnterAppMainCallbacks(int argc, char *argv[], SDL_AppInit_func appinit, 
 }
 
 #endif
+
 
 

--- a/src/main/ios/SDL_sysmain_callbacks.m
+++ b/src/main/ios/SDL_sysmain_callbacks.m
@@ -111,4 +111,3 @@ int SDL_EnterAppMainCallbacks(int argc, char *argv[], SDL_AppInit_func appinit, 
 #endif
 
 
-


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description

On iOS, main callbacks are driven by a `CADisplayLink`, so `SDL_HINT_MAIN_CALLBACK_RATE` was ignored (unlike the generic path, which paces with `SDL_DelayPrecise`).

This change registers an `SDL_AddHintCallback` for `SDL_HINT_MAIN_CALLBACK_RATE` and, when a positive rate is set, applies it to the display link:

- iOS 15+ / tvOS 15+: `preferredFrameRateRange` via `CAFrameRateRangeMake((rate * 2) / 3, rate, rate)`
- older OS versions: `preferredFramesPerSecond`

Default behavior is unchanged when the hint is unset or `"0"` (including the existing ProMotion high-refresh setup). The hint can still be changed at runtime.

Note: the system may still choose a nearby supported frame rate (e.g. divisors of 60/120 Hz), as with other `CADisplayLink` preferences.

## Existing Issue(s)

Fixes #15277