### PR TITLE
Fix initial window size and fullscreen toggle behaviour across APIs

### DIFF
--- a/android-project/app/src/main/res/values/styles.xml
+++ b/android-project/app/src/main/res/values/styles.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="android:Theme.NoTitleBar.Fullscreen">
-        <!-- Customize your theme here. -->
+    <style name="AppTheme" parent="android:Theme.NoTitleBar">
+    <!-- Allow drawing under status & nav bars -->
+    <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+    <item name="android:statusBarColor">@android:color/transparent</item>
+    <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
 </resources>

--- a/android-project/app/src/main/res/values/styles.xml
+++ b/android-project/app/src/main/res/values/styles.xml
@@ -6,5 +6,6 @@
     <item name="android:windowDrawsSystemBarBackgrounds">true</item>
     <item name="android:statusBarColor">@android:color/transparent</item>
     <item name="android:navigationBarColor">@android:color/transparent</item>
+    <!-- Add custom themes here -->
     </style>
 </resources>


### PR DESCRIPTION
[x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

".Fullscreen" theme is legacy and disrupts true control over full screen behaviour on Java side. We also need to be able to see what's drawn under the status & nav bars.

Fixes #16054