### PR TITLE
wayland: don't redeclare getresuid/getresgid

### DIFF
--- a/src/video/wayland/SDL_waylandvideo.c
+++ b/src/video/wayland/SDL_waylandvideo.c
@@ -1604,19 +1604,23 @@ static int SDLCALL LibdecorNewInThread(void *data)
 }
 #endif
 
-#ifndef HAVE_GETRESUID
+#ifdef HAVE_GETRESUID
+#define SDL_getresuid getresuid
+#else
 // Non-POSIX, but Linux and some BSDs have it.
 // To reduce the number of code paths, if getresuid() isn't available at
 // compile-time, we behave as though it existed but failed at runtime.
-static inline int getresuid(uid_t *ruid, uid_t *euid, uid_t *suid) {
+static inline int SDL_getresuid(uid_t *ruid, uid_t *euid, uid_t *suid) {
     errno = ENOSYS;
     return -1;
 }
 #endif
 
-#ifndef HAVE_GETRESGID
+#ifdef HAVE_GETRESGID
+#define SDL_getresgid getresgid
+#else
 // Same as getresuid() but for the primary group
-static inline int getresgid(uid_t *ruid, uid_t *euid, uid_t *suid) {
+static inline int SDL_getresgid(gid_t *rgid, gid_t *egid, gid_t *sgid) {
     errno = ENOSYS;
     return -1;
 }
@@ -1638,12 +1642,12 @@ bool CanUseGtk(void)
     // we don't use Linux getauxval() or prctl PR_GET_DUMPABLE,
     // BSD issetugid(), or similar OS-specific detection
 
-    if (getresuid(&ruid, &euid, &suid) != 0) {
+    if (SDL_getresuid(&ruid, &euid, &suid) != 0) {
         ruid = suid = getuid();
         euid = geteuid();
     }
 
-    if (getresgid(&rgid, &egid, &sgid) != 0) {
+    if (SDL_getresgid(&rgid, &egid, &sgid) != 0) {
         rgid = sgid = getgid();
         egid = getegid();
     }


### PR DESCRIPTION
`SDL_waylandvideo.c` defines `static inline` fallbacks for `getresuid()`/`getresgid()` under
the libc names when `HAVE_GETRESUID`/`HAVE_GETRESGID` are not defined:

```c
#ifndef HAVE_GETRESUID
static inline int getresuid(uid_t *ruid, uid_t *euid, uid_t *suid) { ... }
#endif
```

glibc declares both functions non-static in `<unistd.h>`. If the build's feature checks do not
detect them while those declarations are still visible, the file no longer compiles:

```
src/video/wayland/SDL_waylandvideo.c:1611:19: error: static declaration of 'getresuid' follows non-static declaration
src/video/wayland/SDL_waylandvideo.c:1619:19: error: static declaration of 'getresgid' follows non-static declaration
```

We hit this building SDL 3.4.2 through vcpkg on a current Ubuntu CI image; the same code is
present on `main` (it moved here from `SDL_gtk.c` in e4f75bac4), so the problem is not
release-specific.

This renames the fallbacks to `SDL_getresuid`/`SDL_getresgid` and maps them to the libc
functions when available, so a fallback can never collide with a libc declaration. Behaviour is
unchanged in both configurations.

Also fixes the fallback `getresgid()` declaring `uid_t *` parameters where it should declare
`gid_t *`.
