### PR TITLE
render: Fix Xbox Series X|S shader include paths

### DIFF
--- a/src/render/direct3d12/SDL_shaders_d3d12_xboxseries.cpp
+++ b/src/render/direct3d12/SDL_shaders_d3d12_xboxseries.cpp
@@ -49,11 +49,11 @@
 #undef g_main
 
 #define g_main D3D12_PixelShader_Textures_PQ
-#include "D3D12_PixelShader_Textures_Series_PQ.h"
+#include "D3D12_PixelShader_Textures_PQ_Series.h"
 #undef g_main
 
 #define g_main D3D12_PixelShader_Textures_Simple
-#include "D3D12_PixelShader_Textures_Series_Simple.h"
+#include "D3D12_PixelShader_Textures_Simple_Series.h"
 #undef g_main
 
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description

A couple of the new shader include paths added for Xbox Series X|S in 23b6410 accidentally had the "_Series" suffix in the wrong place, which caused build errors for the VisualC-GDK project. I've fixed those up here.

(I also checked the Xbox One shader paths and confirmed that they're all good!)