### PR TITLE
Fix edge-to-edge layout for Android 11 and above

### DIFF
--- a/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -384,6 +384,9 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
         Log.v(TAG, "onCreate()");
         super.onCreate(savedInstanceState);
 
+        if (Build.VERSION.SDK_INT >= 30 /* Android 11 (R) */) {
+            getWindow().setDecorFitsSystemWindows(false);
+        }
 
         /* Control activity re-creation */
         if (mSDLMainFinished || mActivityCreated) {
@@ -1037,7 +1040,6 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
                                 // Android 15+ (API 35+), where edge-to-edge is enforced for
                                 // apps targeting that SDK, so the status/navigation bars
                                 // would never hide. Use WindowInsetsController instead.
-                                window.setDecorFitsSystemWindows(false);
                                 final WindowInsetsController controller = window.getInsetsController();
                                 if (controller != null) {
                                     controller.hide(WindowInsets.Type.systemBars());
@@ -1079,10 +1081,6 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
                         }
                         if (Build.VERSION.SDK_INT >= 30 /* Android 11 (R) */) {
                             window.getAttributes().layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS;
-                        }
-                        if (Build.VERSION.SDK_INT >= 30 /* Android 11 (R) */ &&
-                            Build.VERSION.SDK_INT < 35 /* Android 15 */) {
-                            SDLActivity.onNativeInsetsChanged(0, 0, 0, 0);
                         }
                     }
                 } else {


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

if setDecorFitsSystemWindows is done too late, then the initial window size won't be the right size. 

Zeroing the safe zone is nonsense, as it's handled correctly elsewhere.

Fixes #16102 
