### PR TITLE
metal: Fix inverted return value in METAL_QueryFence

### DIFF
--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -3633,7 +3633,7 @@ static bool METAL_QueryFence(
     SDL_GPUFence *fence)
 {
     MetalFence *metalFence = (MetalFence *)fence;
-    return METAL_INTERNAL_IsFenceBusy(metalFence);
+    return !METAL_INTERNAL_IsFenceBusy(metalFence);
 }
 
 // Window and Swapchain Management


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description

SDL_QueryGPUFence is documented to return true when the fence is signaled (complete). Since 514b26e4c it returns METAL_INTERNAL_IsFenceBusy directly, so it returns true when the fence is still busy, breaking usage of SDL_AcquireGPUSwapchainTexture.

Reason it went unnoticed is likely that most people use SDL_WaitAndAcquireGPUSwapchainTexture, which goes through [METAL_WaitForFences](https://github.com/libsdl-org/SDL/blob/616b8fb338c55249a4a9d6c2245f0a10410f9aec/src/gpu/metal/SDL_gpu_metal.m#L3598) instead and it does this properly.