### PR TITLE
gdk: Send window resize events on Xbox

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -2500,6 +2500,7 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
         }
         break;
 #else
+    // Xbox does not support WM_WINDOWPOSCHANGED, so use WM_SIZE instead to detect window resizes
     case WM_SIZE:
     {
         RECT rect;

--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -2499,7 +2499,18 @@ LRESULT CALLBACK WIN_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
             WIN_UpdateDisplayUsableBounds(SDL_GetVideoDevice());
         }
         break;
+#else
+    case WM_SIZE:
+    {
+        RECT rect;
+        int w, h;
 
+        if (GetClientRect(hwnd, &rect) && WIN_WindowRectValid(&rect)) {
+            w = rect.right;
+            h = rect.bottom;
+            SDL_SendWindowEvent(data->window, SDL_EVENT_WINDOW_RESIZED, w, h);
+        }
+    } break;
 #endif // !defined(SDL_PLATFORM_XBOXONE) && !defined(SDL_PLATFORM_XBOXSERIES)
 
     default:


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
The Xbox OS does not support `WM_WINDOWPOSCHANGED`, so the handling for that message is #ifdef'd out in `WIN_WindowProc`. But as a result, no window resize events are ever sent on the Xbox platform.

To work around this limitation, we can watch for `WM_SIZE` instead and send window resize events from there.