### PR TITLE
Support running interactive tests with a SDL refusing invalid parameters

### DIFF
--- a/examples/asyncio/01-load-bitmaps/load-bitmaps.c
+++ b/examples/asyncio/01-load-bitmaps/load-bitmaps.c
@@ -102,7 +102,9 @@ SDL_AppResult SDL_AppIterate(void *appstate)
     SDL_RenderClear(renderer);
 
     for (i = 0; i < SDL_arraysize(textures); i++) {
-        SDL_RenderTexture(renderer, textures[i], NULL, &texture_rects[i]);
+        if (textures[i]) {
+            SDL_RenderTexture(renderer, textures[i], NULL, &texture_rects[i]);
+        }
     }
 
     SDL_RenderPresent(renderer);

--- a/examples/demo/04-bytepusher/bytepusher.c
+++ b/examples/demo/04-bytepusher/bytepusher.c
@@ -344,7 +344,7 @@ SDL_AppResult SDL_AppEvent(void* appstate, SDL_Event* event) {
         case SDL_EVENT_DROP_FILE:
             load_file(vm, event->drop.data);
             break;
-        
+
         case SDL_EVENT_KEY_DOWN:
 #ifndef __EMSCRIPTEN__
             if (event->key.key == SDLK_ESCAPE) {
@@ -366,8 +366,8 @@ SDL_AppResult SDL_AppEvent(void* appstate, SDL_Event* event) {
                 vm->keystate |= keycode_mask(event->key.key);
             }
             break;
-        
-        case SDL_EVENT_KEY_UP: 
+
+        case SDL_EVENT_KEY_UP:
             if (vm->positional_input) {
                 vm->keystate &= ~scancode_mask(event->key.scancode);
             } else {

--- a/examples/demo/04-bytepusher/bytepusher.c
+++ b/examples/demo/04-bytepusher/bytepusher.c
@@ -302,6 +302,10 @@ static Uint16 keycode_mask(SDL_Keycode key) {
     int index;
     if (key >= SDLK_0 && key <= SDLK_9) {
         index = key - SDLK_0;
+    } else if (key >= SDLK_KP_1 && key <= SDLK_KP_9) {
+        index = key - SDLK_KP_1 + 1;
+    } else if (key == SDLK_KP_0) {
+        index = 0;
     } else if (key >= SDLK_A && key <= SDLK_F) {
         index = key - SDLK_A + 10;
     } else {

--- a/examples/renderer/17-read-pixels/read-pixels.c
+++ b/examples/renderer/17-read-pixels/read-pixels.c
@@ -126,7 +126,9 @@ SDL_AppResult SDL_AppIterate(void *appstate)
     if (surface) {
         /* Rebuild converted_texture if the dimensions have changed (window resized, etc). */
         if ((surface->w != converted_texture_width) || (surface->h != converted_texture_height)) {
-            SDL_DestroyTexture(converted_texture);
+            if (converted_texture) {
+                SDL_DestroyTexture(converted_texture);
+            }
             converted_texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_STREAMING, surface->w, surface->h);
             if (!converted_texture) {
                 SDL_Log("Couldn't (re)create conversion texture: %s", SDL_GetError());

--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -5533,7 +5533,7 @@ bool SDL_RenderPresent(SDL_Renderer *renderer)
 
     CHECK_RENDERER_MAGIC(renderer, false);
 
-    CHECK_PARAM(renderer->target) {
+    if (renderer->target) {
         if (!renderer->window && SDL_strcmp(renderer->name, SDL_GPU_RENDERER) == 0) {
             // We're an offscreen renderer, we must submit the command queue
         } else {

--- a/src/render/gpu/SDL_render_gpu.c
+++ b/src/render/gpu/SDL_render_gpu.c
@@ -1747,7 +1747,7 @@ static bool GPU_CreateRenderer(SDL_Renderer *renderer, SDL_Window *window, SDL_P
     GPU_RenderData *data = NULL;
 
     // Clear any OpenGL properties on the window to avoid potential driver conflicts.
-    SDL_WindowFlags flags = SDL_GetWindowFlags(window);
+    SDL_WindowFlags flags = window ? SDL_GetWindowFlags(window) : 0;
     if (flags & SDL_WINDOW_OPENGL) {
         flags &= ~SDL_WINDOW_OPENGL;
         SDL_ReconfigureWindow(window, flags);

--- a/test/testffmpeg.c
+++ b/test/testffmpeg.c
@@ -1592,7 +1592,7 @@ int main(int argc, char *argv[])
         }
 
         if (flushing && !decoded) {
-            if (SDL_GetAudioStreamQueued(audio) > 0 && !nodelay) {
+            if (audio && SDL_GetAudioStreamQueued(audio) > 0 && !nodelay) {
                 /* Wait a little bit for the audio to finish */
                 SDL_Delay(10);
             } else {
@@ -1619,11 +1619,15 @@ quit:
     avcodec_free_context(&audio_context);
     avcodec_free_context(&video_context);
     avformat_close_input(&ic);
-    SDL_DestroyRenderer(renderer);
+    if (renderer) {
+        SDL_DestroyRenderer(renderer);
+    }
     if (vulkan_context) {
         DestroyVulkanVideoContext(vulkan_context);
     }
-    SDL_DestroyWindow(window);
+    if (window) {
+        SDL_DestroyWindow(window);
+    }
     SDL_Quit();
     SDLTest_CommonDestroyState(state);
     return return_code;

--- a/test/testintersections.c
+++ b/test/testintersections.c
@@ -210,8 +210,12 @@ static void loop(void *arg)
 
     /* Check for events */
     while (SDL_PollEvent(&event)) {
+        SDL_Window *window;
         SDLTest_CommonEvent(state, &event, done);
-        SDL_ConvertEventToRenderCoordinates(SDL_GetRenderer(SDL_GetWindowFromEvent(&event)), &event);
+        window = SDL_GetWindowFromEvent(&event);
+        if (window) {
+            SDL_ConvertEventToRenderCoordinates(SDL_GetRenderer(window), &event);
+        }
         switch (event.type) {
         case SDL_EVENT_MOUSE_BUTTON_DOWN:
             mouse_begin_x = event.button.x;

--- a/test/testmodal.c
+++ b/test/testmodal.c
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
                 quit = 1;
                 break;
             } else if (e.type == SDL_EVENT_WINDOW_CLOSE_REQUESTED) {
-                if (e.window.windowID == SDL_GetWindowID(w2)) {
+                if (w2 && e.window.windowID == SDL_GetWindowID(w2)) {
                     SDL_DestroyRenderer(r2);
                     SDL_DestroyWindow(w2);
                     r2 = NULL;

--- a/test/testrotate.c
+++ b/test/testrotate.c
@@ -104,7 +104,9 @@ static bool UpdateRotation(SDL_Renderer *renderer)
         return false;
     }
 
-    SDL_DestroyTexture(texture);
+    if (texture) {
+        SDL_DestroyTexture(texture);
+    }
     texture = SDL_CreateTextureFromSurface(renderer, rotated);
     SDL_DestroySurface(rotated);
     if (!texture) {

--- a/test/testyuv.c
+++ b/test/testyuv.c
@@ -674,9 +674,9 @@ static bool run_all_format_test(SDL_Window *window, const char *requested_render
 
     for (int i = 0; i < SDL_GetNumRenderDrivers() && !quit; ++i) {
         const char *renderer_name = SDL_GetRenderDriver(i);
-		if (requested_renderer && SDL_strcmp(renderer_name, requested_renderer) != 0) {
-			continue;
-		}
+        if (requested_renderer && SDL_strcmp(renderer_name, requested_renderer) != 0) {
+            continue;
+        }
 
         SDL_Renderer *renderer = SDL_CreateRenderer(window, renderer_name);
         if (!renderer) {
@@ -1047,9 +1047,11 @@ int main(int argc, char **argv)
     }
 
 done:
-	SDL_free(filename);
+    SDL_free(filename);
     SDL_DestroySurface(original);
-    SDL_DestroyWindow(window);
+    if (window) {
+        SDL_DestroyWindow(window);
+    }
     SDL_Quit();
     SDLTest_CommonDestroyState(state);
     return result;


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

This lets all interactive SDL tests run against a SDL built with `-DSDL_ASSERT_INVALID_PARAMS`,
which shows an assertion failure every time an invalid argument gets passed to SDL.

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
