### PR TITLE
x11: Skip announcing WM_TAKE_FOCUS in WM_PROTOCOLS

### DIFF
--- a/src/video/x11/SDL_x11video.c
+++ b/src/video/x11/SDL_x11video.c
@@ -383,7 +383,6 @@ static bool X11_VideoInit(SDL_VideoDevice *_this)
 #define GET_ATOM(X) data->atoms.X = X11_XInternAtom(data->display, #X, False)
     GET_ATOM(WM_PROTOCOLS);
     GET_ATOM(WM_DELETE_WINDOW);
-    GET_ATOM(WM_TAKE_FOCUS);
     GET_ATOM(WM_NAME);
     GET_ATOM(WM_TRANSIENT_FOR);
     GET_ATOM(WM_STATE);

--- a/src/video/x11/SDL_x11video.h
+++ b/src/video/x11/SDL_x11video.h
@@ -70,7 +70,6 @@ struct SDL_VideoData
     struct {
         Atom WM_PROTOCOLS;
         Atom WM_DELETE_WINDOW;
-        Atom WM_TAKE_FOCUS;
         Atom WM_NAME;
         Atom WM_TRANSIENT_FOR;
         Atom WM_STATE;

--- a/src/video/x11/SDL_x11window.c
+++ b/src/video/x11/SDL_x11window.c
@@ -844,7 +844,6 @@ bool X11_CreateWindow(SDL_VideoDevice *_this, SDL_Window *window, SDL_Properties
         int proto_count = 0;
 
         protocols[proto_count++] = data->atoms.WM_DELETE_WINDOW; // Allow window to be deleted by the WM
-        protocols[proto_count++] = data->atoms.WM_TAKE_FOCUS;    // Since we will want to set input focus explicitly
 
         // Default to using ping if there is no hint
         if (SDL_GetHintBoolean(SDL_HINT_VIDEO_X11_NET_WM_PING, true)) {


### PR DESCRIPTION
By putting the WM_TAKE_FOCUS atom in the WM_PROTOCOLS property, SDL chooses either the "Locally Active" or "Globally Active" input model depending on the input flag in WM_HINTS.

In order to assist the window manager with making the right decision, for example, skip this window when choosing what window to activate next, it will be better if the WM knows right away that the window accepts or doesn't accept focus (in other words, have either both the input flag set in WM_HINTS + WM_TAKE_FOCUS or none).

Since the WM_TAKE_FOCUS atom is placed in the WM_PROTOCOLS property, the WM wanting to adhere to the spec has no choice but send a client message asking to activate the window and hope for the better.

At quick glance, it appears that the WM_TAKE_FOCUS atom is leftover from SDL_WINDOWEVENT_TAKE_FOCUS, which was dropped a while ago, and is not used anymore. So this change removes the WM_TAKE_FOCUS atom to help window managers such as kwin work better.

- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").