### PR TITLE
render: remove exact check on surface pixel size

### DIFF
--- a/src/render/SDL_render.c
+++ b/src/render/SDL_render.c
@@ -1471,7 +1471,7 @@ static SDL_PixelFormat GetClosestSupportedFormat(SDL_Renderer *renderer, SDL_Pix
         // We just want to match the first format that has the same channels
         for (i = 0; i < renderer->num_texture_formats; ++i) {
             if (!SDL_ISPIXELFORMAT_FOURCC(renderer->texture_formats[i]) &&
-                SDL_BYTESPERPIXEL(renderer->texture_formats[i]) == size &&
+                SDL_BYTESPERPIXEL(renderer->texture_formats[i]) >= size &&
                 SDL_ISPIXELFORMAT_ALPHA(renderer->texture_formats[i]) == hasAlpha &&
                 SDL_ISPIXELFORMAT_INDEXED(renderer->texture_formats[i]) == isIndexed) {
                 return renderer->texture_formats[i];
@@ -1856,7 +1856,7 @@ SDL_Texture *SDL_CreateTextureFromSurface(SDL_Renderer *renderer, SDL_Surface *s
 
         for (i = 0; i < renderer->num_texture_formats; ++i) {
             if (!SDL_ISPIXELFORMAT_FOURCC(renderer->texture_formats[i]) &&
-                SDL_BYTESPERPIXEL(renderer->texture_formats[i]) == size &&
+                SDL_BYTESPERPIXEL(renderer->texture_formats[i]) >= size &&
                 SDL_ISPIXELFORMAT_ALPHA(renderer->texture_formats[i]) == needAlpha &&
                 SDL_ISPIXELFORMAT_INDEXED(renderer->texture_formats[i]) == preferIndexed) {
                 format = renderer->texture_formats[i];


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description

Some backends (like the PSP one) have RGB565 as their first texture pixel format. On these renderer the change introduced with commit fdfcfc056696c86a67c9b1f0c4f6fecc9d3f678c breaks the testrendercopyex test, because the new loop does not find a matching surface and therefore the first pixel format reported by the renderer (RGB565) is used, causing the transparency on the icon to be lost.

We fix this by allowing selecting a texture format with a bigger pixel size.

## Existing Issue(s)

Fixes: #16156
