### PR TITLE
Separate KEY_KPJPCOMMA from KEY_MUHENKAN

### DIFF
--- a/src/events/scancodes_linux.h
+++ b/src/events/scancodes_linux.h
@@ -121,7 +121,7 @@ static SDL_Scancode const linux_scancode_table[] = {
     /*  92, 0x05c */    SDL_SCANCODE_INTERNATIONAL4,    // KEY_HENKAN
     /*  93, 0x05d */    SDL_SCANCODE_INTERNATIONAL2,    // KEY_KATAKANAHIRAGANA
     /*  94, 0x05e */    SDL_SCANCODE_INTERNATIONAL5,    // KEY_MUHENKAN
-    /*  95, 0x05f */    SDL_SCANCODE_INTERNATIONAL5,    // KEY_KPJPCOMMA
+    /*  95, 0x05f */    SDL_SCANCODE_INTERNATIONAL6,    // KEY_KPJPCOMMA
     /*  96, 0x060 */    SDL_SCANCODE_KP_ENTER,          // KEY_KPENTER
     /*  97, 0x061 */    SDL_SCANCODE_RCTRL,             // KEY_RIGHTCTRL
     /*  98, 0x062 */    SDL_SCANCODE_KP_DIVIDE,         // KEY_KPSLASH


### PR DESCRIPTION
This seems like it might have been a typo that stuck around for a while.

- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

This literally just entails changing a five to a six in the Linux key codes sheet.

## Description
KEY_MUHENKAN was mapped to International 5, but so was KEY_KPJPCOMMA. If there's a good reason for this to be the case you can reject this PR but this seems like it might have been accidental, since despite the fact that both of these are Japanese keyboard keys, they ostensibly serve completely distinct functions.

If we look at scancodes_windows.h, we see that "International 6" is assigned to something referred to by [this official Microsoft document](https://download.microsoft.com/download/1/6/1/161ba512-40e2-4cc9-843a-923143f3456c/translate.pdf) as "Keyboard Int'l 6 (PC-9800 Keypad ,)", which (due to the Japanese/JP nature of PC-9800) seems like an exact match for this key.

Given the supporting context I think someone just fat-fingered the 5 key at some point or ctrl c ctrl v'd lines without double checking, and it slipped through due to this button's obscurity. Any evidence to the contrary would be appreciated.

## Existing Issue(s)
None, but #16164 does deal with this key code