### PR TITLE
Fix tray menu pointer check

### DIFF
--- a/src/tray/unix/SDL_dbustray.c
+++ b/src/tray/unix/SDL_dbustray.c
@@ -88,8 +88,6 @@ static DBusHandlerResult TrayHandleGetAllProps(SDL_Tray *tray, SDL_TrayDBus *tra
     dbus_uint32_t uint32_val;
     dbus_bool_t bool_value;
 
-    menu_dbus = tray->menu ? (SDL_TrayMenuDBus *)tray->menu->internal : NULL;
-
     empty = "";
     driver->dbus->message_iter_init(msg, &iter);
     driver->dbus->message_iter_get_basic(&iter, &interface);
@@ -150,7 +148,7 @@ static DBusHandlerResult TrayHandleGetAllProps(SDL_Tray *tray, SDL_TrayDBus *tra
     driver->dbus->message_iter_close_container(&dict_iter, &entry_iter);
 
     key = "ItemIsMenu";
-    menu_dbus = (SDL_TrayMenuDBus *)tray->menu->internal;
+    menu_dbus = tray->menu ? (SDL_TrayMenuDBus *)tray->menu->internal : NULL;
     if (menu_dbus && menu_dbus->menu_path) {
         bool_value = TRUE;
     } else {


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Commit 7b7a74e missed that `tray->menu->internal` is read twice. Remove first read and put NULL-check on second one.