### PR TITLE
fixes incorrect comment in viewport example

### DIFF
--- a/examples/renderer/14-viewport/viewport.c
+++ b/examples/renderer/14-viewport/viewport.c
@@ -98,7 +98,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
     SDL_SetRenderViewport(renderer, NULL);  /* NULL means "use the whole window" */
     SDL_RenderTexture(renderer, texture, NULL, &dst_rect);
 
-    /* top right quarter of the window. */
+    /* bottom right quarter of the window. */
     viewport.x = WINDOW_WIDTH / 2;
     viewport.y = WINDOW_HEIGHT / 2;
     viewport.w = WINDOW_WIDTH / 2;


### PR DESCRIPTION
- [x ] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
Fixed a comment which mistakenly describes where the image is rendered.

## Existing Issue(s)
No. Minor fix.
