### PR TITLE
gdk: Update to GDK April 2026 Update 3

### DIFF
--- a/.github/actions/setup-gdk-desktop/action.yml
+++ b/.github/actions/setup-gdk-desktop/action.yml
@@ -4,10 +4,10 @@ inputs:
   # Keep edition and ref in sync!
   edition:
     description: 'GDK edition'
-    default: '240601'  # YYMMUU (Year Month Update)
+    default: '260403'  # YYMMUU (Year Month Update)
   ref:
     description: 'Git reference'
-    default: 'June_2024_Update_1'
+    default: 'April-2026-Update-3-v2604.3.7874'
   folder:
     description: 'Folder where to create Directory.Build.props'
     required: true

--- a/VisualC-GDK/SDL/SDL.vcxproj
+++ b/VisualC-GDK/SDL/SDL.vcxproj
@@ -103,7 +103,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <LibraryPath>$(Console_SdkLibPath);$(LibraryPath)</LibraryPath>
-    <IncludePath>$(Console_SdkIncludeRoot)$(IncludePath)</IncludePath>
+    <IncludePath>$(Console_SdkIncludeRoot);$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Desktop.x64'">
     <Midl>

--- a/VisualC-GDK/SDL/SDL.vcxproj
+++ b/VisualC-GDK/SDL/SDL.vcxproj
@@ -101,11 +101,9 @@
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Xbox.Scarlett.x64'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Xbox.XboxOne.x64'" />
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Desktop.x64'">
-    <IncludePath>$(ProjectDir)../../src;$(IncludePath)</IncludePath>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Desktop.x64'">
-    <IncludePath>$(ProjectDir)../../src;$(IncludePath)</IncludePath>
+  <PropertyGroup>
+    <LibraryPath>$(Console_SdkLibPath);$(LibraryPath)</LibraryPath>
+    <IncludePath>$(Console_SdkIncludeRoot)$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Desktop.x64'">
     <Midl>
@@ -132,7 +130,7 @@
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>gameinput.lib;setupapi.lib;winmm.lib;imm32.lib;version.lib;xgameruntime.lib;vcruntimed.lib;msvcrtd.lib;ucrtd.lib;msvcprtd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gameinput.lib;setupapi.lib;winmm.lib;imm32.lib;version.lib;xgameruntime.lib;appnotify.lib;Microsoft.Xbox.Services.C.Thunks.lib;vcruntimed.lib;msvcrtd.lib;ucrtd.lib;msvcprtd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
@@ -161,7 +159,7 @@
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>gameinput.lib;setupapi.lib;winmm.lib;imm32.lib;version.lib;xgameruntime.lib;d3d12_xs.lib;uuid.lib;vcruntimed.lib;msvcrtd.lib;ucrtd.lib;msvcprtd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gameinput.lib;setupapi.lib;winmm.lib;imm32.lib;version.lib;xgameruntime.lib;d3d12_xs.lib;uuid.lib;Microsoft.Xbox.Services.C.Thunks.lib;vcruntimed.lib;msvcrtd.lib;ucrtd.lib;msvcprtd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
@@ -199,15 +197,15 @@
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>gameinput.lib;setupapi.lib;winmm.lib;imm32.lib;version.lib;xgameruntime.lib;d3d12_x.lib;uuid.lib;vcruntimed.lib;msvcrtd.lib;ucrtd.lib;msvcprtd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gameinput.lib;setupapi.lib;winmm.lib;imm32.lib;version.lib;xgameruntime.lib;d3d12_x.lib;uuid.lib;Microsoft.Xbox.Services.C.Thunks.lib;vcruntimed.lib;msvcrtd.lib;ucrtd.lib;msvcprtd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
     </Link>
     <PreBuildEvent>
       <Command>
-        call $(ProjectDir)..\..\src\render\direct3d12\compile_shaders_xbox.bat $(ProjectDir)..\ one
-        call $(ProjectDir)..\..\src\gpu\d3d12\compile_shaders_xbox.bat $(ProjectDir)..\ one
+        call "$(ProjectDir)..\..\src\render\direct3d12\compile_shaders_xbox.bat" "$(ProjectDir)..\" one
+        call "$(ProjectDir)..\..\src\gpu\d3d12\compile_shaders_xbox.bat" "$(ProjectDir)..\" one
       </Command>
     </PreBuildEvent>
     <PreBuildEvent>
@@ -238,7 +236,7 @@
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>gameinput.lib;setupapi.lib;winmm.lib;imm32.lib;version.lib;xgameruntime.lib;vcruntime.lib;msvcrt.lib;ucrt.lib;msvcprt.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gameinput.lib;setupapi.lib;winmm.lib;imm32.lib;version.lib;xgameruntime.lib;appnotify.lib;Microsoft.Xbox.Services.C.Thunks.lib;vcruntime.lib;msvcrt.lib;ucrt.lib;msvcprt.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -268,7 +266,7 @@
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>gameinput.lib;setupapi.lib;winmm.lib;imm32.lib;version.lib;xgameruntime.lib;d3d12_xs.lib;uuid.lib;vcruntime.lib;msvcrt.lib;ucrt.lib;msvcprt.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gameinput.lib;setupapi.lib;winmm.lib;imm32.lib;version.lib;xgameruntime.lib;d3d12_xs.lib;uuid.lib;Microsoft.Xbox.Services.C.Thunks.lib;vcruntime.lib;msvcrt.lib;ucrt.lib;msvcprt.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -277,8 +275,8 @@
     </Link>
     <PreBuildEvent>
       <Command>
-        call $(ProjectDir)..\..\src\render\direct3d12\compile_shaders_xbox.bat $(ProjectDir)..\
-        call $(ProjectDir)..\..\src\gpu\d3d12\compile_shaders_xbox.bat $(ProjectDir)..\
+        call "$(ProjectDir)..\..\src\render\direct3d12\compile_shaders_xbox.bat" "$(ProjectDir)..\"
+        call "$(ProjectDir)..\..\src\gpu\d3d12\compile_shaders_xbox.bat" "$(ProjectDir)..\"
       </Command>
     </PreBuildEvent>
     <PreBuildEvent>
@@ -307,7 +305,7 @@
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>gameinput.lib;setupapi.lib;winmm.lib;imm32.lib;version.lib;xgameruntime.lib;d3d12_x.lib;uuid.lib;vcruntime.lib;msvcrt.lib;ucrt.lib;msvcprt.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gameinput.lib;setupapi.lib;winmm.lib;imm32.lib;version.lib;xgameruntime.lib;d3d12_x.lib;uuid.lib;Microsoft.Xbox.Services.C.Thunks.lib;vcruntime.lib;msvcrt.lib;ucrt.lib;msvcprt.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -316,8 +314,8 @@
     </Link>
     <PreBuildEvent>
       <Command>
-        call $(ProjectDir)..\..\src\render\direct3d12\compile_shaders_xbox.bat $(ProjectDir)..\ one
-        call $(ProjectDir)..\..\src\gpu\d3d12\compile_shaders_xbox.bat $(ProjectDir)..\ one
+        call "$(ProjectDir)..\..\src\render\direct3d12\compile_shaders_xbox.bat" "$(ProjectDir)..\" one
+        call "$(ProjectDir)..\..\src\gpu\d3d12\compile_shaders_xbox.bat" "$(ProjectDir)..\" one
       </Command>
     </PreBuildEvent>
     <PreBuildEvent>
@@ -658,7 +656,7 @@
     <ClCompile Include="..\..\src\audio\SDL_wave.c" />
     <ClCompile Include="..\..\src\audio\wasapi\SDL_wasapi.c" />
     <ClCompile Include="..\..\src\core\SDL_core_unsupported.c" />
-    <ClCompile Include="..\..\src\core\windows\SDL_gameinput.cpp"/>
+    <ClCompile Include="..\..\src\core\windows\SDL_gameinput.cpp" />
     <ClCompile Include="..\..\src\core\windows\SDL_hid.c" />
     <ClCompile Include="..\..\src\core\windows\SDL_immdevice.c" />
     <ClCompile Include="..\..\src\core\windows\SDL_windows.c" />
@@ -942,6 +940,16 @@
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\src\core\windows\version.rc" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(Platform)'=='Gaming.Desktop.x64'">
+    <ReferenceCopyLocalPaths Include="$(GameDKCoreLatest)windows\bin\x64\libHttpClient.dll" />
+    <ReferenceCopyLocalPaths Include="$(GameDKCoreLatest)windows\bin\x64\XCurl.dll" />
+    <ReferenceCopyLocalPaths Include="$(GameDKCoreLatest)windows\bin\x64\Microsoft.Xbox.Services.C.Thunks.dll" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(Platform)'!='Gaming.Desktop.x64'">
+    <ReferenceCopyLocalPaths Include="$(GameDKCoreLatest)xbox\bin\x64\libHttpClient.dll" />
+    <ReferenceCopyLocalPaths Include="$(GameDKCoreLatest)xbox\bin\x64\XCurl.dll" />
+    <ReferenceCopyLocalPaths Include="$(GameDKCoreLatest)xbox\bin\x64\Microsoft.Xbox.Services.C.Thunks.dll" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/VisualC-GDK/SDL/SDL.vcxproj.filters
+++ b/VisualC-GDK/SDL/SDL.vcxproj.filters
@@ -514,6 +514,7 @@
     <ClInclude Include="..\..\src\video\yuv2rgb\yuv_rgb_lsx_func.h" />
     <ClInclude Include="..\..\src\video\yuv2rgb\yuv_rgb_sse.h" />
     <ClInclude Include="..\..\src\video\yuv2rgb\yuv_rgb_std.h" />
+    <ClInclude Include="..\..\src\gpu\xr\SDL_gpu_openxr_c.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\src\core\windows\version.rc" />

--- a/VisualC-GDK/SDL_test/SDL_test.vcxproj
+++ b/VisualC-GDK/SDL_test/SDL_test.vcxproj
@@ -100,6 +100,10 @@
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Xbox.Scarlett.x64'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Xbox.XboxOne.x64'" />
   </PropertyGroup>
+  <PropertyGroup>
+    <LibraryPath>$(Console_SdkLibPath);$(LibraryPath)</LibraryPath>
+    <IncludePath>$(Console_SdkIncludeRoot)$(IncludePath)</IncludePath>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Desktop.x64'">
     <Midl />
     <ClCompile>

--- a/VisualC-GDK/SDL_test/SDL_test.vcxproj
+++ b/VisualC-GDK/SDL_test/SDL_test.vcxproj
@@ -102,7 +102,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <LibraryPath>$(Console_SdkLibPath);$(LibraryPath)</LibraryPath>
-    <IncludePath>$(Console_SdkIncludeRoot)$(IncludePath)</IncludePath>
+    <IncludePath>$(Console_SdkIncludeRoot);$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Desktop.x64'">
     <Midl />

--- a/VisualC-GDK/tests/testcontroller/testcontroller.vcxproj
+++ b/VisualC-GDK/tests/testcontroller/testcontroller.vcxproj
@@ -113,6 +113,10 @@
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Xbox.Scarlett.x64'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Xbox.XboxOne.x64'" />
   </PropertyGroup>
+  <PropertyGroup>
+    <LibraryPath>$(Console_SdkLibPath);$(LibraryPath)</LibraryPath>
+    <IncludePath>$(Console_SdkIncludeRoot)$(IncludePath)</IncludePath>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Desktop.x64'">
     <Midl>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -134,7 +138,7 @@
     </ResourceCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>xgameruntime.lib;../Microsoft.Xbox.Services.GDK.C.Thunks.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>xgameruntime.lib;Microsoft.Xbox.Services.C.Thunks.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Xbox.Scarlett.x64'">
@@ -209,7 +213,7 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>xgameruntime.lib;../Microsoft.Xbox.Services.GDK.C.Thunks.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>xgameruntime.lib;Microsoft.Xbox.Services.C.Thunks.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Xbox.Scarlett.x64'">
@@ -307,15 +311,6 @@
     <CopyFileToFolders Include="..\..\logos\Logo150x150.png" />
     <CopyFileToFolders Include="..\..\logos\Logo44x44.png" />
     <CopyFileToFolders Include="..\..\logos\Logo480x480.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <CopyFileToFolders Include="$(Console_GRDKExtLibRoot)Xbox.Services.API.C\DesignTime\CommonConfiguration\Neutral\Lib\Release\Microsoft.Xbox.Services.GDK.C.Thunks.dll">
-      <FileType>Document</FileType>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Xbox.Scarlett.x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Xbox.XboxOne.x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Xbox.Scarlett.x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Xbox.XboxOne.x64'">true</ExcludedFromBuild>
-    </CopyFileToFolders>
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="xboxseries\MicrosoftGame.config">

--- a/VisualC-GDK/tests/testcontroller/testcontroller.vcxproj
+++ b/VisualC-GDK/tests/testcontroller/testcontroller.vcxproj
@@ -115,7 +115,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <LibraryPath>$(Console_SdkLibPath);$(LibraryPath)</LibraryPath>
-    <IncludePath>$(Console_SdkIncludeRoot)$(IncludePath)</IncludePath>
+    <IncludePath>$(Console_SdkIncludeRoot);$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Desktop.x64'">
     <Midl>

--- a/VisualC-GDK/tests/testcontroller/testcontroller.vcxproj.filters
+++ b/VisualC-GDK/tests/testcontroller/testcontroller.vcxproj.filters
@@ -31,9 +31,6 @@
       <Filter>logos</Filter>
     </CopyFileToFolders>
     <CopyFileToFolders Include="PackageLayout.xml" />
-    <CopyFileToFolders Include="$(Console_GRDKExtLibRoot)Xbox.Services.API.C\DesignTime\CommonConfiguration\Neutral\Lib\Release\Microsoft.Xbox.Services.GDK.C.Thunks.dll">
-      <Filter>wingdk</Filter>
-    </CopyFileToFolders>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="logos">

--- a/VisualC-GDK/tests/testgdk/testgdk.vcxproj
+++ b/VisualC-GDK/tests/testgdk/testgdk.vcxproj
@@ -113,6 +113,10 @@
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Xbox.Scarlett.x64'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Xbox.XboxOne.x64'" />
   </PropertyGroup>
+  <PropertyGroup>
+    <LibraryPath>$(Console_SdkLibPath);$(LibraryPath)</LibraryPath>
+    <IncludePath>$(Console_SdkIncludeRoot)$(IncludePath)</IncludePath>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Desktop.x64'">
     <Midl>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -134,7 +138,7 @@
     </ResourceCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>xgameruntime.lib;../Microsoft.Xbox.Services.GDK.C.Thunks.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>xgameruntime.lib;Microsoft.Xbox.Services.C.Thunks.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>
@@ -221,7 +225,7 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>xgameruntime.lib;../Microsoft.Xbox.Services.GDK.C.Thunks.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>xgameruntime.lib;Microsoft.Xbox.Services.C.Thunks.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>
@@ -343,15 +347,6 @@ copy "%(FullPath)" "$(OutDir)\"</Command>
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="wingdk\MicrosoftGame.config">
-      <FileType>Document</FileType>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Xbox.Scarlett.x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Xbox.XboxOne.x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Xbox.Scarlett.x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Xbox.XboxOne.x64'">true</ExcludedFromBuild>
-    </CopyFileToFolders>
-  </ItemGroup>
-  <ItemGroup>
-    <CopyFileToFolders Include="$(Console_GRDKExtLibRoot)Xbox.Services.API.C\DesignTime\CommonConfiguration\Neutral\Lib\Release\Microsoft.Xbox.Services.GDK.C.Thunks.dll">
       <FileType>Document</FileType>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Xbox.Scarlett.x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Xbox.XboxOne.x64'">true</ExcludedFromBuild>

--- a/VisualC-GDK/tests/testgdk/testgdk.vcxproj
+++ b/VisualC-GDK/tests/testgdk/testgdk.vcxproj
@@ -115,7 +115,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <LibraryPath>$(Console_SdkLibPath);$(LibraryPath)</LibraryPath>
-    <IncludePath>$(Console_SdkIncludeRoot)$(IncludePath)</IncludePath>
+    <IncludePath>$(Console_SdkIncludeRoot);$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Desktop.x64'">
     <Midl>

--- a/VisualC-GDK/tests/testgdk/testgdk.vcxproj.filters
+++ b/VisualC-GDK/tests/testgdk/testgdk.vcxproj.filters
@@ -32,9 +32,6 @@
       <Filter>logos</Filter>
     </CopyFileToFolders>
     <CopyFileToFolders Include="PackageLayout.xml" />
-    <CopyFileToFolders Include="$(Console_GRDKExtLibRoot)Xbox.Services.API.C\DesignTime\CommonConfiguration\Neutral\Lib\Release\Microsoft.Xbox.Services.GDK.C.Thunks.dll">
-      <Filter>wingdk</Filter>
-    </CopyFileToFolders>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="logos">

--- a/VisualC-GDK/tests/testsprite/testsprite.vcxproj
+++ b/VisualC-GDK/tests/testsprite/testsprite.vcxproj
@@ -113,6 +113,10 @@
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Xbox.Scarlett.x64'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Xbox.XboxOne.x64'" />
   </PropertyGroup>
+  <PropertyGroup>
+    <LibraryPath>$(Console_SdkLibPath);$(LibraryPath)</LibraryPath>
+    <IncludePath>$(Console_SdkIncludeRoot)$(IncludePath)</IncludePath>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Desktop.x64'">
     <Midl>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -134,7 +138,7 @@
     </ResourceCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>xgameruntime.lib;../Microsoft.Xbox.Services.GDK.C.Thunks.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>xgameruntime.lib;Microsoft.Xbox.Services.C.Thunks.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>
@@ -221,7 +225,7 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>xgameruntime.lib;../Microsoft.Xbox.Services.GDK.C.Thunks.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>xgameruntime.lib;Microsoft.Xbox.Services.C.Thunks.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>
@@ -343,15 +347,6 @@ copy "%(FullPath)" "$(OutDir)\"</Command>
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="wingdk/MicrosoftGame.config">
-      <FileType>Document</FileType>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Xbox.Scarlett.x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Xbox.XboxOne.x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Xbox.Scarlett.x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Xbox.XboxOne.x64'">true</ExcludedFromBuild>
-    </CopyFileToFolders>
-  </ItemGroup>
-  <ItemGroup>
-    <CopyFileToFolders Include="$(Console_GRDKExtLibRoot)Xbox.Services.API.C\DesignTime\CommonConfiguration\Neutral\Lib\Release\Microsoft.Xbox.Services.GDK.C.Thunks.dll">
       <FileType>Document</FileType>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Xbox.Scarlett.x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Gaming.Xbox.XboxOne.x64'">true</ExcludedFromBuild>

--- a/VisualC-GDK/tests/testsprite/testsprite.vcxproj
+++ b/VisualC-GDK/tests/testsprite/testsprite.vcxproj
@@ -115,7 +115,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <LibraryPath>$(Console_SdkLibPath);$(LibraryPath)</LibraryPath>
-    <IncludePath>$(Console_SdkIncludeRoot)$(IncludePath)</IncludePath>
+    <IncludePath>$(Console_SdkIncludeRoot);$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Gaming.Desktop.x64'">
     <Midl>

--- a/VisualC-GDK/tests/testsprite/testsprite.vcxproj.filters
+++ b/VisualC-GDK/tests/testsprite/testsprite.vcxproj.filters
@@ -31,9 +31,6 @@
       <Filter>logos</Filter>
     </CopyFileToFolders>
     <CopyFileToFolders Include="PackageLayout.xml" />
-    <CopyFileToFolders Include="$(Console_GRDKExtLibRoot)Xbox.Services.API.C\DesignTime\CommonConfiguration\Neutral\Lib\Release\Microsoft.Xbox.Services.GDK.C.Thunks.dll">
-      <Filter>wingdk</Filter>
-    </CopyFileToFolders>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="logos">

--- a/build-scripts/setup-gdk-desktop.py
+++ b/build-scripts/setup-gdk-desktop.py
@@ -14,8 +14,9 @@ import urllib.request
 import zipfile
 
 # Update both variables when updating the GDK
-GIT_REF = "June_2024_Update_1"
-GDK_EDITION = "240601"  # YYMMUU
+GIT_REF = "April-2026-Update-3-v2604.3.7874"
+GDK_EDITION = "260403"  # YYMMUU
+ARCHIVE_NAME = "GDK_2604.3.7874"
 
 logger = logging.getLogger(__name__)
 
@@ -25,34 +26,33 @@ class GdDesktopConfigurator:
         self.gdk_edition = gdk_edition or GDK_EDITION
         self.gdk_path = gdk_path
         self.temp_folder = temp_folder or Path(tempfile.gettempdir())
-        self.dl_archive_path = Path(self.temp_folder) / f"{ self.git_ref }.zip"
-        self.gdk_extract_path = Path(self.temp_folder) / f"GDK-{ self.git_ref }"
+        self.dl_archive_path = Path(self.temp_folder) / f"{ ARCHIVE_NAME }.zip"
+        self.gdk_extract_path = Path(self.temp_folder) / f"{ ARCHIVE_NAME }"
         self.arch = arch
         self.vs_folder = vs_folder
         self._vs_version = vs_version
         self._vs_toolset = vs_toolset
 
     def download_archive(self) -> None:
-        gdk_url = f"https://github.com/microsoft/GDK/archive/refs/tags/{ GIT_REF }.zip"
+        gdk_url = f"https://github.com/microsoft/GDK/releases/downloads/{ GIT_REF }/{ ARCHIVE_NAME }.zip"
         logger.info("Downloading %s to %s", gdk_url, self.dl_archive_path)
         urllib.request.urlretrieve(gdk_url, self.dl_archive_path)
         assert self.dl_archive_path.is_file()
 
     def extract_zip_archive(self) -> None:
-        extract_path = self.gdk_extract_path.parent
         assert self.dl_archive_path.is_file()
-        logger.info("Extracting %s to %s", self.dl_archive_path, extract_path)
+        logger.info("Extracting %s to %s", self.dl_archive_path, self.gdk_extract_path)
         with zipfile.ZipFile(self.dl_archive_path) as zf:
-            zf.extractall(extract_path)
+            zf.extractall(self.gdk_extract_path)
         assert self.gdk_extract_path.is_dir(), f"{self.gdk_extract_path} must exist"
 
     def extract_development_kit(self) -> None:
-        extract_dks_cmd = self.gdk_extract_path / "SetupScripts/ExtractXboxOneDKs.cmd"
-        assert extract_dks_cmd.is_file()
-        logger.info("Extracting GDK Development Kit: running %s", extract_dks_cmd)
-        cmd = ["cmd.exe", "/C", str(extract_dks_cmd), str(self.gdk_extract_path), str(self.gdk_path)]
-        logger.debug("Running %r", cmd)
-        subprocess.check_call(cmd)
+        extract_dks_ps1 = self.gdk_extract_path / "SetupScripts/ExtractXboxOneDKs.ps1"
+        assert extract_dks_ps1.is_file()
+        logger.info("Extracting GDK Development Kit: running %s", extract_dks_ps1)
+        ps = ["powershell.exe", str(extract_dks_ps1), str(self.gdk_extract_path), str(self.gdk_path)]
+        logger.debug("Running %r", ps)
+        subprocess.check_call(ps)
 
     def detect_vs_version(self) -> str:
         vs_regex = re.compile("VS([0-9]{4})")
@@ -156,7 +156,7 @@ class GdDesktopConfigurator:
         return {
             "GRDKEDITION": f"{self.gdk_edition}",
             "GameDK": f"{game_dk}\\",
-            "GameDKLatest": f"{ game_dk_latest }\\",
+            "GameDKCoreLatest": f"{ game_dk_latest }\\",
             "WindowsSdkDir": f"{ windows_sdk_dir }\\",
             "GamingGRDKBuild": f"{ gaming_grdk_build }\\",
             "VSInstallDir": f"{ self.vs_folder }\\",
@@ -182,6 +182,7 @@ class GdDesktopConfigurator:
                     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
                     <XdkEditionTarget>{ self.gdk_edition }</XdkEditionTarget>
                     <DurangoXdkInstallPath>{ durango_xdk_install_path }</DurangoXdkInstallPath>
+                    <GameDKCoreLatest>{ self.game_dk_latest_path }\\</GameDKCoreLatest>
 
                     <DefaultXdkEditionRootVS2019>$(DurangoXdkInstallPath)\\{self.gdk_edition}\\GRDK\\VS2019\\flatDeployment\\MSBuild\\Microsoft\\VC\\{self.vs_toolset}\\Platforms\\$(Platform)\\</DefaultXdkEditionRootVS2019>
                     <XdkEditionRootVS2019>$(DurangoXdkInstallPath)\\{self.gdk_edition}\\GRDK\\VS2019\\flatDeployment\\MSBuild\\Microsoft\\VC\\{self.vs_toolset}\\Platforms\\$(Platform)\\</XdkEditionRootVS2019>
@@ -206,13 +207,13 @@ class GdDesktopConfigurator:
     @property
     def gdk_include_paths(self) -> list[Path]:
         return [
-            self.gaming_grdk_build_path / "gamekit/include",
+            self.game_dk_latest_path / "windows/include",
         ]
 
     @property
     def gdk_library_paths(self) -> list[Path]:
         return [
-            self.gaming_grdk_build_path / f"gamekit/lib/{self.arch}",
+            self.game_dk_latest_path / f"windows/lib/{self.arch}",
         ]
 
     @property
@@ -248,7 +249,7 @@ class GdDesktopConfigurator:
 def main():
     logging.basicConfig(level=logging.INFO)
     parser = argparse.ArgumentParser(allow_abbrev=False)
-    parser.add_argument("--arch", choices=["amd64"], default="amd64", help="Architecture")
+    parser.add_argument("--arch", choices=["x64"], default="x64", help="Architecture")
     parser.add_argument("--download", action="store_true", help="Download GDK")
     parser.add_argument("--extract", action="store_true", help="Extract downloaded GDK")
     parser.add_argument("--copy-msbuild", action="store_true", help="Copy MSBuild files")

--- a/docs/README-gdk.md
+++ b/docs/README-gdk.md
@@ -9,8 +9,8 @@ Windows (GDK) and  Xbox One/Xbox Series (GDKX) are both supported and all the re
 Requirements
 ------------
 
-* Microsoft Visual Studio 2022 (in theory, it should also work in 2017 or 2019, but this has not been tested)
-* Microsoft GDK October 2023 Update 1 or newer (public release [here](https://github.com/microsoft/GDK/releases/tag/October_2023_Update_1))
+* Microsoft Visual Studio 2022 (in theory, it should also work in 2019 or 2026, but this has not been tested)
+* Microsoft GDK April 2026 Update 3 or newer (public release [here](https://github.com/microsoft/GDK/releases/tag/April-2026-Update-3-v2604.3.7874))
 * For Xbox, you will need the corresponding GDKX version (licensed developers only)
 * To publish a package or successfully authenticate a user, you will need to create an app id/configure services in Partner Center. However, for local testing purposes (without authenticating on Xbox Live), the test identifiers used by the GDK test programs in the included solution work.
 
@@ -76,7 +76,7 @@ While the Gaming.Desktop.x64 configuration sets most of the required settings, t
 * Under Linker > Input > Additional Dependencies, you need the following:
   * `SDL3.lib`
   * `xgameruntime.lib`
-  * `../Microsoft.Xbox.Services.GDK.C.Thunks.lib`
+  * `Microsoft.Xbox.Services.C.Thunks.lib`
 * Note that in general, the GDK libraries depend on the MSVC C/C++ runtime, so there is no way to remove this dependency from a GDK program that links against GDK.
 
 ### 4. Setting up SDL_main ###
@@ -88,10 +88,9 @@ Rather than using your own implementation of `WinMain`, it's recommended that yo
 The game will not launch in the debugger unless required DLLs are included in the directory that contains the game's .exe file. You need to make sure that the following files are copied into the directory:
 
 * Your SDL3.dll
-* "$(Console_GRDKExtLibRoot)Xbox.Services.API.C\DesignTime\CommonConfiguration\Neutral\Lib\Release\Microsoft.Xbox.Services.GDK.C.Thunks.dll"
+* Microsoft.Xbox.Services.C.Thunks.dll
 * XCurl.dll
-
-You can either copy these in a post-build step, or you can add the dlls into the project and set its Configuration Properties > General > Item type to "Copy file," which will also copy them into the output directory.
+* libHttpClient.dll
 
 ### 6. Setting up MicrosoftGame.config ###
 
@@ -199,3 +198,14 @@ Furthermore, confirm that your PC is set to the correct sandbox.
 #### "The current user has already installed an unpackaged version of this app. A packaged version cannot replace this." error when installing
 
 Prior to June 2022 GDK, running from the Visual Studio debugger would still locally register the app (and it would appear on the start menu). To fix this, you have to uninstall it (it's simplest to right click on it from the start menu to uninstall it).
+
+### Missing headers / linker errors after updating to April 2026 GDK or newer
+
+Existing projects using the "old layout" of GDK may need to add the following to their vcxproj in order for GDK system headers and libraries to be found:
+```
+<PropertyGroup>
+  <LibraryPath>$(Console_SdkLibPath);$(LibraryPath)</LibraryPath>
+  <IncludePath>$(Console_SdkIncludeRoot)$(IncludePath)</IncludePath>
+</PropertyGroup>
+```
+See SDL.vcxproj for an example of this.

--- a/docs/README-gdk.md
+++ b/docs/README-gdk.md
@@ -205,7 +205,7 @@ Existing projects using the "old layout" of GDK may need to add the following to
 ```
 <PropertyGroup>
   <LibraryPath>$(Console_SdkLibPath);$(LibraryPath)</LibraryPath>
-  <IncludePath>$(Console_SdkIncludeRoot)$(IncludePath)</IncludePath>
+  <IncludePath>$(Console_SdkIncludeRoot);$(IncludePath)</IncludePath>
 </PropertyGroup>
 ```
 See SDL.vcxproj for an example of this.

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -1996,7 +1996,7 @@ static void D3D12_INTERNAL_TextureTransitionToDefaultUsage(
 static D3D12_RESOURCE_STATES D3D12_INTERNAL_DefaultBufferResourceState(
     D3D12Buffer *buffer)
 {
-    D3D12_RESOURCE_STATES states = 0;
+    D3D12_RESOURCE_STATES states = (D3D12_RESOURCE_STATES)0;
 
     if (buffer->container->usage & SDL_GPU_BUFFERUSAGE_VERTEX) {
         states |= D3D12_RESOURCE_STATE_VERTEX_AND_CONSTANT_BUFFER;

--- a/src/gpu/d3d12/compile_shaders_xbox.bat
+++ b/src/gpu/d3d12/compile_shaders_xbox.bat
@@ -1,11 +1,11 @@
 if %2.==one. goto setxboxone
 rem Xbox Series compile
-set COMPILER="%GameDKLatest%\GXDK\bin\Scarlett\DXC.exe"
+set COMPILER="%GameDKCoreLatest%xbox\bin\gen9\DXC.exe"
 set SUFFIX=_Series.h
 goto startbuild
 
 :setxboxone
-set COMPILER="%GameDKLatest%\GXDK\bin\XboxOne\DXC.exe"
+set COMPILER="%GameDKCoreLatest%xbox\bin\gen8\DXC.exe"
 set SUFFIX=_One.h
 
 :startbuild

--- a/src/render/direct3d12/compile_shaders_xbox.bat
+++ b/src/render/direct3d12/compile_shaders_xbox.bat
@@ -1,11 +1,11 @@
 if %2.==one. goto setxboxone
 rem Xbox Series compile
-set DXC="%GameDKLatest%\GXDK\bin\Scarlett\DXC.exe"
+set DXC="%GameDKCoreLatest%xbox\bin\gen9\DXC.exe"
 set SUFFIX=_Series.h
 goto startbuild
 
 :setxboxone
-set DXC="%GameDKLatest%\GXDK\bin\XboxOne\DXC.exe"
+set DXC="%GameDKCoreLatest%xbox\bin\gen8\DXC.exe"
 set SUFFIX=_One.h
 
 :startbuild


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
SDL currently targets the October 2023 GDK, which is no longer allowed for Xbox submissions.

It's still possible to use the existing Visual Studio project with newer GDK versions, but not for much longer; the build system relies heavily on the "old layout" of the GDK install directory, which is being fully removed and replaced as of the upcoming October 2026 GDK update. When using SDL with the "new layout", the platform include paths, library paths, and even shader compiler paths are no longer functional.

This PR updates the VisualC-GDK project to target the latest GDK version as of the time of this writing (April 2026) with support for the new layout. This should hopefully future-proof the build system for a few years at least.

I also fixed a C++ compile error in SDL_gpu_d3d12.c and aligned all shader compiler invocations to use quoted paths.

WinGDK is happy with these changes, but I'm marking this as a draft until I can do some Xbox testing.
