### PR TITLE
evdev: Fix vertical high-resolution mouse wheel scaling

### DIFF
--- a/src/core/linux/SDL_evdev.c
+++ b/src/core/linux/SDL_evdev.c
@@ -516,11 +516,10 @@ void SDL_EVDEV_Poll(void)
 
                         if (item->mouse_wheel != 0 || item->mouse_hwheel != 0) {
                             Uint64 timestamp = SDL_EVDEV_GetEventTimestamp(event);
-                            const float denom = (item->high_res_hwheel ? 120.0f : 1.0f);
                             SDL_SendMouseWheel(timestamp,
                                                mouse->focus, (SDL_MouseID)item->fd,
-                                               item->mouse_hwheel / denom,
-                                               item->mouse_wheel / denom,
+                                               item->mouse_hwheel / (item->high_res_hwheel ? 120.0f : 1.0f),
+                                               item->mouse_wheel / (item->high_res_wheel ? 120.0f : 1.0f),
                                                SDL_MOUSEWHEEL_NORMAL);
                             item->mouse_wheel = item->mouse_hwheel = 0;
                         }


### PR DESCRIPTION
## Description

This pull request fixes a regression introduced by c44fa5bb

https://github.com/libsdl-org/SDL/blob/c44fa5bb07f7f859ded7bc7bcb037f9976ec147b/src/core/linux/SDL_evdev.c#L521-L529

The following commit f37eef9 removed the raw mouse API but retained the shared scaling logic in the form of the current denom variable.

https://github.com/libsdl-org/SDL/blob/f37eef948ce7844e8c6310c8785a16919e28e21f/src/core/linux/SDL_evdev.c#L517-L522

The evdev backend currently uses high_res_hwheel to select the normalization denominator for both horizontal and vertical wheel events.

This causes devices which advertise REL_WHEEL_HI_RES but not REL_HWHEEL_HI_RES to report vertical wheel movement 120 times larger than intended.

## Changes

This commit use the corresponding high-resolution capability independently for each axis, restoring the behavior before c44fa5bb.

---

I encountered this bug while running Moonlight Qt directly from a Debian TTY using SDL3/sdl2-compat with KMSDRM and evdev. A single mouse-wheel detent caused the remote system to scroll an abnormally large distance.

My mouse supports REL_WHEEL_HI_RES but not REL_HWHEEL_HI_RES, which exposed the incorrect shared scaling factor in SDL's evdev backend.

---

Declaration: I used ChatGPT to help trace the evdev → SDL → Moonlight input path and review the relevant SDL commit history. But the code patch is verified to fix the issue on my machine.

- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->
