### PR TITLE
camera: Detect `exclusive_caps` v4l2loopback devices

### DIFF
--- a/src/core/linux/SDL_udev.c
+++ b/src/core/linux/SDL_udev.c
@@ -485,7 +485,7 @@ static int device_class(struct udev_device *dev)
 {
     const char *subsystem;
     const char *val = NULL;
-    const char* attr = NULL;
+    const char *attr = NULL;
     int devclass = 0;
 
     subsystem = _this->syms.udev_device_get_subsystem(dev);

--- a/src/core/linux/SDL_udev.c
+++ b/src/core/linux/SDL_udev.c
@@ -510,7 +510,6 @@ static int device_class(struct udev_device *dev)
                 }
             }
         }
-
     } else if (SDL_strcmp(subsystem, "input") == 0) {
         // udev rules reference: http://cgit.freedesktop.org/systemd/systemd/tree/src/udev/udev-builtin-input_id.c
 

--- a/src/core/linux/SDL_udev.c
+++ b/src/core/linux/SDL_udev.c
@@ -485,6 +485,7 @@ static int device_class(struct udev_device *dev)
 {
     const char *subsystem;
     const char *val = NULL;
+    const char* attr = NULL;
     int devclass = 0;
 
     subsystem = _this->syms.udev_device_get_subsystem(dev);
@@ -496,9 +497,20 @@ static int device_class(struct udev_device *dev)
         devclass = SDL_UDEV_DEVICE_SOUND;
     } else if (SDL_strcmp(subsystem, "video4linux") == 0) {
         val = _this->syms.udev_device_get_property_value(dev, "ID_V4L_CAPABILITIES");
-        if (val && SDL_strcasestr(val, "capture")) {
-            devclass = SDL_UDEV_DEVICE_VIDEO_CAPTURE;
+        if (val) {
+            if (SDL_strcasestr(val, "capture")) {
+                devclass = SDL_UDEV_DEVICE_VIDEO_CAPTURE;
+            }
+            // v4l2loopback may report output caps before reporting capture caps
+            // and ID_V4L_CAPABILITIES is never updated
+            else if (SDL_strcasestr(val, "video_output")) {
+                attr = _this->syms.udev_device_get_sysattr_value(dev, "state");
+                if (attr && SDL_strcmp(attr, "capture") == 0) {
+                    devclass = SDL_UDEV_DEVICE_VIDEO_CAPTURE;
+                }
+            }
         }
+
     } else if (SDL_strcmp(subsystem, "input") == 0) {
         // udev rules reference: http://cgit.freedesktop.org/systemd/systemd/tree/src/udev/udev-builtin-input_id.c
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
As stated in the issue linked below, v4l2loopback devices in `exclusive_caps` mode are ignored by SDL_Camera, because  device is created with `video_output` caps and changed when frames start being produced, and udev is never informed that the device now has `capture` caps.

The code checks if the device has `video_output` caps as well as being in the `capture` state.

There are two concerns with this solution: 
- The `state` attribute is not documented and was found by looking through the attributes available on the /sys device.

- v4l2loopback devices are usually not destroyed when they stop capturing, and no notification is provided via udev either, so the device will remain enumerated forever. 
However there is an upside to this, being that a virtual camera can be disconnected and reconnected with no interruption (other than no longer receiving new frames).

## Existing Issue(s)
https://github.com/libsdl-org/SDL/issues/15003
