### PR TITLE
Add back metadata reset change that was accidentally reverted

### DIFF
--- a/src/joystick/hidapi/SDL_hidapi_gip.c
+++ b/src/joystick/hidapi/SDL_hidapi_gip.c
@@ -2789,7 +2789,7 @@ static bool HIDAPI_DriverGIP_InitDevice(SDL_HIDAPI_Device *device)
         return false;
     }
     ctx->device = device;
-    ctx->reset_for_metadata = SDL_GetHintBoolean(SDL_HINT_JOYSTICK_HIDAPI_GIP_RESET_FOR_METADATA, false);
+    ctx->reset_for_metadata = SDL_GetHintBoolean(SDL_HINT_JOYSTICK_HIDAPI_GIP_RESET_FOR_METADATA, true);
 
     attachment = GIP_EnsureAttachment(ctx, 0);
     GIP_HandleQuirks(attachment);


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When i was tidying up https://github.com/libsdl-org/SDL/pull/16009 i accidentally reverted a change to the reset behaviour, so this just applies that change again

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
