### PR TITLE
pipewire: Apply pending default when device is added

### DIFF
--- a/src/audio/pipewire/SDL_pipewire.c
+++ b/src/audio/pipewire/SDL_pipewire.c
@@ -291,7 +291,11 @@ static bool io_list_check_add(struct io_node *node)
     spa_list_append(&hotplug_io_list, &node->link);
 
     if (hotplug_events_enabled) {
-        SDL_AddAudioDevice(node->recording, node->name, &node->spec, PW_ID_TO_HANDLE(node->id));
+        SDL_AudioDevice *device = SDL_AddAudioDevice(node->recording, node->name, &node->spec, PW_ID_TO_HANDLE(node->id));
+        const char *default_path = node->recording ? pipewire_default_source_id : pipewire_default_sink_id;
+        if (default_path && SDL_strcmp(node->path, default_path) == 0) {
+            SDL_DefaultAudioDeviceChanged(device);
+        }
     }
 
     return true;


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

PipeWire may publish a new default source or sink through its metadata before the corresponding node has finished registering, so SDL records the new default path but cannot resolve it to an audio device immediately. When the node is added later, SDL currently reports the new audio device without checking whether it matches the pending default. 

This PR compares the node path with the recorded default source or sink path and, when they match, notifies SDL that the default audio device has changed.