### PR TITLE
examples: Fix use of keycodes and scancodes

### DIFF
--- a/examples/demo/01-snake/snake.c
+++ b/examples/demo/01-snake/snake.c
@@ -214,10 +214,12 @@ void snake_step(SnakeContext *ctx)
 static SDL_AppResult handle_key_event_(SnakeContext *ctx, SDL_Keycode key_code)
 {
     switch (key_code) {
+#ifndef SDL_PLATFORM_EMSCRIPTEN
     /* Quit. */
     case SDLK_ESCAPE:
     case SDLK_Q:
         return SDL_APP_SUCCESS;
+#endif
     /* Restart the game as if the program was launched. */
     case SDLK_R:
         snake_initialize(ctx);

--- a/examples/demo/01-snake/snake.c
+++ b/examples/demo/01-snake/snake.c
@@ -211,28 +211,28 @@ void snake_step(SnakeContext *ctx)
     }
 }
 
-static SDL_AppResult handle_key_event_(SnakeContext *ctx, SDL_Scancode key_code)
+static SDL_AppResult handle_key_event_(SnakeContext *ctx, SDL_Keycode key_code)
 {
     switch (key_code) {
     /* Quit. */
-    case SDL_SCANCODE_ESCAPE:
-    case SDL_SCANCODE_Q:
+    case SDLK_ESCAPE:
+    case SDLK_Q:
         return SDL_APP_SUCCESS;
     /* Restart the game as if the program was launched. */
-    case SDL_SCANCODE_R:
+    case SDLK_R:
         snake_initialize(ctx);
         break;
     /* Decide new direction of the snake. */
-    case SDL_SCANCODE_RIGHT:
+    case SDLK_RIGHT:
         snake_redir(ctx, SNAKE_DIR_RIGHT);
         break;
-    case SDL_SCANCODE_UP:
+    case SDLK_UP:
         snake_redir(ctx, SNAKE_DIR_UP);
         break;
-    case SDL_SCANCODE_LEFT:
+    case SDLK_LEFT:
         snake_redir(ctx, SNAKE_DIR_LEFT);
         break;
-    case SDL_SCANCODE_DOWN:
+    case SDLK_DOWN:
         snake_redir(ctx, SNAKE_DIR_DOWN);
         break;
     default:
@@ -375,7 +375,7 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
     case SDL_EVENT_JOYSTICK_HAT_MOTION:
         return handle_hat_event_(ctx, event->jhat.value);
     case SDL_EVENT_KEY_DOWN:
-        return handle_key_event_(ctx, event->key.scancode);
+        return handle_key_event_(ctx, event->key.key);
     default:
         break;
     }

--- a/examples/demo/02-woodeneye-008/woodeneye-008.c
+++ b/examples/demo/02-woodeneye-008/woodeneye-008.c
@@ -411,15 +411,15 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
             break;
         }
         case SDL_EVENT_KEY_DOWN: {
-            SDL_Keycode sym = event->key.key;
+            SDL_Scancode scancode = event->key.scancode;
             SDL_KeyboardID id = event->key.which;
             int index = whoseKeyboard(id, players, player_count);
             if (index >= 0) {
-                if (sym == SDLK_W) players[index].wasd |= 1;
-                if (sym == SDLK_A) players[index].wasd |= 2;
-                if (sym == SDLK_S) players[index].wasd |= 4;
-                if (sym == SDLK_D) players[index].wasd |= 8;
-                if (sym == SDLK_SPACE) players[index].wasd |= 16;
+                if (scancode == SDL_SCANCODE_W) players[index].wasd |= 1;
+                if (scancode == SDL_SCANCODE_A) players[index].wasd |= 2;
+                if (scancode == SDL_SCANCODE_S) players[index].wasd |= 4;
+                if (scancode == SDL_SCANCODE_D) players[index].wasd |= 8;
+                if (scancode == SDL_SCANCODE_SPACE) players[index].wasd |= 16;
             } else if (id) {
                 for (i = 0; i < MAX_PLAYER_COUNT; i++) {
                     if (players[i].keyboard == 0) {
@@ -432,16 +432,16 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
             break;
         }
         case SDL_EVENT_KEY_UP: {
-            SDL_Keycode sym = event->key.key;
+            SDL_Scancode scancode = event->key.scancode;
             SDL_KeyboardID id = event->key.which;
-            if (sym == SDLK_ESCAPE) return SDL_APP_SUCCESS;
+            if (scancode == SDL_SCANCODE_ESCAPE) return SDL_APP_SUCCESS;
             int index = whoseKeyboard(id, players, player_count);
             if (index >= 0) {
-                if (sym == SDLK_W) players[index].wasd &= 30;
-                if (sym == SDLK_A) players[index].wasd &= 29;
-                if (sym == SDLK_S) players[index].wasd &= 27;
-                if (sym == SDLK_D) players[index].wasd &= 23;
-                if (sym == SDLK_SPACE) players[index].wasd &= 15;
+                if (scancode == SDL_SCANCODE_W) players[index].wasd &= 30;
+                if (scancode == SDL_SCANCODE_A) players[index].wasd &= 29;
+                if (scancode == SDL_SCANCODE_S) players[index].wasd &= 27;
+                if (scancode == SDL_SCANCODE_D) players[index].wasd &= 23;
+                if (scancode == SDL_SCANCODE_SPACE) players[index].wasd &= 15;
             }
             break;
         }

--- a/examples/demo/02-woodeneye-008/woodeneye-008.c
+++ b/examples/demo/02-woodeneye-008/woodeneye-008.c
@@ -434,7 +434,9 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
         case SDL_EVENT_KEY_UP: {
             SDL_Scancode scancode = event->key.scancode;
             SDL_KeyboardID id = event->key.which;
+#ifndef SDL_PLATFORM_EMSCRIPTEN
             if (scancode == SDL_SCANCODE_ESCAPE) return SDL_APP_SUCCESS;
+#endif
             int index = whoseKeyboard(id, players, player_count);
             if (index >= 0) {
                 if (scancode == SDL_SCANCODE_W) players[index].wasd &= 30;

--- a/examples/demo/04-bytepusher/bytepusher.c
+++ b/examples/demo/04-bytepusher/bytepusher.c
@@ -346,7 +346,7 @@ SDL_AppResult SDL_AppEvent(void* appstate, SDL_Event* event) {
             break;
         
         case SDL_EVENT_KEY_DOWN:
-#ifndef __EMSCRIPTEN__
+#ifndef SDL_PLATFORM_EMSCRIPTEN
             if (event->key.key == SDLK_ESCAPE) {
                 return SDL_APP_SUCCESS;
             }


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

* snake uses 'Q' for quit and 'R' for restart, which should depend on the keyboard layout.
* woodeneye uses WASD for input, which should be independent of the keyboard layout.

The escape key is also disabled with Emscripten to avoid being left with a blank page. Ideally all of the examples should allow this on non-Emscripten for platforms like DOS or RISC OS where there wouldn't be a way to terminate the application cleanly otherwise, but I'm not sure how best to approach this other than copying the relevant code (and accompanying platform-specific ifdefs) into all examples.