### PR TITLE
Fix wired Xbox controllers not detected when SDL is compiled with GameInput

### DIFF
--- a/src/joystick/gdk/SDL_gameinputjoystick.cpp
+++ b/src/joystick/gdk/SDL_gameinputjoystick.cpp
@@ -492,7 +492,9 @@ static bool GAMEINPUT_JoystickIsDevicePresent(Uint16 vendor_id, Uint16 product_i
         if (vendor_id == USB_VENDOR_MICROSOFT &&
             product_id == USB_PRODUCT_XBOX_ONE_XBOXGIP_CONTROLLER) {
             // The Xbox One controller shows up as a hardcoded raw input VID/PID, which we definitely handle
-            return true;
+            if (SDL_GetHintBoolean(SDL_HINT_JOYSTICK_GAMEINPUT, SDL_GAMEINPUT_DEFAULT)) {
+                return true;
+            }
         }
 
         for (int i = 0; i < g_GameInputList.count; ++i) {


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
There is a circular ownership bug between XInput and GameInput drivers.

This bug is not present on `main`, but is present on latest stable release (3.4.12 as of writing).

This PR is simply a cherry-pick of the existing commit that fixed this in `main`.

### Circularity

1. SDL 3.4.12 defaults the desktop GameInput controller hint off, but GameInput v3 raw-device handling on. Therefore [`SDL_gameinputjoystick.cpp:413`](https://github.com/libsdl-org/SDL/blob/release-3.4.12/src/joystick/gdk/SDL_gameinputjoystick.cpp#L413) initialises GameInput and leaves `g_pGameInput` non-null, while registering only for `GameInputKindRawDeviceReport`.
2. XInput detects the wired controller under the generic VID/PID `045e:02ff`.
3. [`SDL_xinputjoystick.c:143`](https://github.com/libsdl-org/SDL/blob/release-3.4.12/src/joystick/windows/SDL_xinputjoystick.c#L143) asks higher-priority drivers whether they own that identity.
4. [`SDL_gameinputjoystick.cpp:491`](https://github.com/libsdl-org/SDL/blob/release-3.4.12/src/joystick/gdk/SDL_gameinputjoystick.cpp#L491) sees non-null `g_pGameInput` and unconditionally claims `045e:02ff`, even though the GameInput controller hint is off and GameInput has not exposed the controller. XInput consequently rejects it.
5. DirectInput is enabled by default. [`SDL_dinputjoystick.c:252`](https://github.com/libsdl-org/SDL/blob/release-3.4.12/src/joystick/windows/SDL_dinputjoystick.c#L252) sees the IG_ device path and enabled XInput, so DirectInput also rejects it, expecting XInput to handle it.
6. RawInput and WGI are disabled by default. HIDAPI deliberately ignores Windows' fake XGIP HID endpoint. No backend remains.

Disabling `SDL_JOYSTICK_GAMEINPUT_RAW` restored the controller through XInput (since `g_pGameInput` is then null). Disabling XInput as well restored it as a DirectInput joystick. 

## Existing Issue(s)
Fixes #16096 
