### PR TITLE
ci: write the commit message from env instead of through an expanding heredoc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,13 +38,12 @@ jobs:
           sparse-checkout: '.github/workflows/create-test-plan.py'
       - name: 'Create plan'
         id: plan
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           # Adding [sdl-ci-filter GLOB] to the commit message will limit the jobs
           # e.g. [sdl-ci-filter msvc-*]
-          EOF=$(openssl rand -hex 32)
-          cat >/tmp/commit_message.txt <<$EOF
-          ${{ github.event.head_commit.message }}
-          $EOF
+          printf '%s\n' "$COMMIT_MESSAGE" >/tmp/commit_message.txt
 
           python .github/workflows/create-test-plan.py \
             ${{ (github.event_name != 'schedule' && '--priority-only') || '' }} \


### PR DESCRIPTION
Hi, and thanks for SDL.

In `.github/workflows/build.yml`, the "Create plan" step writes the commit message to a file via a heredoc:

```yaml
run: |
  EOF=$(openssl rand -hex 32)
  cat >/tmp/commit_message.txt <<$EOF
  ${{ github.event.head_commit.message }}
  $EOF
```

The random delimiter is a thoughtful touch and it does close the obvious hole — a commit message cannot terminate the heredoc early, because it cannot guess 32 random hex characters. What it does not close is command substitution: the delimiter word `$EOF` is unquoted, so bash still performs expansion on the heredoc body, and `${{ ... }}` has already been spliced into the script text by Actions before bash reads any of it. A commit message containing `$(...)` or backticks therefore runs rather than being written to the file.

This PR replaces the heredoc with a `printf` that reads the message from the environment:

```yaml
env:
  COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
run: |
  printf '%s\n' "$COMMIT_MESSAGE" >/tmp/commit_message.txt
```

That removes the need for the random delimiter altogether — nothing in the message is ever part of the script — and `/tmp/commit_message.txt` still receives the message verbatim, so `create-test-plan.py --commit-message-file` and the `[sdl-ci-filter GLOB]` handling behave exactly as before. Multi-line messages are preserved.

I left the other `${{ }}` uses in the step alone: `github.event_name` and `github.repository_owner` are GitHub-controlled values being used to pick fixed flag strings, so they do not have this problem.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the step and the plan script's interface myself.
