### PR TITLE
Subsystem naming consistency

### DIFF
--- a/src/SDL.c
+++ b/src/SDL.c
@@ -668,7 +668,7 @@ void SDL_QuitSubSystem(SDL_InitFlags flags)
     if (flags & SDL_INIT_VIDEO) {
         if (SDL_ShouldQuitSubsystem(SDL_INIT_VIDEO)) {
             SDL_QuitRender();
-            SDL_VideoQuit();
+            SDL_QuitVideo();
             SDL_VideoThreadID = 0;
             // video implies events
             SDL_QuitSubSystem(SDL_INIT_EVENTS);

--- a/src/SDL.c
+++ b/src/SDL.c
@@ -565,7 +565,7 @@ bool SDL_InitSubSystem(SDL_InitFlags flags)
             }
 
             SDL_IncrementSubsystemRefCount(SDL_INIT_CAMERA);
-            if (!SDL_CameraInit(NULL)) {
+            if (!SDL_InitCamera(NULL)) {
                 SDL_DecrementSubsystemRefCount(SDL_INIT_CAMERA);
                 SDL_PushError();
                 SDL_QuitSubSystem(SDL_INIT_EVENTS);

--- a/src/SDL.c
+++ b/src/SDL.c
@@ -420,7 +420,7 @@ bool SDL_InitSubSystem(SDL_InitFlags flags)
             SDL_assert(SDL_VideoThreadID == SDL_MainThreadID);
 #endif
 
-            if (!SDL_VideoInit(NULL)) {
+            if (!SDL_InitVideo(NULL)) {
                 SDL_DecrementSubsystemRefCount(SDL_INIT_VIDEO);
                 SDL_PushError();
                 SDL_QuitSubSystem(SDL_INIT_EVENTS);

--- a/src/audio/SDL_audio.c
+++ b/src/audio/SDL_audio.c
@@ -949,7 +949,6 @@ static Uint32 SDLCALL HashAudioDeviceID(void *userdata, const void *key)
     return ((Uint32) ((uintptr_t) key)) >> 2;
 }
 
-// !!! FIXME: the video subsystem does SDL_VideoInit, not SDL_InitVideo. Make this match.
 bool SDL_InitAudio(const char *driver_name)
 {
     if (SDL_GetCurrentAudioDriver()) {

--- a/src/camera/SDL_camera.c
+++ b/src/camera/SDL_camera.c
@@ -1477,7 +1477,7 @@ static void SDLCALL DestroyCameraHashItem(void *userdata, const void *key, const
     SDL_free(device);
 }
 
-bool SDL_CameraInit(const char *driver_name)
+bool SDL_InitCamera(const char *driver_name)
 {
     if (SDL_GetCurrentCameraDriver()) {
         SDL_QuitCamera(); // shutdown driver if already running.

--- a/src/camera/SDL_camera_c.h
+++ b/src/camera/SDL_camera_c.h
@@ -24,7 +24,7 @@
 #define SDL_camera_c_h_
 
 // Initialize the camera subsystem
-extern bool SDL_CameraInit(const char *driver_name);
+extern bool SDL_InitCamera(const char *driver_name);
 
 // Shutdown the camera subsystem
 extern void SDL_QuitCamera(void);

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -616,7 +616,7 @@ const char *SDL_GetVideoDriver(int index)
 /*
  * Initialize the video and event subsystems -- determine native pixel format
  */
-bool SDL_VideoInit(const char *driver_name)
+bool SDL_InitVideo(const char *driver_name)
 {
     SDL_VideoDevice *video;
     bool init_events = false;

--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -628,7 +628,7 @@ bool SDL_InitVideo(const char *driver_name)
 
     // Check to make sure we don't overwrite '_this'
     if (_this) {
-        SDL_VideoQuit();
+        SDL_QuitVideo();
     }
 
     SDL_InitTicks();
@@ -705,7 +705,7 @@ bool SDL_InitVideo(const char *driver_name)
         goto pre_driver_error;
     }
 
-    /* From this point on, use SDL_VideoQuit to cleanup on error, rather than
+    /* From this point on, use SDL_QuitVideo to cleanup on error, rather than
     pre_driver_error. */
     _this = video;
     _this->name = bootstrap[i]->name;
@@ -718,13 +718,13 @@ bool SDL_InitVideo(const char *driver_name)
 
     // Initialize the video subsystem
     if (!_this->VideoInit(_this)) {
-        SDL_VideoQuit();
+        SDL_QuitVideo();
         return false;
     }
 
     // Make sure some displays were added
     if (_this->num_displays == 0) {
-        SDL_VideoQuit();
+        SDL_QuitVideo();
         return SDL_SetError("The video driver did not add any displays");
     }
 
@@ -4673,7 +4673,7 @@ bool SDL_DisableScreenSaver(void)
     return SDL_Unsupported();
 }
 
-void SDL_VideoQuit(void)
+void SDL_QuitVideo(void)
 {
     int i;
 

--- a/src/video/SDL_video_c.h
+++ b/src/video/SDL_video_c.h
@@ -37,7 +37,7 @@ struct SDL_VideoDevice;
  * either SDL_Init() or SDL_InitSubSystem(), you should call SDL_VideoQuit()
  * before calling SDL_Quit().
  *
- * It is safe to call this function multiple times. SDL_VideoInit() will call
+ * It is safe to call this function multiple times. SDL_InitVideo() will call
  * SDL_VideoQuit() itself if the video subsystem has already been initialized.
  *
  * You can use SDL_GetNumVideoDrivers() and SDL_GetVideoDriver() to find a
@@ -48,10 +48,10 @@ struct SDL_VideoDevice;
  * \returns true on success or false on failure; call
  *          SDL_GetError() for more information.
  */
-extern bool SDL_VideoInit(const char *driver_name);
+extern bool SDL_InitVideo(const char *driver_name);
 
 /**
- * Shut down the video subsystem, if initialized with SDL_VideoInit().
+ * Shut down the video subsystem, if initialized with SDL_InitVideo().
  *
  * This function closes all windows, and restores the original video mode.
  */

--- a/src/video/SDL_video_c.h
+++ b/src/video/SDL_video_c.h
@@ -34,11 +34,11 @@ struct SDL_VideoDevice;
  * pixel formats, but does not initialize a window or graphics mode.
  *
  * If you use this function and you haven't used the SDL_INIT_VIDEO flag with
- * either SDL_Init() or SDL_InitSubSystem(), you should call SDL_VideoQuit()
+ * either SDL_Init() or SDL_InitSubSystem(), you should call SDL_QuitVideo()
  * before calling SDL_Quit().
  *
  * It is safe to call this function multiple times. SDL_InitVideo() will call
- * SDL_VideoQuit() itself if the video subsystem has already been initialized.
+ * SDL_QuitVideo() itself if the video subsystem has already been initialized.
  *
  * You can use SDL_GetNumVideoDrivers() and SDL_GetVideoDriver() to find a
  * specific `driver_name`.
@@ -55,7 +55,7 @@ extern bool SDL_InitVideo(const char *driver_name);
  *
  * This function closes all windows, and restores the original video mode.
  */
-extern void SDL_VideoQuit(void);
+extern void SDL_QuitVideo(void);
 
 extern bool SDL_SetWindowTextureVSync(struct SDL_VideoDevice *_this, SDL_Window *window, int vsync);
 

--- a/src/video/cocoa/SDL_cocoavideo.m
+++ b/src/video/cocoa/SDL_cocoavideo.m
@@ -61,7 +61,7 @@ static SDL_VideoDevice *Cocoa_CreateDevice(void)
         SDL_CocoaVideoData *data;
 
         if (![NSThread isMainThread]) {
-            return NULL;  // this doesn't SDL_SetError() because SDL_VideoInit is just going to overwrite it.
+            return NULL;  // this doesn't SDL_SetError() because SDL_InitVideo is just going to overwrite it.
         }
 
         Cocoa_RegisterApp();


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

All names of functions for initializing and quitting subsystems are now consistent.

## Description

`SDL_VideoInit` -> `SDL_InitVideo`
`SDL_VideoQuit` -> `SDL_QuitVideo`
`SDL_CameraInit` -> `SDL_InitCamera`

[FIXME comment](https://github.com/libsdl-org/SDL/blob/5ff9c119fcd40bcd0b7b62283df0b3b8b6d7994d/src/audio/SDL_audio.c#L952) is removed since convention for subsystem naming is established.

The mention of `SDL_VideoInit` and `SDL_VideoQuit` in [README-migration.md](https://github.com/libsdl-org/SDL/blob/5ff9c119fcd40bcd0b7b62283df0b3b8b6d7994d/docs/README-migration.md?plain=1#L2112) are left untouched, as they refer to SDL2 public functions.

## Existing Issue(s)
[#16149](https://github.com/libsdl-org/SDL/issues/16149)
