### PR TITLE
iOS: fix SDL_GetUIKitDeviceFormFactor return type

### DIFF
--- a/src/SDL.c
+++ b/src/SDL.c
@@ -874,7 +874,7 @@ SDL_FormFactor SDL_GetDeviceFormFactor(void)
 #elif defined(SDL_PLATFORM_ANDROID)
     return SDL_GetAndroidDeviceFormFactor();
 #elif defined(SDL_PLATFORM_IOS)
-    extern bool SDL_GetUIKitDeviceFormFactor(void);
+    extern SDL_FormFactor SDL_GetUIKitDeviceFormFactor(void);
     return SDL_GetUIKitDeviceFormFactor();
 #elif defined(SDL_PLATFORM_XBOXONE) || defined(SDL_PLATFORM_XBOXSERIES) || defined(SDL_PLATFORM_PS2)
     return SDL_FORMFACTOR_CONSOLE;

--- a/src/video/uikit/SDL_uikitvideo.m
+++ b/src/video/uikit/SDL_uikitvideo.m
@@ -385,7 +385,7 @@ void SDL_NSLog(const char *prefix, const char *text)
  * subsystem, but we need to stuff this into an Objective-C source code file.
  */
 
-bool SDL_GetUIKitDeviceFormFactor(void)
+SDL_FormFactor SDL_GetUIKitDeviceFormFactor(void)
 {
     // TODO: Apple Watch
     switch ([UIDevice currentDevice].userInterfaceIdiom) {


### PR DESCRIPTION
The function returns SDL_FormFactor values but was declared as bool, so iOS devices were misclassified (e.g. tablets as desktop).

- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description

`SDL_GetUIKitDeviceFormFactor()` returns `SDL_FormFactor` values, but was still declared as returning `bool` after #12584.

Because of that, the result was truncated to 0/1 (`SDL_FORMFACTOR_UNKNOWN` / `SDL_FORMFACTOR_DESKTOP`), so iOS devices were misclassified — for example tablets were not reported as tablets.

This changes the declaration and definition to `SDL_FormFactor`, matching `SDL_GetAndroidDeviceFormFactor()` and the public `SDL_GetDeviceFormFactor()` API.

cc @Semphriss (related to #12584)

## Existing Issue(s)

None (regression from #12584)
