### PR TITLE
Wayland clipboard cleanup

### DIFF
--- a/src/video/wayland/SDL_waylandclipboard.c
+++ b/src/video/wayland/SDL_waylandclipboard.c
@@ -28,7 +28,6 @@
 #include "../SDL_clipboard_c.h"
 #include "../../events/SDL_events_c.h"
 
-
 bool Wayland_SetClipboardData(SDL_VideoDevice *_this)
 {
     SDL_VideoData *video_data = _this->internal;
@@ -46,15 +45,15 @@ bool Wayland_SetClipboardData(SDL_VideoDevice *_this)
         SDL_WaylandDataDevice *data_device = seat->data_device;
 
         if (_this->clipboard_callback && _this->clipboard_mime_types) {
-            SDL_WaylandDataSource *source = Wayland_data_source_create(video_data);
-            Wayland_data_source_set_callback(source, _this->clipboard_callback, _this->clipboard_userdata, _this->clipboard_sequence);
+            SDL_WaylandDataSource *source = Wayland_DataSourceCreate(video_data);
+            Wayland_DataSourceSetCallback(source, _this->clipboard_callback, _this->clipboard_userdata, _this->clipboard_sequence);
 
-            result = Wayland_data_device_set_selection(data_device, source, (const char **)_this->clipboard_mime_types, _this->num_clipboard_mime_types);
+            result = Wayland_DataDeviceSetSelection(data_device, source, (const char **)_this->clipboard_mime_types, _this->num_clipboard_mime_types);
             if (!result) {
-                Wayland_data_source_destroy(source);
+                Wayland_DataSourceDestroy(source);
             }
         } else {
-            result = Wayland_data_device_clear_selection(data_device);
+            result = Wayland_DataDeviceClearSelection(data_device);
         }
     }
 
@@ -71,8 +70,8 @@ void *Wayland_GetClipboardData(SDL_VideoDevice *_this, const char *mime_type, si
         SDL_WaylandDataDevice *data_device = seat->data_device;
         if (data_device->selection_source) {
             buffer = SDL_GetInternalClipboardData(_this, mime_type, length);
-        } else if (Wayland_data_offer_has_mime(data_device->selection_offer, mime_type)) {
-            buffer = Wayland_data_offer_receive(data_device->selection_offer, mime_type, length, true);
+        } else if (Wayland_DataOfferHasMIME(data_device->selection_offer, mime_type)) {
+            buffer = Wayland_DataOfferReceive(data_device->selection_offer, mime_type, length, true);
         }
     }
 
@@ -90,7 +89,7 @@ bool Wayland_HasClipboardData(SDL_VideoDevice *_this, const char *mime_type)
         if (data_device->selection_source) {
             result = SDL_HasInternalClipboardData(_this, mime_type);
         } else {
-            result = Wayland_data_offer_has_mime(data_device->selection_offer, mime_type);
+            result = Wayland_DataOfferHasMIME(data_device->selection_offer, mime_type);
         }
     }
     return result;
@@ -126,18 +125,15 @@ bool Wayland_SetPrimarySelectionText(SDL_VideoDevice *_this, const char *text)
     if (seat && seat->primary_selection_device) {
         SDL_WaylandPrimarySelectionDevice *primary_selection_device = seat->primary_selection_device;
         if (text[0] != '\0') {
-            SDL_WaylandPrimarySelectionSource *source = Wayland_primary_selection_source_create(video_data);
-            Wayland_primary_selection_source_set_callback(source, SDL_ClipboardTextCallback, SDL_strdup(text));
+            SDL_WaylandPrimarySelectionSource *source = Wayland_PrimarySelectionSourceCreate(video_data);
+            Wayland_PrimarySelectionSourceSetCallback(source, SDL_ClipboardTextCallback, SDL_strdup(text));
 
-            result = Wayland_primary_selection_device_set_selection(primary_selection_device,
-                                                                    source,
-                                                                    text_mime_types,
-                                                                    SDL_arraysize(text_mime_types));
+            result = Wayland_PrimarySelectionDeviceSetSelection(primary_selection_device, source, text_mime_types, SDL_arraysize(text_mime_types));
             if (!result) {
-                Wayland_primary_selection_source_destroy(source);
+                Wayland_PrimarySelectionSourceDestroy(source);
             }
         } else {
-            result = Wayland_primary_selection_device_clear_selection(primary_selection_device);
+            result = Wayland_PrimarySelectionDeviceClearSelection(primary_selection_device);
         }
     } else {
         result = SDL_SetError("Primary selection not supported");
@@ -155,11 +151,11 @@ char *Wayland_GetPrimarySelectionText(SDL_VideoDevice *_this)
     if (seat && seat->primary_selection_device) {
         SDL_WaylandPrimarySelectionDevice *primary_selection_device = seat->primary_selection_device;
         if (primary_selection_device->selection_source) {
-            text = Wayland_primary_selection_source_get_data(primary_selection_device->selection_source, TEXT_MIME, &length);
+            text = Wayland_PrimarySelectionSourceGetData(primary_selection_device->selection_source, TEXT_MIME, &length);
         } else {
             for (size_t i = 0; i < SDL_arraysize(text_mime_types); i++) {
-                if (Wayland_primary_selection_offer_has_mime(primary_selection_device->selection_offer, text_mime_types[i])) {
-                    text = Wayland_primary_selection_offer_receive(primary_selection_device->selection_offer, text_mime_types[i], &length);
+                if (Wayland_PrimarySelectionOfferHasMIME(primary_selection_device->selection_offer, text_mime_types[i])) {
+                    text = Wayland_PrimarySelectionOfferReceive(primary_selection_device->selection_offer, text_mime_types[i], &length);
                     break;
                 }
             }
@@ -187,7 +183,7 @@ bool Wayland_HasPrimarySelectionText(SDL_VideoDevice *_this)
             size_t mime_count = 0;
             const char *const *mime_types = Wayland_GetTextMimeTypes(_this, &mime_count);
             for (size_t i = 0; i < mime_count; i++) {
-                if (Wayland_primary_selection_offer_has_mime(primary_selection_device->selection_offer, mime_types[i])) {
+                if (Wayland_PrimarySelectionOfferHasMIME(primary_selection_device->selection_offer, mime_types[i])) {
                     result = true;
                     break;
                 }

--- a/src/video/wayland/SDL_waylandclipboard.c
+++ b/src/video/wayland/SDL_waylandclipboard.c
@@ -39,9 +39,26 @@ bool Wayland_SetClipboardData(SDL_VideoDevice *_this)
         seat = wl_container_of(video_data->seat_list.next, seat, link);
     }
 
-    video_data->last_incoming_data_offer_seat = seat;
+    video_data->current_data_offer_seat = seat;
 
     if (seat && seat->data_device) {
+        /* Clear references to the clipboard held by other seats, as they are about to become invalid.
+         * For the target seat, the new source data is set before clearing the old source, as some
+         * clipboard managers prefer this behavior.
+         */
+        SDL_WaylandSeat *s;
+        wl_list_for_each (s, &video_data->seat_list, link) {
+            if (s->data_device) {
+                if (s != seat) {
+                    Wayland_DataSourceDestroy(s->data_device->selection_source);
+                    s->data_device->selection_source = NULL;
+                }
+
+                Wayland_DataOfferDestroy(s->data_device->selection_offer);
+                s->data_device->selection_offer = NULL;
+            }
+        }
+
         SDL_WaylandDataDevice *data_device = seat->data_device;
 
         if (_this->clipboard_callback && _this->clipboard_mime_types) {
@@ -65,7 +82,7 @@ bool Wayland_SetClipboardData(SDL_VideoDevice *_this)
 void *Wayland_GetClipboardData(SDL_VideoDevice *_this, const char *mime_type, size_t *length)
 {
     SDL_VideoData *video_data = _this->internal;
-    SDL_WaylandSeat *seat = video_data->last_incoming_data_offer_seat;
+    SDL_WaylandSeat *seat = video_data->current_data_offer_seat;
     void *buffer = NULL;
 
     if (seat && seat->data_device) {
@@ -83,7 +100,7 @@ void *Wayland_GetClipboardData(SDL_VideoDevice *_this, const char *mime_type, si
 bool Wayland_HasClipboardData(SDL_VideoDevice *_this, const char *mime_type)
 {
     SDL_VideoData *video_data = _this->internal;
-    SDL_WaylandSeat *seat = video_data->last_incoming_data_offer_seat;
+    SDL_WaylandSeat *seat = video_data->current_data_offer_seat;
     bool result = false;
 
     if (seat && seat->data_device) {
@@ -122,7 +139,7 @@ bool Wayland_SetPrimarySelectionText(SDL_VideoDevice *_this, const char *text)
         seat = wl_container_of(video_data->seat_list.next, seat, link);
     }
 
-    video_data->last_incoming_primary_selection_seat = seat;
+    video_data->current_primary_selection_seat = seat;
 
     if (seat && seat->primary_selection_device) {
         SDL_WaylandPrimarySelectionDevice *primary_selection_device = seat->primary_selection_device;
@@ -148,7 +165,7 @@ bool Wayland_SetPrimarySelectionText(SDL_VideoDevice *_this, const char *text)
 char *Wayland_GetPrimarySelectionText(SDL_VideoDevice *_this)
 {
     SDL_VideoData *video_data = _this->internal;
-    SDL_WaylandSeat *seat = video_data->last_incoming_primary_selection_seat;
+    SDL_WaylandSeat *seat = video_data->current_primary_selection_seat;
     char *text = NULL;
     size_t length = 0;
 
@@ -176,7 +193,7 @@ char *Wayland_GetPrimarySelectionText(SDL_VideoDevice *_this)
 bool Wayland_HasPrimarySelectionText(SDL_VideoDevice *_this)
 {
     SDL_VideoData *video_data = _this->internal;
-    SDL_WaylandSeat *seat = video_data->last_incoming_primary_selection_seat;
+    SDL_WaylandSeat *seat = video_data->current_primary_selection_seat;
     bool result = false;
 
     if (seat && seat->primary_selection_device) {

--- a/src/video/wayland/SDL_waylandclipboard.c
+++ b/src/video/wayland/SDL_waylandclipboard.c
@@ -53,7 +53,9 @@ bool Wayland_SetClipboardData(SDL_VideoDevice *_this)
                 Wayland_DataSourceDestroy(source);
             }
         } else {
-            result = Wayland_DataDeviceClearSelection(data_device);
+            Wayland_DataSourceDestroy(data_device->selection_source);
+            data_device->selection_source = NULL;
+            result = true;
         }
     }
 
@@ -133,7 +135,9 @@ bool Wayland_SetPrimarySelectionText(SDL_VideoDevice *_this, const char *text)
                 Wayland_PrimarySelectionSourceDestroy(source);
             }
         } else {
-            result = Wayland_PrimarySelectionDeviceClearSelection(primary_selection_device);
+            Wayland_PrimarySelectionSourceDestroy(seat->primary_selection_device->selection_source);
+            seat->primary_selection_device->selection_source = NULL;
+            result = true;
         }
     } else {
         result = SDL_SetError("Primary selection not supported");

--- a/src/video/wayland/SDL_waylandclipboard.c
+++ b/src/video/wayland/SDL_waylandclipboard.c
@@ -46,7 +46,7 @@ bool Wayland_SetClipboardData(SDL_VideoDevice *_this)
         SDL_WaylandDataDevice *data_device = seat->data_device;
 
         if (_this->clipboard_callback && _this->clipboard_mime_types) {
-            SDL_WaylandDataSource *source = Wayland_data_source_create(_this);
+            SDL_WaylandDataSource *source = Wayland_data_source_create(video_data);
             Wayland_data_source_set_callback(source, _this->clipboard_callback, _this->clipboard_userdata, _this->clipboard_sequence);
 
             result = Wayland_data_device_set_selection(data_device, source, (const char **)_this->clipboard_mime_types, _this->num_clipboard_mime_types);
@@ -126,7 +126,7 @@ bool Wayland_SetPrimarySelectionText(SDL_VideoDevice *_this, const char *text)
     if (seat && seat->primary_selection_device) {
         SDL_WaylandPrimarySelectionDevice *primary_selection_device = seat->primary_selection_device;
         if (text[0] != '\0') {
-            SDL_WaylandPrimarySelectionSource *source = Wayland_primary_selection_source_create(_this);
+            SDL_WaylandPrimarySelectionSource *source = Wayland_primary_selection_source_create(video_data);
             Wayland_primary_selection_source_set_callback(source, SDL_ClipboardTextCallback, SDL_strdup(text));
 
             result = Wayland_primary_selection_device_set_selection(primary_selection_device,

--- a/src/video/wayland/SDL_waylanddatamanager.c
+++ b/src/video/wayland/SDL_waylanddatamanager.c
@@ -620,35 +620,6 @@ void Wayland_PrimarySelectionOfferDestroy(SDL_WaylandPrimarySelectionOffer *offe
     }
 }
 
-bool Wayland_DataDeviceClearSelection(SDL_WaylandDataDevice *data_device)
-{
-    if (!data_device || !data_device->data_device) {
-        return SDL_SetError("Invalid Data Device");
-    }
-
-    if (data_device->selection_source) {
-        wl_data_device_set_selection(data_device->data_device, NULL, data_device->seat->last_implicit_grab_serial);
-        Wayland_DataSourceDestroy(data_device->selection_source);
-        data_device->selection_source = NULL;
-    }
-    return true;
-}
-
-bool Wayland_PrimarySelectionDeviceClearSelection(SDL_WaylandPrimarySelectionDevice *primary_selection_device)
-{
-    if (!primary_selection_device || !primary_selection_device->primary_selection_device) {
-        return SDL_SetError("Invalid Primary Selection Device");
-    }
-
-    if (primary_selection_device->selection_source) {
-        zwp_primary_selection_device_v1_set_selection(primary_selection_device->primary_selection_device,
-                                                      NULL, primary_selection_device->seat->last_implicit_grab_serial);
-        Wayland_PrimarySelectionSourceDestroy(primary_selection_device->selection_source);
-        primary_selection_device->selection_source = NULL;
-    }
-    return true;
-}
-
 bool Wayland_DataDeviceSetSelection(SDL_WaylandDataDevice *data_device, SDL_WaylandDataSource *source, const char **mime_types, size_t mime_count)
 {
     if (!data_device) {
@@ -678,7 +649,8 @@ bool Wayland_DataDeviceSetSelection(SDL_WaylandDataDevice *data_device, SDL_Wayl
         source->data_device = data_device;
 
     } else {
-        Wayland_DataDeviceClearSelection(data_device);
+        Wayland_DataSourceDestroy(data_device->selection_source);
+        data_device->selection_source = NULL;
         return SDL_SetError("No mime data");
     }
 
@@ -714,7 +686,8 @@ bool Wayland_PrimarySelectionDeviceSetSelection(SDL_WaylandPrimarySelectionDevic
         primary_selection_device->selection_source = source;
         source->primary_selection_device = primary_selection_device;
     } else {
-        Wayland_PrimarySelectionDeviceClearSelection(primary_selection_device);
+        Wayland_PrimarySelectionSourceDestroy(primary_selection_device->selection_source);
+        primary_selection_device->selection_source = NULL;
         return SDL_SetError("No mime data");
     }
 

--- a/src/video/wayland/SDL_waylanddatamanager.c
+++ b/src/video/wayland/SDL_waylanddatamanager.c
@@ -446,6 +446,29 @@ static void DataOfferCheckSource(SDL_WaylandDataOffer *offer, const char *mime_t
     }
 }
 
+static void SetCurrentClipboardOffer(SDL_WaylandDataOffer *offer)
+{
+    SDL_WaylandSeat *offer_seat = offer->data_device->seat;
+    SDL_VideoData *video_data = offer_seat->display;
+
+    // Clear any existing references to the existing clipboard data before replacing the current offer.
+    SDL_WaylandSeat *s;
+    wl_list_for_each (s, &video_data->seat_list, link) {
+        if (s->data_device) {
+            Wayland_DataSourceDestroy(s->data_device->selection_source);
+            s->data_device->selection_source = NULL;
+
+            // Don't clear the offer that is about to be set.
+            if (s != offer_seat) {
+                Wayland_DataOfferDestroy(s->data_device->selection_offer);
+                s->data_device->selection_offer = NULL;
+            }
+        }
+    }
+
+    video_data->current_data_offer_seat = offer_seat;
+}
+
 void Wayland_DataOfferNotifyFromMIMEs(SDL_WaylandDataOffer *offer, bool check_origin)
 {
     int nformats = 0;
@@ -494,6 +517,7 @@ void Wayland_DataOfferNotifyFromMIMEs(SDL_WaylandDataOffer *offer, bool check_or
         new_mime_types[nformats] = NULL;
     }
 
+    SetCurrentClipboardOffer(offer);
     SDL_SendClipboardUpdate(false, new_mime_types, nformats);
 }
 
@@ -697,26 +721,26 @@ bool Wayland_PrimarySelectionDeviceSetSelection(SDL_WaylandPrimarySelectionDevic
 void Wayland_DataDeviceSetSerial(SDL_WaylandDataDevice *data_device, uint32_t serial)
 {
     if (data_device) {
-        data_device->selection_serial = serial;
-
-        // If there was no serial and there is a pending selection set it now.
+        // If there was no serial and there is a pending selection, set it now.
         if (data_device->selection_serial == 0 && data_device->selection_source) {
-            wl_data_device_set_selection(data_device->data_device, data_device->selection_source->source, data_device->selection_serial);
+            wl_data_device_set_selection(data_device->data_device, data_device->selection_source->source, serial);
         }
+
+        data_device->selection_serial = serial;
     }
 }
 
 void Wayland_PrimarySelectionDeviceSetSerial(SDL_WaylandPrimarySelectionDevice *primary_selection_device, uint32_t serial)
 {
     if (primary_selection_device) {
-        primary_selection_device->selection_serial = serial;
-
-        // If there was no serial and there is a pending selection set it now.
+        // If there was no serial and there is a pending selection, set it now.
         if (primary_selection_device->selection_serial == 0 && primary_selection_device->selection_source) {
             zwp_primary_selection_device_v1_set_selection(primary_selection_device->primary_selection_device,
                                                           primary_selection_device->selection_source->source,
-                                                          primary_selection_device->selection_serial);
+                                                          serial);
         }
+
+        primary_selection_device->selection_serial = serial;
     }
 }
 

--- a/src/video/wayland/SDL_waylanddatamanager.c
+++ b/src/video/wayland/SDL_waylanddatamanager.c
@@ -88,7 +88,7 @@ static int sigtimedwait(const sigset_t *set, siginfo_t *info, const struct times
 }
 #endif
 
-static ssize_t write_pipe(int fd, const void *buffer, size_t total_length, size_t *pos)
+static ssize_t WritePipe(int fd, const void *buffer, size_t total_length, size_t *pos)
 {
     ssize_t bytes_written = 0;
     const ssize_t length = total_length - *pos;
@@ -133,7 +133,7 @@ static ssize_t write_pipe(int fd, const void *buffer, size_t total_length, size_
     return bytes_written;
 }
 
-static ssize_t read_pipe(int fd, void **buffer, size_t *total_length, Sint64 timeout_ns)
+static ssize_t ReadPipe(int fd, void **buffer, size_t *total_length, Sint64 timeout_ns)
 {
     void *output_buffer = NULL;
     char temp[PIPE_BUF];
@@ -174,8 +174,7 @@ static ssize_t read_pipe(int fd, void **buffer, size_t *total_length, Sint64 tim
     return bytes_read;
 }
 
-static SDL_MimeDataList *mime_data_list_find(struct wl_list *list,
-                                             const char *mime_type)
+static SDL_MimeDataList *MIMEDataListFind(struct wl_list *list, const char *mime_type)
 {
     SDL_MimeDataList *found = NULL;
 
@@ -193,9 +192,7 @@ static SDL_MimeDataList *mime_data_list_find(struct wl_list *list,
     return found;
 }
 
-static bool mime_data_list_add(struct wl_list *list,
-                               const char *mime_type,
-                               const void *buffer, size_t length)
+static bool MIMEDataListAdd(struct wl_list *list, const char *mime_type, const void *buffer, size_t length)
 {
     bool result = true;
     void *internal_buffer = NULL;
@@ -208,7 +205,7 @@ static bool mime_data_list_add(struct wl_list *list,
         SDL_memcpy(internal_buffer, buffer, length);
     }
 
-    SDL_MimeDataList *mime_data = mime_data_list_find(list, mime_type);
+    SDL_MimeDataList *mime_data = MIMEDataListFind(list, mime_type);
 
     if (!mime_data) {
         mime_data = SDL_calloc(1, sizeof(*mime_data));
@@ -238,7 +235,7 @@ static bool mime_data_list_add(struct wl_list *list,
     return result;
 }
 
-static void mime_data_list_free(struct wl_list *list)
+static void MIMEDataListFree(struct wl_list *list)
 {
     SDL_MimeDataList *mime_data = NULL;
     SDL_MimeDataList *next = NULL;
@@ -250,12 +247,12 @@ static void mime_data_list_free(struct wl_list *list)
     }
 }
 
-static size_t Wayland_send_data(const void *data, size_t length, int fd)
+static size_t SendData(const void *data, size_t length, int fd)
 {
     size_t result = 0;
 
     if (length > 0 && data) {
-        while (write_pipe(fd, data, length, &result) > 0) {
+        while (WritePipe(fd, data, length, &result) > 0) {
             // Just keep spinning
         }
     }
@@ -264,7 +261,7 @@ static size_t Wayland_send_data(const void *data, size_t length, int fd)
     return result;
 }
 
-ssize_t Wayland_data_source_send(SDL_WaylandDataSource *source, const char *mime_type, int fd)
+ssize_t Wayland_DataSourceSend(SDL_WaylandDataSource *source, const char *mime_type, int fd)
 {
     const void *data = NULL;
     size_t length = 0;
@@ -276,10 +273,10 @@ ssize_t Wayland_data_source_send(SDL_WaylandDataSource *source, const char *mime
         data = source->callback(source->userdata.data, mime_type, &length);
     }
 
-    return Wayland_send_data(data, length, fd);
+    return SendData(data, length, fd);
 }
 
-ssize_t Wayland_primary_selection_source_send(SDL_WaylandPrimarySelectionSource *source, const char *mime_type, int fd)
+ssize_t Wayland_PrimarySelectionSourceSend(SDL_WaylandPrimarySelectionSource *source, const char *mime_type, int fd)
 {
     const void *data = NULL;
     size_t length = 0;
@@ -288,13 +285,10 @@ ssize_t Wayland_primary_selection_source_send(SDL_WaylandPrimarySelectionSource 
         data = source->callback(source->userdata.data, mime_type, &length);
     }
 
-    return Wayland_send_data(data, length, fd);
+    return SendData(data, length, fd);
 }
 
-void Wayland_data_source_set_callback(SDL_WaylandDataSource *source,
-                                      SDL_ClipboardDataCallback callback,
-                                      void *userdata,
-                                      Uint32 sequence)
+void Wayland_DataSourceSetCallback(SDL_WaylandDataSource *source, SDL_ClipboardDataCallback callback, void *userdata, Uint32 sequence)
 {
     if (source) {
         source->callback = callback;
@@ -303,9 +297,7 @@ void Wayland_data_source_set_callback(SDL_WaylandDataSource *source,
     }
 }
 
-void Wayland_primary_selection_source_set_callback(SDL_WaylandPrimarySelectionSource *source,
-                                                   SDL_ClipboardDataCallback callback,
-                                                   void *userdata)
+void Wayland_PrimarySelectionSourceSetCallback(SDL_WaylandPrimarySelectionSource *source, SDL_ClipboardDataCallback callback, void *userdata)
 {
     if (source) {
         source->callback = callback;
@@ -314,7 +306,7 @@ void Wayland_primary_selection_source_set_callback(SDL_WaylandPrimarySelectionSo
     }
 }
 
-static void *Wayland_clone_data_buffer(const void *buffer, const size_t *len)
+static void *CloneDataBuffer(const void *buffer, const size_t *len)
 {
     void *clone = NULL;
     if (*len > 0 && buffer) {
@@ -327,8 +319,7 @@ static void *Wayland_clone_data_buffer(const void *buffer, const size_t *len)
     return clone;
 }
 
-void *Wayland_data_source_get_data(SDL_WaylandDataSource *source,
-                                   const char *mime_type, size_t *length)
+void *Wayland_DataSourceGetData(SDL_WaylandDataSource *source, const char *mime_type, size_t *length)
 {
     void *buffer = NULL;
     *length = 0;
@@ -337,14 +328,13 @@ void *Wayland_data_source_get_data(SDL_WaylandDataSource *source,
         SDL_SetError("Invalid data source");
     } else if (source->callback) {
         const void *internal_buffer = source->callback(source->userdata.data, mime_type, length);
-        buffer = Wayland_clone_data_buffer(internal_buffer, length);
+        buffer = CloneDataBuffer(internal_buffer, length);
     }
 
     return buffer;
 }
 
-void *Wayland_primary_selection_source_get_data(SDL_WaylandPrimarySelectionSource *source,
-                                                const char *mime_type, size_t *length)
+void *Wayland_PrimarySelectionSourceGetData(SDL_WaylandPrimarySelectionSource *source, const char *mime_type, size_t *length)
 {
     void *buffer = NULL;
     *length = 0;
@@ -353,13 +343,13 @@ void *Wayland_primary_selection_source_get_data(SDL_WaylandPrimarySelectionSourc
         SDL_SetError("Invalid primary selection source");
     } else if (source->callback) {
         const void *internal_buffer = source->callback(source->userdata.data, mime_type, length);
-        buffer = Wayland_clone_data_buffer(internal_buffer, length);
+        buffer = CloneDataBuffer(internal_buffer, length);
     }
 
     return buffer;
 }
 
-void Wayland_data_source_destroy(SDL_WaylandDataSource *source)
+void Wayland_DataSourceDestroy(SDL_WaylandDataSource *source)
 {
     if (source) {
         SDL_WaylandDataDevice *data_device = source->data_device;
@@ -376,7 +366,7 @@ void Wayland_data_source_destroy(SDL_WaylandDataSource *source)
     }
 }
 
-void Wayland_primary_selection_source_destroy(SDL_WaylandPrimarySelectionSource *source)
+void Wayland_PrimarySelectionSourceDestroy(SDL_WaylandPrimarySelectionSource *source)
 {
     if (source) {
         SDL_WaylandPrimarySelectionDevice *primary_selection_device = source->primary_selection_device;
@@ -404,7 +394,7 @@ static void offer_source_done_handler(void *data, struct wl_callback *callback, 
     wl_callback_destroy(offer->callback);
     offer->callback = NULL;
 
-    while (read_pipe(offer->read_fd, (void **)&id, &length, DEFAULT_PIPE_TIMEOUT_NS) > 0) {
+    while (ReadPipe(offer->read_fd, (void **)&id, &length, DEFAULT_PIPE_TIMEOUT_NS) > 0) {
     }
     close(offer->read_fd);
     offer->read_fd = -1;
@@ -413,11 +403,11 @@ static void offer_source_done_handler(void *data, struct wl_callback *callback, 
         const bool source_is_external = SDL_strncmp(offer->data_device->id_str, id, length) != 0;
         SDL_free(id);
         if (source_is_external) {
-            Wayland_data_offer_notify_from_mimes(offer, false);
+            Wayland_DataOfferNotifyFromMIMEs(offer, false);
         } else {
             // Recursive data offer; just destroy it.
             SDL_WaylandDataDevice *data_device = offer->data_device;
-            Wayland_data_offer_destroy(offer);
+            Wayland_DataOfferDestroy(offer);
             data_device->selection_offer = NULL;
         }
     }
@@ -427,7 +417,7 @@ static struct wl_callback_listener offer_source_listener = {
     offer_source_done_handler
 };
 
-static void Wayland_data_offer_check_source(SDL_WaylandDataOffer *offer, const char *mime_type)
+static void DataOfferCheckSource(SDL_WaylandDataOffer *offer, const char *mime_type)
 {
     int pipefd[2];
 
@@ -456,7 +446,7 @@ static void Wayland_data_offer_check_source(SDL_WaylandDataOffer *offer, const c
     }
 }
 
-void Wayland_data_offer_notify_from_mimes(SDL_WaylandDataOffer *offer, bool check_origin)
+void Wayland_DataOfferNotifyFromMIMEs(SDL_WaylandDataOffer *offer, bool check_origin)
 {
     int nformats = 0;
     char **new_mime_types = NULL;
@@ -472,7 +462,7 @@ void Wayland_data_offer_notify_from_mimes(SDL_WaylandDataOffer *offer, bool chec
 
             // If origin metadata is found, queue a check and wait for confirmation that this offer isn't recursive.
             if (check_origin && SDL_strcmp(item->mime_type, SDL_DATA_ORIGIN_MIME) == 0) {
-                Wayland_data_offer_check_source(offer, item->mime_type);
+                DataOfferCheckSource(offer, item->mime_type);
                 return;
             }
 
@@ -507,7 +497,7 @@ void Wayland_data_offer_notify_from_mimes(SDL_WaylandDataOffer *offer, bool chec
     SDL_SendClipboardUpdate(false, new_mime_types, nformats);
 }
 
-void *Wayland_data_offer_receive(SDL_WaylandDataOffer *offer, const char *mime_type, size_t *length, bool extended_timeout)
+void *Wayland_DataOfferReceive(SDL_WaylandDataOffer *offer, const char *mime_type, size_t *length, bool extended_timeout)
 {
     const Sint64 timeout = extended_timeout ? EXTENDED_PIPE_TIMEOUT_NS : DEFAULT_PIPE_TIMEOUT_NS;
 
@@ -528,7 +518,7 @@ void *Wayland_data_offer_receive(SDL_WaylandDataOffer *offer, const char *mime_t
 
         WAYLAND_wl_display_flush(data_device->seat->display->display);
 
-        while (read_pipe(pipefd[0], &buffer, length, timeout) > 0) {
+        while (ReadPipe(pipefd[0], &buffer, length, timeout) > 0) {
         }
         close(pipefd[0]);
     } else {
@@ -542,8 +532,7 @@ void *Wayland_data_offer_receive(SDL_WaylandDataOffer *offer, const char *mime_t
     return buffer;
 }
 
-void *Wayland_primary_selection_offer_receive(SDL_WaylandPrimarySelectionOffer *offer,
-                                              const char *mime_type, size_t *length)
+void *Wayland_PrimarySelectionOfferReceive(SDL_WaylandPrimarySelectionOffer *offer, const char *mime_type, size_t *length)
 {
     int pipefd[2];
     void *buffer = NULL;
@@ -562,7 +551,7 @@ void *Wayland_primary_selection_offer_receive(SDL_WaylandPrimarySelectionOffer *
 
         WAYLAND_wl_display_flush(primary_selection_device->seat->display->display);
 
-        while (read_pipe(pipefd[0], &buffer, length, EXTENDED_PIPE_TIMEOUT_NS) > 0) {
+        while (ReadPipe(pipefd[0], &buffer, length, EXTENDED_PIPE_TIMEOUT_NS) > 0) {
         }
         close(pipefd[0]);
 
@@ -577,41 +566,37 @@ void *Wayland_primary_selection_offer_receive(SDL_WaylandPrimarySelectionOffer *
     return buffer;
 }
 
-bool Wayland_data_offer_add_mime(SDL_WaylandDataOffer *offer,
-                                const char *mime_type)
+bool Wayland_DataOfferAddMIME(SDL_WaylandDataOffer *offer, const char *mime_type)
 {
-    return mime_data_list_add(&offer->mimes, mime_type, NULL, 0);
+    return MIMEDataListAdd(&offer->mimes, mime_type, NULL, 0);
 }
 
-bool Wayland_primary_selection_offer_add_mime(SDL_WaylandPrimarySelectionOffer *offer,
-                                             const char *mime_type)
+bool Wayland_PrimarySelectionOfferAddMIME(SDL_WaylandPrimarySelectionOffer *offer, const char *mime_type)
 {
-    return mime_data_list_add(&offer->mimes, mime_type, NULL, 0);
+    return MIMEDataListAdd(&offer->mimes, mime_type, NULL, 0);
 }
 
-bool Wayland_data_offer_has_mime(SDL_WaylandDataOffer *offer,
-                                 const char *mime_type)
+bool Wayland_DataOfferHasMIME(SDL_WaylandDataOffer *offer, const char *mime_type)
 {
     bool found = false;
 
     if (offer) {
-        found = mime_data_list_find(&offer->mimes, mime_type) != NULL;
+        found = MIMEDataListFind(&offer->mimes, mime_type) != NULL;
     }
     return found;
 }
 
-bool Wayland_primary_selection_offer_has_mime(SDL_WaylandPrimarySelectionOffer *offer,
-                                              const char *mime_type)
+bool Wayland_PrimarySelectionOfferHasMIME(SDL_WaylandPrimarySelectionOffer *offer, const char *mime_type)
 {
     bool found = false;
 
     if (offer) {
-        found = mime_data_list_find(&offer->mimes, mime_type) != NULL;
+        found = MIMEDataListFind(&offer->mimes, mime_type) != NULL;
     }
     return found;
 }
 
-void Wayland_data_offer_destroy(SDL_WaylandDataOffer *offer)
+void Wayland_DataOfferDestroy(SDL_WaylandDataOffer *offer)
 {
     if (offer) {
         if (offer->callback) {
@@ -621,21 +606,21 @@ void Wayland_data_offer_destroy(SDL_WaylandDataOffer *offer)
             close(offer->read_fd);
         }
         wl_data_offer_destroy(offer->offer);
-        mime_data_list_free(&offer->mimes);
+        MIMEDataListFree(&offer->mimes);
         SDL_free(offer);
     }
 }
 
-void Wayland_primary_selection_offer_destroy(SDL_WaylandPrimarySelectionOffer *offer)
+void Wayland_PrimarySelectionOfferDestroy(SDL_WaylandPrimarySelectionOffer *offer)
 {
     if (offer) {
         zwp_primary_selection_offer_v1_destroy(offer->offer);
-        mime_data_list_free(&offer->mimes);
+        MIMEDataListFree(&offer->mimes);
         SDL_free(offer);
     }
 }
 
-bool Wayland_data_device_clear_selection(SDL_WaylandDataDevice *data_device)
+bool Wayland_DataDeviceClearSelection(SDL_WaylandDataDevice *data_device)
 {
     if (!data_device || !data_device->data_device) {
         return SDL_SetError("Invalid Data Device");
@@ -643,13 +628,13 @@ bool Wayland_data_device_clear_selection(SDL_WaylandDataDevice *data_device)
 
     if (data_device->selection_source) {
         wl_data_device_set_selection(data_device->data_device, NULL, data_device->seat->last_implicit_grab_serial);
-        Wayland_data_source_destroy(data_device->selection_source);
+        Wayland_DataSourceDestroy(data_device->selection_source);
         data_device->selection_source = NULL;
     }
     return true;
 }
 
-bool Wayland_primary_selection_device_clear_selection(SDL_WaylandPrimarySelectionDevice *primary_selection_device)
+bool Wayland_PrimarySelectionDeviceClearSelection(SDL_WaylandPrimarySelectionDevice *primary_selection_device)
 {
     if (!primary_selection_device || !primary_selection_device->primary_selection_device) {
         return SDL_SetError("Invalid Primary Selection Device");
@@ -658,13 +643,13 @@ bool Wayland_primary_selection_device_clear_selection(SDL_WaylandPrimarySelectio
     if (primary_selection_device->selection_source) {
         zwp_primary_selection_device_v1_set_selection(primary_selection_device->primary_selection_device,
                                                       NULL, primary_selection_device->seat->last_implicit_grab_serial);
-        Wayland_primary_selection_source_destroy(primary_selection_device->selection_source);
+        Wayland_PrimarySelectionSourceDestroy(primary_selection_device->selection_source);
         primary_selection_device->selection_source = NULL;
     }
     return true;
 }
 
-bool Wayland_data_device_set_selection(SDL_WaylandDataDevice *data_device, SDL_WaylandDataSource *source, const char **mime_types, size_t mime_count)
+bool Wayland_DataDeviceSetSelection(SDL_WaylandDataDevice *data_device, SDL_WaylandDataSource *source, const char **mime_types, size_t mime_count)
 {
     if (!data_device) {
         return SDL_SetError("Invalid Data Device");
@@ -684,28 +669,25 @@ bool Wayland_data_device_set_selection(SDL_WaylandDataDevice *data_device, SDL_W
 
         // Only set if there is a valid serial if not set it later
         if (data_device->selection_serial != 0) {
-            wl_data_device_set_selection(data_device->data_device,
-                                         source->source,
-                                         data_device->selection_serial);
+            wl_data_device_set_selection(data_device->data_device, source->source, data_device->selection_serial);
         }
         if (data_device->selection_source) {
-            Wayland_data_source_destroy(data_device->selection_source);
+            Wayland_DataSourceDestroy(data_device->selection_source);
         }
         data_device->selection_source = source;
         source->data_device = data_device;
 
     } else {
-        Wayland_data_device_clear_selection(data_device);
+        Wayland_DataDeviceClearSelection(data_device);
         return SDL_SetError("No mime data");
     }
 
     return true;
 }
 
-bool Wayland_primary_selection_device_set_selection(SDL_WaylandPrimarySelectionDevice *primary_selection_device,
-                                                   SDL_WaylandPrimarySelectionSource *source,
-                                                   const char *const *mime_types,
-                                                   size_t mime_count)
+bool Wayland_PrimarySelectionDeviceSetSelection(SDL_WaylandPrimarySelectionDevice *primary_selection_device,
+                                                SDL_WaylandPrimarySelectionSource *source,
+                                                const char *const *mime_types, size_t mime_count)
 {
     if (!primary_selection_device) {
         return SDL_SetError("Invalid Primary Selection Device");
@@ -727,34 +709,31 @@ bool Wayland_primary_selection_device_set_selection(SDL_WaylandPrimarySelectionD
                                                           primary_selection_device->selection_serial);
         }
         if (primary_selection_device->selection_source) {
-            Wayland_primary_selection_source_destroy(primary_selection_device->selection_source);
+            Wayland_PrimarySelectionSourceDestroy(primary_selection_device->selection_source);
         }
         primary_selection_device->selection_source = source;
         source->primary_selection_device = primary_selection_device;
     } else {
-        Wayland_primary_selection_device_clear_selection(primary_selection_device);
+        Wayland_PrimarySelectionDeviceClearSelection(primary_selection_device);
         return SDL_SetError("No mime data");
     }
 
     return true;
 }
 
-void Wayland_data_device_set_serial(SDL_WaylandDataDevice *data_device, uint32_t serial)
+void Wayland_DataDeviceSetSerial(SDL_WaylandDataDevice *data_device, uint32_t serial)
 {
     if (data_device) {
         data_device->selection_serial = serial;
 
         // If there was no serial and there is a pending selection set it now.
         if (data_device->selection_serial == 0 && data_device->selection_source) {
-            wl_data_device_set_selection(data_device->data_device,
-                                         data_device->selection_source->source,
-                                         data_device->selection_serial);
+            wl_data_device_set_selection(data_device->data_device, data_device->selection_source->source, data_device->selection_serial);
         }
     }
 }
 
-void Wayland_primary_selection_device_set_serial(SDL_WaylandPrimarySelectionDevice *primary_selection_device,
-                                                 uint32_t serial)
+void Wayland_PrimarySelectionDeviceSetSerial(SDL_WaylandPrimarySelectionDevice *primary_selection_device, uint32_t serial)
 {
     if (primary_selection_device) {
         primary_selection_device->selection_serial = serial;

--- a/src/video/wayland/SDL_waylanddatamanager.c
+++ b/src/video/wayland/SDL_waylanddatamanager.c
@@ -90,15 +90,14 @@ static int sigtimedwait(const sigset_t *set, siginfo_t *info, const struct times
 
 static ssize_t write_pipe(int fd, const void *buffer, size_t total_length, size_t *pos)
 {
-    int ready = 0;
     ssize_t bytes_written = 0;
-    ssize_t length = total_length - *pos;
+    const ssize_t length = total_length - *pos;
 
     sigset_t sig_set;
     sigset_t old_sig_set;
     struct timespec zerotime = { 0 };
 
-    ready = SDL_IOReady(fd, SDL_IOR_WRITE, DEFAULT_PIPE_TIMEOUT_NS);
+    const int ready = SDL_IOReady(fd, SDL_IOR_WRITE, DEFAULT_PIPE_TIMEOUT_NS);
 
     sigemptyset(&sig_set);
     sigaddset(&sig_set, SIGPIPE);
@@ -109,11 +108,7 @@ static ssize_t write_pipe(int fd, const void *buffer, size_t total_length, size_
     pthread_sigmask(SIG_BLOCK, &sig_set, &old_sig_set);
 #endif
 
-    if (ready == 0) {
-        bytes_written = SDL_SetError("Pipe timeout");
-    } else if (ready < 0) {
-        bytes_written = SDL_SetError("Pipe select error");
-    } else {
+    if (ready > 0) {
         if (length > 0) {
             bytes_written = write(fd, (Uint8 *)buffer + *pos, SDL_min(length, PIPE_BUF));
         }
@@ -121,6 +116,10 @@ static ssize_t write_pipe(int fd, const void *buffer, size_t total_length, size_
         if (bytes_written > 0) {
             *pos += bytes_written;
         }
+    } else if (ready == 0) {
+        SDL_SetError("Pipe timeout");
+    } else  {
+        SDL_SetError("Pipe poll error");
     }
 
     sigtimedwait(&sig_set, NULL, &zerotime);
@@ -136,28 +135,25 @@ static ssize_t write_pipe(int fd, const void *buffer, size_t total_length, size_
 
 static ssize_t read_pipe(int fd, void **buffer, size_t *total_length, Sint64 timeout_ns)
 {
-    int ready = 0;
     void *output_buffer = NULL;
     char temp[PIPE_BUF];
-    size_t new_buffer_length = 0;
     ssize_t bytes_read = 0;
-    size_t pos = 0;
 
-    ready = SDL_IOReady(fd, SDL_IOR_READ, timeout_ns);
+    const int ready = SDL_IOReady(fd, SDL_IOR_READ, timeout_ns);
 
-    if (ready == 0) {
-        bytes_read = SDL_SetError("Pipe timeout");
-    } else if (ready < 0) {
-        bytes_read = SDL_SetError("Pipe select error");
-    } else {
+    if (ready > 0) {
         bytes_read = read(fd, temp, sizeof(temp));
+    } else if (ready == 0) {
+        SDL_SetError("Pipe timeout");
+    } else {
+        SDL_SetError("Pipe poll error");
     }
 
     if (bytes_read > 0) {
-        pos = *total_length;
+        const size_t pos = *total_length;
         *total_length += bytes_read;
 
-        new_buffer_length = *total_length + sizeof(Uint32);
+        const size_t new_buffer_length = *total_length + sizeof(Uint32);
 
         if (!*buffer) {
             output_buffer = SDL_malloc(new_buffer_length);
@@ -202,8 +198,6 @@ static bool mime_data_list_add(struct wl_list *list,
                                const void *buffer, size_t length)
 {
     bool result = true;
-    size_t mime_type_length = 0;
-    SDL_MimeDataList *mime_data = NULL;
     void *internal_buffer = NULL;
 
     if (buffer) {
@@ -214,7 +208,7 @@ static bool mime_data_list_add(struct wl_list *list,
         SDL_memcpy(internal_buffer, buffer, length);
     }
 
-    mime_data = mime_data_list_find(list, mime_type);
+    SDL_MimeDataList *mime_data = mime_data_list_find(list, mime_type);
 
     if (!mime_data) {
         mime_data = SDL_calloc(1, sizeof(*mime_data));
@@ -223,7 +217,7 @@ static bool mime_data_list_add(struct wl_list *list,
         } else {
             WAYLAND_wl_list_insert(list, &(mime_data->link));
 
-            mime_type_length = SDL_strlen(mime_type) + 1;
+            const size_t mime_type_length = SDL_strlen(mime_type) + 1;
             mime_data->mime_type = SDL_malloc(mime_type_length);
             if (!mime_data->mime_type) {
                 result = false;
@@ -337,13 +331,12 @@ void *Wayland_data_source_get_data(SDL_WaylandDataSource *source,
                                    const char *mime_type, size_t *length)
 {
     void *buffer = NULL;
-    const void *internal_buffer;
     *length = 0;
 
     if (!source) {
         SDL_SetError("Invalid data source");
     } else if (source->callback) {
-        internal_buffer = source->callback(source->userdata.data, mime_type, length);
+        const void *internal_buffer = source->callback(source->userdata.data, mime_type, length);
         buffer = Wayland_clone_data_buffer(internal_buffer, length);
     }
 
@@ -354,13 +347,12 @@ void *Wayland_primary_selection_source_get_data(SDL_WaylandPrimarySelectionSourc
                                                 const char *mime_type, size_t *length)
 {
     void *buffer = NULL;
-    const void *internal_buffer;
     *length = 0;
 
     if (!source) {
         SDL_SetError("Invalid primary selection source");
     } else if (source->callback) {
-        internal_buffer = source->callback(source->userdata.data, mime_type, length);
+        const void *internal_buffer = source->callback(source->userdata.data, mime_type, length);
         buffer = Wayland_clone_data_buffer(internal_buffer, length);
     }
 
@@ -370,7 +362,7 @@ void *Wayland_primary_selection_source_get_data(SDL_WaylandPrimarySelectionSourc
 void Wayland_data_source_destroy(SDL_WaylandDataSource *source)
 {
     if (source) {
-        SDL_WaylandDataDevice *data_device = (SDL_WaylandDataDevice *)source->data_device;
+        SDL_WaylandDataDevice *data_device = source->data_device;
         if (data_device && (data_device->selection_source == source)) {
             data_device->selection_source = NULL;
         }
@@ -387,7 +379,7 @@ void Wayland_data_source_destroy(SDL_WaylandDataSource *source)
 void Wayland_primary_selection_source_destroy(SDL_WaylandPrimarySelectionSource *source)
 {
     if (source) {
-        SDL_WaylandPrimarySelectionDevice *primary_selection_device = (SDL_WaylandPrimarySelectionDevice *)source->primary_selection_device;
+        SDL_WaylandPrimarySelectionDevice *primary_selection_device = source->primary_selection_device;
         if (primary_selection_device && (primary_selection_device->selection_source == source)) {
             primary_selection_device->selection_source = NULL;
         }
@@ -405,7 +397,7 @@ static void offer_source_done_handler(void *data, struct wl_callback *callback, 
         return;
     }
 
-    SDL_WaylandDataOffer *offer = data;
+    SDL_WaylandDataOffer *offer = (SDL_WaylandDataOffer *)data;
     char *id = NULL;
     size_t length = 0;
 
@@ -437,19 +429,14 @@ static struct wl_callback_listener offer_source_listener = {
 
 static void Wayland_data_offer_check_source(SDL_WaylandDataOffer *offer, const char *mime_type)
 {
-    SDL_WaylandDataDevice *data_device = NULL;
     int pipefd[2];
 
     if (!offer) {
-        SDL_SetError("Invalid data offer");
         return;
     }
-    data_device = offer->data_device;
-    if (!data_device) {
-        SDL_SetError("Data device not initialized");
-    } else if (pipe2(pipefd, O_CLOEXEC | O_NONBLOCK) == -1) {
-        SDL_SetError("Could not read pipe");
-    } else {
+    SDL_WaylandDataDevice *data_device = offer->data_device;
+
+    if (pipe2(pipefd, O_CLOEXEC | O_NONBLOCK) == 0) {
         if (offer->callback) {
             wl_callback_destroy(offer->callback);
         }
@@ -522,7 +509,6 @@ void Wayland_data_offer_notify_from_mimes(SDL_WaylandDataOffer *offer, bool chec
 
 void *Wayland_data_offer_receive(SDL_WaylandDataOffer *offer, const char *mime_type, size_t *length, bool extended_timeout)
 {
-    SDL_WaylandDataDevice *data_device = NULL;
     const Sint64 timeout = extended_timeout ? EXTENDED_PIPE_TIMEOUT_NS : DEFAULT_PIPE_TIMEOUT_NS;
 
     int pipefd[2];
@@ -533,12 +519,10 @@ void *Wayland_data_offer_receive(SDL_WaylandDataOffer *offer, const char *mime_t
         SDL_SetError("Invalid data offer");
         return NULL;
     }
-    data_device = offer->data_device;
-    if (!data_device) {
-        SDL_SetError("Data device not initialized");
-    } else if (pipe2(pipefd, O_CLOEXEC | O_NONBLOCK) == -1) {
-        SDL_SetError("Could not read pipe");
-    } else {
+
+    SDL_WaylandDataDevice *data_device = offer->data_device;
+
+    if (pipe2(pipefd, O_CLOEXEC | O_NONBLOCK) == 0) {
         wl_data_offer_receive(offer->offer, mime_type, pipefd[1]);
         close(pipefd[1]);
 
@@ -547,18 +531,20 @@ void *Wayland_data_offer_receive(SDL_WaylandDataOffer *offer, const char *mime_t
         while (read_pipe(pipefd[0], &buffer, length, timeout) > 0) {
         }
         close(pipefd[0]);
+    } else {
+        SDL_SetError("Could not create pipe");
     }
+
     SDL_LogTrace(SDL_LOG_CATEGORY_INPUT,
                  ". In Wayland_data_offer_receive for '%s', buffer (%zu) at %p",
                  mime_type, *length, buffer);
+
     return buffer;
 }
 
 void *Wayland_primary_selection_offer_receive(SDL_WaylandPrimarySelectionOffer *offer,
                                               const char *mime_type, size_t *length)
 {
-    SDL_WaylandPrimarySelectionDevice *primary_selection_device = NULL;
-
     int pipefd[2];
     void *buffer = NULL;
     *length = 0;
@@ -567,12 +553,10 @@ void *Wayland_primary_selection_offer_receive(SDL_WaylandPrimarySelectionOffer *
         SDL_SetError("Invalid data offer");
         return NULL;
     }
-    primary_selection_device = offer->primary_selection_device;
-    if (!primary_selection_device) {
-        SDL_SetError("Primary selection device not initialized");
-    } else if (pipe2(pipefd, O_CLOEXEC | O_NONBLOCK) == -1) {
-        SDL_SetError("Could not read pipe");
-    } else {
+
+    SDL_WaylandPrimarySelectionDevice *primary_selection_device = offer->primary_selection_device;
+
+    if (pipe2(pipefd, O_CLOEXEC | O_NONBLOCK) == 0) {
         zwp_primary_selection_offer_v1_receive(offer->offer, mime_type, pipefd[1]);
         close(pipefd[1]);
 
@@ -581,10 +565,15 @@ void *Wayland_primary_selection_offer_receive(SDL_WaylandPrimarySelectionOffer *
         while (read_pipe(pipefd[0], &buffer, length, EXTENDED_PIPE_TIMEOUT_NS) > 0) {
         }
         close(pipefd[0]);
+
+    } else {
+        SDL_SetError("Could not create pipe");
     }
+
     SDL_LogTrace(SDL_LOG_CATEGORY_INPUT,
                  ". In Wayland_primary_selection_offer_receive for '%s', buffer (%zu) at %p",
                  mime_type, *length, buffer);
+
     return buffer;
 }
 
@@ -648,76 +637,69 @@ void Wayland_primary_selection_offer_destroy(SDL_WaylandPrimarySelectionOffer *o
 
 bool Wayland_data_device_clear_selection(SDL_WaylandDataDevice *data_device)
 {
-    bool result = true;
-
     if (!data_device || !data_device->data_device) {
-        result = SDL_SetError("Invalid Data Device");
-    } else if (data_device->selection_source) {
+        return SDL_SetError("Invalid Data Device");
+    }
+
+    if (data_device->selection_source) {
         wl_data_device_set_selection(data_device->data_device, NULL, data_device->seat->last_implicit_grab_serial);
         Wayland_data_source_destroy(data_device->selection_source);
         data_device->selection_source = NULL;
     }
-    return result;
+    return true;
 }
 
 bool Wayland_primary_selection_device_clear_selection(SDL_WaylandPrimarySelectionDevice *primary_selection_device)
 {
-    bool result = true;
-
     if (!primary_selection_device || !primary_selection_device->primary_selection_device) {
-        result = SDL_SetError("Invalid Primary Selection Device");
-    } else if (primary_selection_device->selection_source) {
+        return SDL_SetError("Invalid Primary Selection Device");
+    }
+
+    if (primary_selection_device->selection_source) {
         zwp_primary_selection_device_v1_set_selection(primary_selection_device->primary_selection_device,
                                                       NULL, primary_selection_device->seat->last_implicit_grab_serial);
         Wayland_primary_selection_source_destroy(primary_selection_device->selection_source);
         primary_selection_device->selection_source = NULL;
     }
-    return result;
+    return true;
 }
 
-bool Wayland_data_device_set_selection(SDL_WaylandDataDevice *data_device,
-                                       SDL_WaylandDataSource *source,
-                                       const char **mime_types,
-                                       size_t mime_count)
+bool Wayland_data_device_set_selection(SDL_WaylandDataDevice *data_device, SDL_WaylandDataSource *source, const char **mime_types, size_t mime_count)
 {
-    bool result = true;
-
     if (!data_device) {
-        result = SDL_SetError("Invalid Data Device");
-    } else if (!source) {
-        result = SDL_SetError("Invalid source");
-    } else {
-        size_t index = 0;
-        const char *mime_type;
+        return SDL_SetError("Invalid Data Device");
+    }
+    if (!source) {
+        return SDL_SetError("Invalid source");
+    }
 
-        for (index = 0; index < mime_count; ++index) {
-            mime_type = mime_types[index];
-            wl_data_source_offer(source->source,
-                                 mime_type);
+    if (mime_count) {
+        for (size_t index = 0; index < mime_count; ++index) {
+            const char *mime_type = mime_types[index];
+            wl_data_source_offer(source->source, mime_type);
         }
 
         // Advertise the data origin MIME
         wl_data_source_offer(source->source, SDL_DATA_ORIGIN_MIME);
 
-        if (index == 0) {
-            Wayland_data_device_clear_selection(data_device);
-            result = SDL_SetError("No mime data");
-        } else {
-            // Only set if there is a valid serial if not set it later
-            if (data_device->selection_serial != 0) {
-                wl_data_device_set_selection(data_device->data_device,
-                                             source->source,
-                                             data_device->selection_serial);
-            }
-            if (data_device->selection_source) {
-                Wayland_data_source_destroy(data_device->selection_source);
-            }
-            data_device->selection_source = source;
-            source->data_device = data_device;
+        // Only set if there is a valid serial if not set it later
+        if (data_device->selection_serial != 0) {
+            wl_data_device_set_selection(data_device->data_device,
+                                         source->source,
+                                         data_device->selection_serial);
         }
+        if (data_device->selection_source) {
+            Wayland_data_source_destroy(data_device->selection_source);
+        }
+        data_device->selection_source = source;
+        source->data_device = data_device;
+
+    } else {
+        Wayland_data_device_clear_selection(data_device);
+        return SDL_SetError("No mime data");
     }
 
-    return result;
+    return true;
 }
 
 bool Wayland_primary_selection_device_set_selection(SDL_WaylandPrimarySelectionDevice *primary_selection_device,
@@ -725,40 +707,36 @@ bool Wayland_primary_selection_device_set_selection(SDL_WaylandPrimarySelectionD
                                                    const char *const *mime_types,
                                                    size_t mime_count)
 {
-    bool result = true;
-
     if (!primary_selection_device) {
-        result = SDL_SetError("Invalid Primary Selection Device");
-    } else if (!source) {
-        result = SDL_SetError("Invalid source");
-    } else {
-        size_t index = 0;
-        const char *mime_type = mime_types[index];
+        return SDL_SetError("Invalid Primary Selection Device");
+    }
+    if (!source) {
+        return SDL_SetError("Invalid source");
+    }
 
-        for (index = 0; index < mime_count; ++index) {
-            mime_type = mime_types[index];
+    if (mime_count) {
+        for (size_t index = 0; index < mime_count; ++index) {
+            const char *mime_type = mime_types[index];
             zwp_primary_selection_source_v1_offer(source->source, mime_type);
         }
 
-        if (index == 0) {
-            Wayland_primary_selection_device_clear_selection(primary_selection_device);
-            result = SDL_SetError("No mime data");
-        } else {
-            // Only set if there is a valid serial if not set it later
-            if (primary_selection_device->selection_serial != 0) {
-                zwp_primary_selection_device_v1_set_selection(primary_selection_device->primary_selection_device,
-                                                              source->source,
-                                                              primary_selection_device->selection_serial);
-            }
-            if (primary_selection_device->selection_source) {
-                Wayland_primary_selection_source_destroy(primary_selection_device->selection_source);
-            }
-            primary_selection_device->selection_source = source;
-            source->primary_selection_device = primary_selection_device;
+        // Only set if there is a valid serial if not set it later
+        if (primary_selection_device->selection_serial != 0) {
+            zwp_primary_selection_device_v1_set_selection(primary_selection_device->primary_selection_device,
+                                                          source->source,
+                                                          primary_selection_device->selection_serial);
         }
+        if (primary_selection_device->selection_source) {
+            Wayland_primary_selection_source_destroy(primary_selection_device->selection_source);
+        }
+        primary_selection_device->selection_source = source;
+        source->primary_selection_device = primary_selection_device;
+    } else {
+        Wayland_primary_selection_device_clear_selection(primary_selection_device);
+        return SDL_SetError("No mime data");
     }
 
-    return result;
+    return true;
 }
 
 void Wayland_data_device_set_serial(SDL_WaylandDataDevice *data_device, uint32_t serial)

--- a/src/video/wayland/SDL_waylanddatamanager.h
+++ b/src/video/wayland/SDL_waylanddatamanager.h
@@ -28,9 +28,9 @@
 #include "SDL_waylandvideo.h"
 #include "SDL_waylandwindow.h"
 
-#define TEXT_MIME "text/plain;charset=utf-8"
-#define FILE_MIME "text/uri-list"
-#define FILE_PORTAL_MIME "application/vnd.portal.filetransfer"
+#define TEXT_MIME            "text/plain;charset=utf-8"
+#define FILE_MIME            "text/uri-list"
+#define FILE_PORTAL_MIME     "application/vnd.portal.filetransfer"
 #define SDL_DATA_ORIGIN_MIME "application/x-sdl3-source-id"
 
 typedef struct SDL_WaylandDataDevice SDL_WaylandDataDevice;
@@ -116,62 +116,34 @@ struct SDL_WaylandPrimarySelectionDevice
 };
 
 // Wayland Data Source / Primary Selection Source - (Sending)
-extern SDL_WaylandDataSource *Wayland_data_source_create(SDL_VideoData *video_data);
-extern SDL_WaylandPrimarySelectionSource *Wayland_primary_selection_source_create(SDL_VideoData *video_data);
-extern ssize_t Wayland_data_source_send(SDL_WaylandDataSource *source,
-                                        const char *mime_type, int fd);
-extern ssize_t Wayland_primary_selection_source_send(SDL_WaylandPrimarySelectionSource *source,
-                                                     const char *mime_type, int fd);
-extern void Wayland_data_source_set_callback(SDL_WaylandDataSource *source,
-                                            SDL_ClipboardDataCallback callback,
-                                            void *userdata,
-                                            Uint32 sequence);
-extern void Wayland_primary_selection_source_set_callback(SDL_WaylandPrimarySelectionSource *source,
-                                                          SDL_ClipboardDataCallback callback,
-                                                          void *userdata);
-extern void *Wayland_data_source_get_data(SDL_WaylandDataSource *source,
-                                          const char *mime_type,
-                                          size_t *length);
-extern void *Wayland_primary_selection_source_get_data(SDL_WaylandPrimarySelectionSource *source,
-                                                       const char *mime_type,
-                                                       size_t *length);
-extern void Wayland_data_source_destroy(SDL_WaylandDataSource *source);
-extern void Wayland_primary_selection_source_destroy(SDL_WaylandPrimarySelectionSource *source);
+extern SDL_WaylandDataSource *Wayland_DataSourceCreate(SDL_VideoData *video_data);
+extern SDL_WaylandPrimarySelectionSource *Wayland_PrimarySelectionSourceCreate(SDL_VideoData *video_data);
+extern ssize_t Wayland_DataSourceSend(SDL_WaylandDataSource *source, const char *mime_type, int fd);
+extern ssize_t Wayland_PrimarySelectionSourceSend(SDL_WaylandPrimarySelectionSource *source, const char *mime_type, int fd);
+extern void Wayland_DataSourceSetCallback(SDL_WaylandDataSource *source, SDL_ClipboardDataCallback callback, void *userdata, Uint32 sequence);
+extern void Wayland_PrimarySelectionSourceSetCallback(SDL_WaylandPrimarySelectionSource *source, SDL_ClipboardDataCallback callback, void *userdata);
+extern void *Wayland_DataSourceGetData(SDL_WaylandDataSource *source, const char *mime_type, size_t *length);
+extern void *Wayland_PrimarySelectionSourceGetData(SDL_WaylandPrimarySelectionSource *source, const char *mime_type, size_t *length);
+extern void Wayland_DataSourceDestroy(SDL_WaylandDataSource *source);
+extern void Wayland_PrimarySelectionSourceDestroy(SDL_WaylandPrimarySelectionSource *source);
 
 // Wayland Data / Primary Selection Offer - (Receiving)
-extern void *Wayland_data_offer_receive(SDL_WaylandDataOffer *offer,
-                                        const char *mime_type,
-                                        size_t *length,
-                                        bool extended_timeout);
-extern void *Wayland_primary_selection_offer_receive(SDL_WaylandPrimarySelectionOffer *offer,
-                                                     const char *mime_type,
-                                                     size_t *length);
-extern bool Wayland_data_offer_has_mime(SDL_WaylandDataOffer *offer,
-                                        const char *mime_type);
-extern void Wayland_data_offer_notify_from_mimes(SDL_WaylandDataOffer *offer,
-                                                 bool check_origin);
-extern bool Wayland_primary_selection_offer_has_mime(SDL_WaylandPrimarySelectionOffer *offer,
-                                                     const char *mime_type);
-extern bool Wayland_data_offer_add_mime(SDL_WaylandDataOffer *offer,
-                                        const char *mime_type);
-extern bool Wayland_primary_selection_offer_add_mime(SDL_WaylandPrimarySelectionOffer *offer,
-                                                     const char *mime_type);
-extern void Wayland_data_offer_destroy(SDL_WaylandDataOffer *offer);
-extern void Wayland_primary_selection_offer_destroy(SDL_WaylandPrimarySelectionOffer *offer);
+extern void *Wayland_DataOfferReceive(SDL_WaylandDataOffer *offer, const char *mime_type, size_t *length, bool extended_timeout);
+extern void *Wayland_PrimarySelectionOfferReceive(SDL_WaylandPrimarySelectionOffer *offer, const char *mime_type, size_t *length);
+extern bool Wayland_DataOfferHasMIME(SDL_WaylandDataOffer *offer, const char *mime_type);
+extern void Wayland_DataOfferNotifyFromMIMEs(SDL_WaylandDataOffer *offer, bool check_origin);
+extern bool Wayland_PrimarySelectionOfferHasMIME(SDL_WaylandPrimarySelectionOffer *offer, const char *mime_type);
+extern bool Wayland_DataOfferAddMIME(SDL_WaylandDataOffer *offer, const char *mime_type);
+extern bool Wayland_PrimarySelectionOfferAddMIME(SDL_WaylandPrimarySelectionOffer *offer, const char *mime_type);
+extern void Wayland_DataOfferDestroy(SDL_WaylandDataOffer *offer);
+extern void Wayland_PrimarySelectionOfferDestroy(SDL_WaylandPrimarySelectionOffer *offer);
 
 // Clipboard / Primary Selection
-extern bool Wayland_data_device_clear_selection(SDL_WaylandDataDevice *device);
-extern bool Wayland_primary_selection_device_clear_selection(SDL_WaylandPrimarySelectionDevice *device);
-extern bool Wayland_data_device_set_selection(SDL_WaylandDataDevice *device,
-                                              SDL_WaylandDataSource *source,
-                                              const char **mime_types,
-                                              size_t mime_count);
-extern bool Wayland_primary_selection_device_set_selection(SDL_WaylandPrimarySelectionDevice *device,
-                                                           SDL_WaylandPrimarySelectionSource *source,
-                                                           const char *const *mime_types,
-                                                           size_t mime_count);
-extern void Wayland_data_device_set_serial(SDL_WaylandDataDevice *device,
-                                           uint32_t serial);
-extern void Wayland_primary_selection_device_set_serial(SDL_WaylandPrimarySelectionDevice *device,
-                                                        uint32_t serial);
+extern bool Wayland_DataDeviceClearSelection(SDL_WaylandDataDevice *device);
+extern bool Wayland_PrimarySelectionDeviceClearSelection(SDL_WaylandPrimarySelectionDevice *device);
+extern bool Wayland_DataDeviceSetSelection(SDL_WaylandDataDevice *device, SDL_WaylandDataSource *source, const char **mime_types, size_t mime_count);
+extern bool Wayland_PrimarySelectionDeviceSetSelection(SDL_WaylandPrimarySelectionDevice *device, SDL_WaylandPrimarySelectionSource *source, const char *const *mime_types, size_t mime_count);
+extern void Wayland_DataDeviceSetSerial(SDL_WaylandDataDevice *device, uint32_t serial);
+extern void Wayland_PrimarySelectionDeviceSetSerial(SDL_WaylandPrimarySelectionDevice *device, uint32_t serial);
+
 #endif // SDL_waylanddatamanager_h_

--- a/src/video/wayland/SDL_waylanddatamanager.h
+++ b/src/video/wayland/SDL_waylanddatamanager.h
@@ -116,8 +116,8 @@ struct SDL_WaylandPrimarySelectionDevice
 };
 
 // Wayland Data Source / Primary Selection Source - (Sending)
-extern SDL_WaylandDataSource *Wayland_data_source_create(SDL_VideoDevice *_this);
-extern SDL_WaylandPrimarySelectionSource *Wayland_primary_selection_source_create(SDL_VideoDevice *_this);
+extern SDL_WaylandDataSource *Wayland_data_source_create(SDL_VideoData *video_data);
+extern SDL_WaylandPrimarySelectionSource *Wayland_primary_selection_source_create(SDL_VideoData *video_data);
 extern ssize_t Wayland_data_source_send(SDL_WaylandDataSource *source,
                                         const char *mime_type, int fd);
 extern ssize_t Wayland_primary_selection_source_send(SDL_WaylandPrimarySelectionSource *source,

--- a/src/video/wayland/SDL_waylanddatamanager.h
+++ b/src/video/wayland/SDL_waylanddatamanager.h
@@ -139,8 +139,6 @@ extern void Wayland_DataOfferDestroy(SDL_WaylandDataOffer *offer);
 extern void Wayland_PrimarySelectionOfferDestroy(SDL_WaylandPrimarySelectionOffer *offer);
 
 // Clipboard / Primary Selection
-extern bool Wayland_DataDeviceClearSelection(SDL_WaylandDataDevice *device);
-extern bool Wayland_PrimarySelectionDeviceClearSelection(SDL_WaylandPrimarySelectionDevice *device);
 extern bool Wayland_DataDeviceSetSelection(SDL_WaylandDataDevice *device, SDL_WaylandDataSource *source, const char **mime_types, size_t mime_count);
 extern bool Wayland_PrimarySelectionDeviceSetSelection(SDL_WaylandPrimarySelectionDevice *device, SDL_WaylandPrimarySelectionSource *source, const char *const *mime_types, size_t mime_count);
 extern void Wayland_DataDeviceSetSerial(SDL_WaylandDataDevice *device, uint32_t serial);

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -3698,9 +3698,11 @@ void Wayland_SeatDestroy(SDL_WaylandSeat *seat, bool shutting_down)
     SDL_free(seat->name);
 
     if (seat->data_device) {
-        Wayland_DataDeviceClearSelection(seat->data_device);
         if (seat->data_device->selection_offer) {
             Wayland_DataOfferDestroy(seat->data_device->selection_offer);
+        }
+        if (seat->data_device->selection_source) {
+            Wayland_DataSourceDestroy(seat->data_device->selection_source);
         }
         if (seat->data_device->drag_offer) {
             Wayland_DataOfferDestroy(seat->data_device->drag_offer);

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -2614,14 +2614,14 @@ static void data_source_handle_target(void *data, struct wl_data_source *wl_data
 static void data_source_handle_send(void *data, struct wl_data_source *wl_data_source,
                                     const char *mime_type, int32_t fd)
 {
-    Wayland_data_source_send((SDL_WaylandDataSource *)data, mime_type, fd);
+    Wayland_DataSourceSend((SDL_WaylandDataSource *)data, mime_type, fd);
 }
 
 static void data_source_handle_cancelled(void *data, struct wl_data_source *wl_data_source)
 {
     SDL_WaylandDataSource *source = data;
     if (source) {
-        Wayland_data_source_destroy(source);
+        Wayland_DataSourceDestroy(source);
     }
 }
 
@@ -2650,13 +2650,13 @@ static const struct wl_data_source_listener data_source_listener = {
 static void primary_selection_source_send(void *data, struct zwp_primary_selection_source_v1 *zwp_primary_selection_source_v1,
                                           const char *mime_type, int32_t fd)
 {
-    Wayland_primary_selection_source_send((SDL_WaylandPrimarySelectionSource *)data,
+    Wayland_PrimarySelectionSourceSend((SDL_WaylandPrimarySelectionSource *)data,
                                           mime_type, fd);
 }
 
 static void primary_selection_source_cancelled(void *data, struct zwp_primary_selection_source_v1 *zwp_primary_selection_source_v1)
 {
-    Wayland_primary_selection_source_destroy(data);
+    Wayland_PrimarySelectionSourceDestroy(data);
 }
 
 static const struct zwp_primary_selection_source_v1_listener primary_selection_source_listener = {
@@ -2664,7 +2664,7 @@ static const struct zwp_primary_selection_source_v1_listener primary_selection_s
     primary_selection_source_cancelled,
 };
 
-SDL_WaylandDataSource *Wayland_data_source_create(SDL_VideoData *video_data)
+SDL_WaylandDataSource *Wayland_DataSourceCreate(SDL_VideoData *video_data)
 {
     SDL_WaylandDataSource *data_source = SDL_calloc(1, sizeof(*data_source));
     if (!data_source) {
@@ -2679,7 +2679,7 @@ SDL_WaylandDataSource *Wayland_data_source_create(SDL_VideoData *video_data)
     return data_source;
 }
 
-SDL_WaylandPrimarySelectionSource *Wayland_primary_selection_source_create(SDL_VideoData *video_data)
+SDL_WaylandPrimarySelectionSource *Wayland_PrimarySelectionSourceCreate(SDL_VideoData *video_data)
 {
     SDL_WaylandPrimarySelectionSource *primary_selection_source = SDL_calloc(1, sizeof(*primary_selection_source));
     if (!primary_selection_source) {
@@ -2697,7 +2697,7 @@ static void data_offer_handle_offer(void *data, struct wl_data_offer *wl_data_of
                                     const char *mime_type)
 {
     SDL_WaylandDataOffer *offer = data;
-    Wayland_data_offer_add_mime(offer, mime_type);
+    Wayland_DataOfferAddMIME(offer, mime_type);
     SDL_LogTrace(SDL_LOG_CATEGORY_INPUT,
                  ". In wl_data_offer_listener . data_offer_handle_offer on data_offer 0x%08x for MIME '%s'",
                  (wl_data_offer ? WAYLAND_wl_proxy_get_id((struct wl_proxy *)wl_data_offer) : -1),
@@ -2732,7 +2732,7 @@ static void primary_selection_offer_handle_offer(void *data, struct zwp_primary_
                                                  const char *mime_type)
 {
     SDL_WaylandPrimarySelectionOffer *offer = data;
-    Wayland_primary_selection_offer_add_mime(offer, mime_type);
+    Wayland_PrimarySelectionOfferAddMIME(offer, mime_type);
     SDL_LogTrace(SDL_LOG_CATEGORY_INPUT,
                  ". In zwp_primary_selection_offer_v1_listener . primary_selection_offer_handle_offer on primary_selection_offer 0x%08x for MIME '%s'",
                  (zwp_primary_selection_offer_v1 ? WAYLAND_wl_proxy_get_id((struct wl_proxy *)zwp_primary_selection_offer_v1) : -1),
@@ -2781,13 +2781,13 @@ static void data_device_handle_enter(void *data, struct wl_data_device *wl_data_
     if (data_device->drag_offer && window && window->accepts_drag_and_drop) {
         // TODO: SDL Support more mime types
 #ifdef SDL_USE_LIBDBUS
-        if (Wayland_data_offer_has_mime(data_device->drag_offer, FILE_PORTAL_MIME)) {
+        if (Wayland_DataOfferHasMIME(data_device->drag_offer, FILE_PORTAL_MIME)) {
             data_device->has_mime_file = true;
             data_device->mime_type = FILE_PORTAL_MIME;
             wl_data_offer_accept(id, serial, FILE_PORTAL_MIME);
         }
 #endif
-        if (Wayland_data_offer_has_mime(data_device->drag_offer, FILE_MIME)) {
+        if (Wayland_DataOfferHasMIME(data_device->drag_offer, FILE_MIME)) {
             data_device->has_mime_file = true;
             data_device->mime_type = FILE_MIME;
             wl_data_offer_accept(id, serial, FILE_MIME);
@@ -2796,7 +2796,7 @@ static void data_device_handle_enter(void *data, struct wl_data_device *wl_data_
         size_t mime_count = 0;
         const char *const *text_mime_types = Wayland_GetTextMimeTypes(SDL_GetVideoDevice(), &mime_count);
         for (size_t i = 0; i < mime_count; ++i) {
-            if (Wayland_data_offer_has_mime(data_device->drag_offer, text_mime_types[i])) {
+            if (Wayland_DataOfferHasMIME(data_device->drag_offer, text_mime_types[i])) {
                 data_device->has_mime_text = true;
                 data_device->mime_type = text_mime_types[i];
                 wl_data_offer_accept(id, serial, text_mime_types[i]);
@@ -2876,7 +2876,7 @@ static void data_device_handle_leave(void *data, struct wl_data_device *wl_data_
                          WAYLAND_wl_proxy_get_id((struct wl_proxy *)data_device->drag_offer->offer),
                          data_device->drag_serial);
         }
-        Wayland_data_offer_destroy(data_device->drag_offer);
+        Wayland_DataOfferDestroy(data_device->drag_offer);
         data_device->drag_offer = NULL;
     } else {
         SDL_LogTrace(SDL_LOG_CATEGORY_INPUT,
@@ -2936,8 +2936,8 @@ static void data_device_handle_drop(void *data, struct wl_data_device *wl_data_d
         size_t length;
         bool drop_handled = false;
 #ifdef SDL_USE_LIBDBUS
-        if (Wayland_data_offer_has_mime(data_device->drag_offer, FILE_PORTAL_MIME)) {
-            void *buffer = Wayland_data_offer_receive(data_device->drag_offer, FILE_PORTAL_MIME, &length, false);
+        if (Wayland_DataOfferHasMIME(data_device->drag_offer, FILE_PORTAL_MIME)) {
+            void *buffer = Wayland_DataOfferReceive(data_device->drag_offer, FILE_PORTAL_MIME, &length, false);
             if (buffer) {
                 SDL_DBusContext *dbus = SDL_DBus_GetContext();
                 if (dbus) {
@@ -2963,7 +2963,7 @@ static void data_device_handle_drop(void *data, struct wl_data_device *wl_data_d
          * non paths that are not visible to the application
          */
         if (!drop_handled) {
-            void *buffer = Wayland_data_offer_receive(data_device->drag_offer, data_device->mime_type, &length, false);
+            void *buffer = Wayland_DataOfferReceive(data_device->drag_offer, data_device->mime_type, &length, false);
             if (data_device->has_mime_file) {
                 if (buffer) {
                     char *saveptr = NULL;
@@ -3012,7 +3012,7 @@ static void data_device_handle_drop(void *data, struct wl_data_device *wl_data_d
                      -1, -1);
     }
 
-    Wayland_data_offer_destroy(data_device->drag_offer);
+    Wayland_DataOfferDestroy(data_device->drag_offer);
     data_device->drag_offer = NULL;
 }
 
@@ -3032,10 +3032,10 @@ static void data_device_handle_selection(void *data, struct wl_data_device *wl_d
 
     // Don't notify when clearing the old selection offer if doing so will inadvertently clear the selection source.
     const bool notify = offer || (!offer && data_device->selection_offer && (!data_device->selection_offer->callback || !data_device->selection_source));
-    Wayland_data_offer_destroy(data_device->selection_offer);
+    Wayland_DataOfferDestroy(data_device->selection_offer);
     data_device->selection_offer = offer;
     if (notify) {
-        Wayland_data_offer_notify_from_mimes(offer, true);
+        Wayland_DataOfferNotifyFromMIMEs(offer, true);
     }
 }
 
@@ -3077,7 +3077,7 @@ static void primary_selection_device_handle_selection(void *data, struct zwp_pri
     }
 
     if (primary_selection_device->selection_offer != offer) {
-        Wayland_primary_selection_offer_destroy(primary_selection_device->selection_offer);
+        Wayland_PrimarySelectionOfferDestroy(primary_selection_device->selection_offer);
         primary_selection_device->selection_offer = offer;
     }
     SDL_LogTrace(SDL_LOG_CATEGORY_INPUT,
@@ -3698,12 +3698,12 @@ void Wayland_SeatDestroy(SDL_WaylandSeat *seat, bool shutting_down)
     SDL_free(seat->name);
 
     if (seat->data_device) {
-        Wayland_data_device_clear_selection(seat->data_device);
+        Wayland_DataDeviceClearSelection(seat->data_device);
         if (seat->data_device->selection_offer) {
-            Wayland_data_offer_destroy(seat->data_device->selection_offer);
+            Wayland_DataOfferDestroy(seat->data_device->selection_offer);
         }
         if (seat->data_device->drag_offer) {
-            Wayland_data_offer_destroy(seat->data_device->drag_offer);
+            Wayland_DataOfferDestroy(seat->data_device->drag_offer);
         }
         if (seat->data_device->data_device) {
             if (wl_data_device_get_version(seat->data_device->data_device) >= WL_DATA_DEVICE_RELEASE_SINCE_VERSION) {
@@ -3718,10 +3718,10 @@ void Wayland_SeatDestroy(SDL_WaylandSeat *seat, bool shutting_down)
 
     if (seat->primary_selection_device) {
         if (seat->primary_selection_device->selection_offer) {
-            Wayland_primary_selection_offer_destroy(seat->primary_selection_device->selection_offer);
+            Wayland_PrimarySelectionOfferDestroy(seat->primary_selection_device->selection_offer);
         }
         if (seat->primary_selection_device->selection_source) {
-            Wayland_primary_selection_source_destroy(seat->primary_selection_device->selection_source);
+            Wayland_PrimarySelectionSourceDestroy(seat->primary_selection_device->selection_source);
         }
         if (seat->primary_selection_device->primary_selection_device) {
             zwp_primary_selection_device_v1_destroy(seat->primary_selection_device->primary_selection_device);
@@ -3965,8 +3965,8 @@ void Wayland_UpdateImplicitGrabSerial(SDL_WaylandSeat *seat, Uint32 serial)
     if (serial > seat->last_implicit_grab_serial) {
         seat->last_implicit_grab_serial = serial;
         seat->display->last_implicit_grab_seat = seat;
-        Wayland_data_device_set_serial(seat->data_device, serial);
-        Wayland_primary_selection_device_set_serial(seat->primary_selection_device, serial);
+        Wayland_DataDeviceSetSerial(seat->data_device, serial);
+        Wayland_PrimarySelectionDeviceSetSerial(seat->primary_selection_device, serial);
     }
 }
 

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -2664,68 +2664,32 @@ static const struct zwp_primary_selection_source_v1_listener primary_selection_s
     primary_selection_source_cancelled,
 };
 
-SDL_WaylandDataSource *Wayland_data_source_create(SDL_VideoDevice *_this)
+SDL_WaylandDataSource *Wayland_data_source_create(SDL_VideoData *video_data)
 {
-    SDL_WaylandDataSource *data_source = NULL;
-    SDL_VideoData *driver_data = NULL;
-    struct wl_data_source *id = NULL;
-
-    if (!_this || !_this->internal) {
-        SDL_SetError("Video driver uninitialized");
-    } else {
-        driver_data = _this->internal;
-
-        if (driver_data->data_device_manager) {
-            id = wl_data_device_manager_create_data_source(
-                driver_data->data_device_manager);
-        }
-
-        if (!id) {
-            SDL_SetError("Wayland unable to create data source");
-        } else {
-            data_source = SDL_calloc(1, sizeof(*data_source));
-            if (!data_source) {
-                wl_data_source_destroy(id);
-            } else {
-                data_source->source = id;
-                wl_data_source_set_user_data(id, data_source);
-                wl_data_source_add_listener(id, &data_source_listener,
-                                            data_source);
-            }
-        }
+    SDL_WaylandDataSource *data_source = SDL_calloc(1, sizeof(*data_source));
+    if (!data_source) {
+        return NULL;
     }
+
+    struct wl_data_source *id = wl_data_device_manager_create_data_source(video_data->data_device_manager);
+    data_source->source = id;
+    wl_data_source_set_user_data(id, data_source);
+    wl_data_source_add_listener(id, &data_source_listener, data_source);
+
     return data_source;
 }
 
-SDL_WaylandPrimarySelectionSource *Wayland_primary_selection_source_create(SDL_VideoDevice *_this)
+SDL_WaylandPrimarySelectionSource *Wayland_primary_selection_source_create(SDL_VideoData *video_data)
 {
-    SDL_WaylandPrimarySelectionSource *primary_selection_source = NULL;
-    SDL_VideoData *driver_data = NULL;
-    struct zwp_primary_selection_source_v1 *id = NULL;
-
-    if (!_this || !_this->internal) {
-        SDL_SetError("Video driver uninitialized");
-    } else {
-        driver_data = _this->internal;
-
-        if (driver_data->primary_selection_device_manager) {
-            id = zwp_primary_selection_device_manager_v1_create_source(
-                driver_data->primary_selection_device_manager);
-        }
-
-        if (!id) {
-            SDL_SetError("Wayland unable to create primary selection source");
-        } else {
-            primary_selection_source = SDL_calloc(1, sizeof(*primary_selection_source));
-            if (!primary_selection_source) {
-                zwp_primary_selection_source_v1_destroy(id);
-            } else {
-                primary_selection_source->source = id;
-                zwp_primary_selection_source_v1_add_listener(id, &primary_selection_source_listener,
-                                                             primary_selection_source);
-            }
-        }
+    SDL_WaylandPrimarySelectionSource *primary_selection_source = SDL_calloc(1, sizeof(*primary_selection_source));
+    if (!primary_selection_source) {
+        return NULL;
     }
+
+    struct zwp_primary_selection_source_v1 *id = zwp_primary_selection_device_manager_v1_create_source(video_data->primary_selection_device_manager);
+    primary_selection_source->source = id;
+    zwp_primary_selection_source_v1_add_listener(id, &primary_selection_source_listener, primary_selection_source);
+
     return primary_selection_source;
 }
 

--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -2749,7 +2749,6 @@ static void data_device_handle_data_offer(void *data, struct wl_data_device *wl_
     SDL_WaylandDataOffer *data_offer = SDL_calloc(1, sizeof(*data_offer));
     if (data_offer) {
         SDL_WaylandDataDevice *data_device = (SDL_WaylandDataDevice *)data;
-        data_device->seat->display->last_incoming_data_offer_seat = data_device->seat;
         data_offer->offer = id;
         data_offer->data_device = data_device;
         data_offer->read_fd = -1;
@@ -3054,7 +3053,7 @@ static void primary_selection_device_handle_offer(void *data, struct zwp_primary
     SDL_WaylandPrimarySelectionOffer *primary_selection_offer = SDL_calloc(1, sizeof(*primary_selection_offer));
     if (primary_selection_offer) {
         SDL_WaylandPrimarySelectionDevice *primary_selection_device = (SDL_WaylandPrimarySelectionDevice *)data;
-        primary_selection_device->seat->display->last_incoming_primary_selection_seat = primary_selection_device->seat;
+        primary_selection_device->seat->display->current_primary_selection_seat = primary_selection_device->seat;
         primary_selection_offer->offer = id;
         primary_selection_offer->primary_selection_device = primary_selection_device;
         WAYLAND_wl_list_init(&(primary_selection_offer->mimes));

--- a/src/video/wayland/SDL_waylandvideo.h
+++ b/src/video/wayland/SDL_waylandvideo.h
@@ -96,8 +96,8 @@ struct SDL_VideoData
 
     struct wl_list seat_list;
     struct SDL_WaylandSeat *last_implicit_grab_seat;
-    struct SDL_WaylandSeat *last_incoming_data_offer_seat;
-    struct SDL_WaylandSeat *last_incoming_primary_selection_seat;
+    struct SDL_WaylandSeat *current_data_offer_seat;
+    struct SDL_WaylandSeat *current_primary_selection_seat;
     Wayland_EventThreadContext *event_thread_context;
 
     SDL_DisplayData **output_list;


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Cleans up the clipboard coding style (it was always different from the rest of the backend, and unnecessarily enforced an 80 character limit), fixes some edge-case behavior when dealing with multiple seats, and adjusts the behavior to not send intermediate nil source events when changing the clipboard data, as some clipboard managers prefer this.