### PR TITLE
[SDL2] emscripten: add main thread proxy for getting audio frequency in EMSCRIPTENAUDIO_OpenDevice

### DIFF
--- a/src/audio/emscripten/SDL_emscriptenaudio.c
+++ b/src/audio/emscripten/SDL_emscriptenaudio.c
@@ -270,7 +270,7 @@ static int EMSCRIPTENAUDIO_OpenDevice(_THIS, const char *devname)
     this->hidden = (struct SDL_PrivateAudioData *)0x1;
 
     /* limit to native freq */
-    this->spec.freq = EM_ASM_INT({
+    this->spec.freq = MAIN_THREAD_EM_ASM_INT({
       var SDL2 = Module['SDL2'];
       return SDL2.audioContext.sampleRate;
     });


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description

The rest of the calls were updated in aec86ba8bb68d8bf5262cd11c3573b7e318bf749 but one was missed

SDL3 was similarly fixed in 168d1a9253244f9dd1fdc771a362fee9e27aa22d

Ported our engine to emscripten (64 bit, pthread, thread proxying), this change allowed audio to work