### PR TITLE
fix SDL_gpu_vulkan validation warning

### DIFF
--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -6209,6 +6209,8 @@ static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
         colorAttachmentReferences[colorAttachmentReferenceCount].attachment = attachmentDescriptionCount;
         colorAttachmentReferences[colorAttachmentReferenceCount].layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
+        resolveReferences[colorAttachmentReferenceCount].layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
         attachmentDescriptionCount += 1;
 
         if (colorTargetInfos[i].store_op == SDL_GPU_STOREOP_RESOLVE || colorTargetInfos[i].store_op == SDL_GPU_STOREOP_RESOLVE_AND_STORE) {
@@ -6225,7 +6227,6 @@ static VkRenderPass VULKAN_INTERNAL_CreateRenderPass(
             attachmentDescriptions[attachmentDescriptionCount].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
             resolveReferences[colorAttachmentReferenceCount].attachment = attachmentDescriptionCount;
-            resolveReferences[colorAttachmentReferenceCount].layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
             attachmentDescriptionCount += 1;
             resolveReferenceCount += 1;


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Fixes a validation warning from layout being unset.

```

VUID-VkAttachmentReference-layout-parameter(ERROR / SPEC): msgNum: 1971405941 - Validation Error: [ VUID-VkAttachmentReference-layout-parameter ] | MessageID = 0x75814475 | vkCreateRenderPass(): pCreateInfo->pSubpasses[0].pResolveAttachments[0].layout (3435973836) does not fall within the begin..end range of the VkImageLayout enumeration tokens and is not an extension added token.
The Vulkan spec states: layout must be a valid VkImageLayout value (https://vulkan.lunarg.com/doc/view/1.4.304.1/windows/antora/spec/latest/chapters/renderpass.html#VUID-VkAttachmentReference-layout-parameter)
VUID-VkAttachmentReference-layout-parameter(ERROR / SPEC): msgNum: 1971405941 - Validation Error: [ VUID-VkAttachmentReference-layout-parameter ] | MessageID = 0x75814475 | vkCreateRenderPass(): pCreateInfo->pSubpasses[0].pResolveAttachments[0].layout (3435973836) does not fall within the begin..end range of the VkImageLayout enumeration tokens and is not an extension added token.
The Vulkan spec states: layout must be a valid VkImageLayout value (https://vulkan.lunarg.com/doc/view/1.4.304.1/windows/antora/spec/latest/chapters/renderpass.html#VUID-VkAttachmentReference-layout-parameter)
```
