### PR TITLE
examples/woodeneye: Display correct splitview for 4 players

### DIFF
--- a/examples/demo/02-woodeneye-008/woodeneye-008.c
+++ b/examples/demo/02-woodeneye-008/woodeneye-008.c
@@ -206,7 +206,7 @@ static void draw(SDL_Renderer *renderer, const float (*edges)[6], const Player p
         for (i = 0; i < players_len; i++) {
             const Player *player = &players[i];
             float mod_x = (float)(i % part_hor);
-            float mod_y = (float)i / part_hor;
+            float mod_y = (float)(i / part_hor);
             float hor_origin = (mod_x + 0.5f) * size_hor;
             float ver_origin = (mod_y + 0.5f) * size_ver;
             float cam_origin = (float)(0.5 * SDL_sqrt(size_hor * size_hor + size_ver * size_ver));


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<img width="640" height="480" alt="Screenshot From 2026-08-07 19-17-56" src="https://github.com/user-attachments/assets/a9fd6b91-319b-4af9-864d-733210438f7a" />


## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
Fixes #16126