### PR TITLE
Haiku: Fix incorrect version macro in SDL_SYS_OpenURL

### DIFF
--- a/src/misc/haiku/SDL_sysurl.cc
+++ b/src/misc/haiku/SDL_sysurl.cc
@@ -25,7 +25,7 @@
 
 bool SDL_SYS_OpenURL(const char *url)
 {
-#if B_BEOS_VERSION <= B_HAIKU_VERSION_1_BETA_5
+#if B_HAIKU_VERSION <= B_HAIKU_VERSION_1_BETA_5
     BUrl burl(url);
 #else
     BUrl burl(url, true);


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Use B_HAIKU_VERSION instead of B_BEOS_VERSION.

## Description
Previous version would compare B_BEOS_VERSION to B_HAIKU_VERSION_1_BETA_5. These are not compatible, and, as a result, the wrong branch was used and the program would fail to compile.
Using B_HAIKU_VERSION instead fixes the issue as tested on a nightly build (hrev59933).

## Existing Issue(s)
None
