### PR TITLE
cocoa: Fix macOS 26 popup window regression in 3.4.14

### DIFF
--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -1927,11 +1927,18 @@ static void Cocoa_SendMouseButtonClicks(SDL_Mouse *mouse, NSEvent *theEvent, SDL
     if (@available(macOS 26.0, *)) {
         // do for all windows for now, not just fullscreen spaces. And hopefully remove this code entirely soon.
         //if ([_data.listener isInFullscreenSpace]) {
-            int posx = 0, posy = 0;
-            SDL_GetWindowPosition(window, &posx, &posy);
-            SDL_GetGlobalMouseState(&x, &y);
-            x -= posx;
-            y -= posy;
+            int windowRelativePosX = 0, windowRelativePosY = 0;
+            // If window is a popup, these coordinates are relative to the parent window.
+            SDL_GetWindowPosition(window, &windowRelativePosX, &windowRelativePosY);
+
+            int windowGlobalPosX = 0, windowGlobalPosY = 0;
+            // For the popup case
+            SDL_RelativeToGlobalForWindow(window, windowRelativePosX, windowRelativePosY, &windowGlobalPosX, &windowGlobalPosY);
+
+            float globalMouseX = 0.0f, globalMouseY = 0.0f;
+            SDL_GetGlobalMouseState(&globalMouseX, &globalMouseY);
+            x = globalMouseX - windowGlobalPosX;
+            y = globalMouseY - windowGlobalPosY;
         //}
     }
 


### PR DESCRIPTION
## Summary

SDL 3.4.14 widened the macOS 26 stale-mouse-motion workaround from fullscreen Spaces to all windows (958c4cbf0d). The workaround recomputes each motion event's position as `SDL_GetGlobalMouseState()` minus `SDL_GetWindowPosition()`, but window positions are parent-relative for popup windows, so popups received coordinates offset by their parent's global origin — or no usable motion events at all. The popup path was unreachable before 3.4.14 because a popup is never a fullscreen Space.

This converts the window position to global with `SDL_RelativeToGlobalForWindow()` before the subtraction. The helper is a no-op for non-popup windows, so top-level windows behave exactly as before — and `SDL_cocoawindow.m` already uses it for this conversion in four other places, so this applies the file's established pattern to the one call site that missed it.

Diagnosed by @pipiwoaini in [#15967 (comment)](https://github.com/libsdl-org/SDL/issues/15967#issuecomment-5293077971).

## Testing

- Verified on macOS 26.5 with the repro utility from #16152: popup motion events are wrong before the fix and match the global-derived positions after it.
- `testautomation`: 374 passed, 0 failed, 2 skipped.
- Builds warning-free.

Fixes #16152