### PR TITLE
Metal: Crash fix for required rebinding when switching pipelines.

### DIFF
--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -2417,7 +2417,6 @@ static void METAL_BindGraphicsPipeline(
 {
     @autoreleasepool {
         MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
-        MetalGraphicsPipeline *previousPipeline = metalCommandBuffer->graphics_pipeline;
         MetalGraphicsPipeline *pipeline = (MetalGraphicsPipeline *)graphicsPipeline;
         SDL_GPURasterizerState *rast = &pipeline->rasterizerState;
         Uint32 i;
@@ -2444,6 +2443,14 @@ static void METAL_BindGraphicsPipeline(
                 setDepthStencilState:pipeline->depth_stencil_state];
         }
 
+        // Mark that bindings are needed
+        metalCommandBuffer->needVertexSamplerBind = true;
+        metalCommandBuffer->needVertexStorageTextureBind = true;
+        metalCommandBuffer->needVertexStorageBufferBind = true;
+        metalCommandBuffer->needFragmentSamplerBind = true;
+        metalCommandBuffer->needFragmentStorageTextureBind = true;
+        metalCommandBuffer->needFragmentStorageBufferBind = true;
+
         for (i = 0; i < MAX_UNIFORM_BUFFERS_PER_STAGE; i += 1) {
             metalCommandBuffer->needVertexUniformBufferBind[i] = true;
             metalCommandBuffer->needFragmentUniformBufferBind[i] = true;
@@ -2460,17 +2467,6 @@ static void METAL_BindGraphicsPipeline(
             if (metalCommandBuffer->fragmentUniformBuffers[i] == NULL) {
                 metalCommandBuffer->fragmentUniformBuffers[i] = METAL_INTERNAL_AcquireUniformBufferFromPool(
                     metalCommandBuffer);
-            }
-        }
-
-        if (previousPipeline && previousPipeline != pipeline) {
-            // if the number of uniform buffers has changed, the storage buffers will move as well
-            // and need a rebind at their new locations
-            if (previousPipeline->header.num_vertex_uniform_buffers != pipeline->header.num_vertex_uniform_buffers) {
-                metalCommandBuffer->needVertexStorageBufferBind = true;
-            }
-            if (previousPipeline->header.num_fragment_uniform_buffers != pipeline->header.num_fragment_uniform_buffers) {
-                metalCommandBuffer->needFragmentStorageBufferBind = true;
             }
         }
     }
@@ -3187,6 +3183,10 @@ static void METAL_BindComputePipeline(
                     metalCommandBuffer);
             }
         }
+
+        metalCommandBuffer->needComputeSamplerBind = true;
+        metalCommandBuffer->needComputeReadOnlyStorageTextureBind = true;
+        metalCommandBuffer->needComputeReadOnlyStorageBufferBind = true;
 
         // Bind write-only resources
         if (pipeline->header.numReadWriteStorageTextures > 0) {


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

When switching pipelines, the Metal implementation omits rebinding of samplers, storagetextures, and storagebuffers, which can cause crashes when switching between pipelines. 

## Description
In METAL_BindGraphicsPipeline and METAL_BindComputePipeline it does not mark samplers, storage textures, and storage buffers for rebinding. This can cause a crash in this sequence of events:

Pipeline A: 1 Sampler --> Slot 0
Pipeline B: 1 Storage Texture --> overwrites Slot 0
Pipeline A: 1 Sampler -> no rebinding, but still using slot 0, which now has the storage texture in it, but it expects a sampler  --> Crash

This PR makes the Metal implementation match the D3D12 and Vulkan implementation. To fix the issue, I looked at:
- D3D12_BindGraphicsPipeline: it marks bindings that need a refresh on line 4788-4794.
- D3D12_BindComputePipeline: it marks bindings that need a refresh on line 5565-5567.
- VULKAN_BindGraphicsPipeline: it marks bindings that need a refresh on line 8170-8175.
- VULKAN_BindComputePipeline: it marks bindings that need a refresh on line 8393-8396.

All of these mark the samplers, storage textures and storage buffers need rebinding, so I added this to the metal implementation as well. I also removed a test inside METAL_BindGraphicsPipeline that was checking for one particular situation of pipeline switch, possibly to fix a previous problem like this. My changes catch this situation as well.

I ran testautomation (All tests passed) and can also confirm it fixed the crash I was seeing. 

## Existing Issue(s)
I couldn't find an open issue for this. 