### PR TITLE
test: Fix MSAA support in testgpu_spinning_cube

### DIFF
--- a/test/testgpu_spinning_cube.c
+++ b/test/testgpu_spinning_cube.c
@@ -715,8 +715,6 @@ static void Render(SDL_Window *window, const int windownum)
         color_target.store_op = SDL_GPU_STOREOP_RESOLVE;
         color_target.texture = winstate->tex_msaa;
         color_target.resolve_texture = winstate->tex_resolve;
-        color_target.cycle = true;
-        color_target.cycle_resolve_texture = true;
     } else {
         color_target.load_op = SDL_GPU_LOADOP_CLEAR;
         color_target.store_op = SDL_GPU_STOREOP_STORE;
@@ -752,6 +750,13 @@ static void Render(SDL_Window *window, const int windownum)
     if (sprite_render_state.renderer) {
         /* Load the existing color target so we can blend with it */
         color_target.load_op = SDL_GPU_LOADOP_LOAD;
+
+        if (render_state.sample_count > SDL_GPU_SAMPLECOUNT_1) {
+            /* Use the resolve texture for the sprite overlay */
+            color_target.texture = winstate->tex_resolve;
+            color_target.resolve_texture = NULL;
+            color_target.store_op = SDL_GPU_STOREOP_STORE;
+        }
 
         pass = SDL_BeginGPURenderPass(cmd, &color_target, 1, NULL);
         RenderSpriteOverlay(pass, &sprite_render_state, &winstate->sprite_state);


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
When the sprite overlay in the `testgpu_spinning_cube` app begins its render pass, it uses the same `SDL_GPUColorTargetInfo` that was previously used for the cube's render pass. When the `--msaa` option is set, this results in a bunch of invalid behavior:

* `color_target.cycle` is set to true, which is incompatible with `LOADOP_LOAD`
* `color_target.texture` is still set to the multisample texture, whose contents are undefined at this point since the target has a `store_op` of `RESOLVE` instead of `RESOLVE_AND_STORE`
* The SDL_Render sprite pipeline is not configured to render to multisample color targets

To fix all of this, I've made it so that the color target textures are never cycled, and the sprite overlay render pass sets its `color_target.texture` to the previous pass's resolve texture instead of the multisample texture.

## Existing Issue(s)
Resolves https://github.com/libsdl-org/SDL/issues/16139
