### PR TITLE
emscripten: Avoid unnecessarily enabling simulate_vsync

### DIFF
--- a/src/video/emscripten/SDL_emscriptenopengles.c
+++ b/src/video/emscripten/SDL_emscriptenopengles.c
@@ -30,6 +30,8 @@
 #include "SDL_emscriptenopengles.h"
 #include "../../main/SDL_main_callbacks.h"
 
+static int pending_swap_interval = -1;
+
 bool Emscripten_GLES_LoadLibrary(SDL_VideoDevice *_this, const char *path)
 {
     return true;
@@ -50,6 +52,7 @@ bool Emscripten_GLES_SetSwapInterval(SDL_VideoDevice *_this, int interval)
         return SDL_SetError("Late swap tearing currently unsupported");
     }
 
+    pending_swap_interval = -1;
     if (Emscripten_ShouldSetSwapInterval(interval)) {
         // don't change the mainloop timing if the app is also driving a main callback with this hint,
         //  as we assume that was the more deliberate action.
@@ -60,6 +63,10 @@ bool Emscripten_GLES_SetSwapInterval(SDL_VideoDevice *_this, int interval)
                 emscripten_set_main_loop_timing(EM_TIMING_RAF, interval);
             }
         }
+    } else {
+        // Mirror what's happening on the video side to make sure Emscripten_GLES_GetSwapInterval
+        // returns a consistent view of the swap interval, to avoid enabling simulate_vsync.
+        pending_swap_interval = interval;
     }
 
     return true;
@@ -68,6 +75,11 @@ bool Emscripten_GLES_SetSwapInterval(SDL_VideoDevice *_this, int interval)
 bool Emscripten_GLES_GetSwapInterval(SDL_VideoDevice *_this, int *interval)
 {
     int mode, value;
+
+    if (pending_swap_interval != -1) {
+        *interval = pending_swap_interval;
+        return true;
+    }
 
     emscripten_get_main_loop_timing(&mode, &value);
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description

`SDL_SetRendererVSync` enables `simulate_vsync` if it notices that setting the swap interval does nothing: set 1, get 0 => simulate vsync. In the emscripten implementation's case, if called early enough, the setter will not actually change the emscripten main loop timing. Instead, the requested interval will be stored to be used later. The problem is, the getter gets its swap interval from the emscripten main loop's current state, which wasn't changed, and this leads to `simulate_vsync` being enabled.

I verified with the Chromium profiler that the original issue (unnecessary sleep) reproduces in the `testrendercopyex` test if vsync is enabled, and also that this PR fixes the issue (no more unnecessary sleep).

The actual fix is a little annoying, repeating the file-local pending variable pattern from `SDL_emscriptenvideo.c`. But it doesn't seem too ugly to me, and doesn't require communicating that state more explicitly between these two, which is a plus. I'm assuming that deferring setting the main loop timing is load-bearing enough that we should still maintain this functionality where the swap interval sometimes gets "pendingly set" instead of actually making the change.

## Existing Issue(s)

This fixes #16146.