### PR TITLE
iOS: don't attach a window to AirPlay Screen Mirroring scenes

### DIFF
--- a/src/video/uikit/SDL_uikitappdelegate.m
+++ b/src/video/uikit/SDL_uikitappdelegate.m
@@ -39,6 +39,7 @@ static SDL_main_func forward_main;
 static int forward_argc;
 static char **forward_argv;
 static int exit_status;
+static bool sdl_main_started = false;
 
 int SDL_RunApp(int argc, char *argv[], SDL_main_func mainFunction, void *reserved)
 {
@@ -366,6 +367,18 @@ API_AVAILABLE(ios(13.0))
         return;
     }
 
+    // Attaching a window here turns off system Screen Mirroring and leaves
+    // the TV on a launch screen / black. Leave the scene empty so iOS mirrors.
+    if (UIKit_IsExternalDisplayScene(scene)) {
+        return;
+    }
+
+    // Only the first (device) scene should start the app.
+    if (sdl_main_started) {
+        return;
+    }
+    sdl_main_started = true;
+
     UIWindowScene *windowScene = (UIWindowScene *)scene;
     windowScene.delegate = self;
 
@@ -437,21 +450,33 @@ API_AVAILABLE(ios(13.0))
 
 - (void)sceneDidBecomeActive:(UIScene *)scene
 {
+    if (UIKit_IsExternalDisplayScene(scene)) {
+        return;
+    }
     SDL_OnApplicationDidEnterForeground();
 }
 
 - (void)sceneWillResignActive:(UIScene *)scene
 {
+    if (UIKit_IsExternalDisplayScene(scene)) {
+        return;
+    }
     SDL_OnApplicationWillEnterBackground();
 }
 
 - (void)sceneWillEnterForeground:(UIScene *)scene
 {
+    if (UIKit_IsExternalDisplayScene(scene)) {
+        return;
+    }
     SDL_OnApplicationWillEnterForeground();
 }
 
 - (void)sceneDidEnterBackground:(UIScene *)scene
 {
+    if (UIKit_IsExternalDisplayScene(scene)) {
+        return;
+    }
     SDL_OnApplicationDidEnterBackground();
 }
 

--- a/src/video/uikit/SDL_uikitvideo.h
+++ b/src/video/uikit/SDL_uikitvideo.h
@@ -43,6 +43,9 @@ extern CGRect UIKit_ComputeViewFrame(SDL_Window *window, UIScreen *screen);
 
 extern API_AVAILABLE(ios(13.0)) UIWindowScene *UIKit_GetActiveWindowScene(void);
 
+// AirPlay Screen Mirroring and other non-interactive external displays.
+extern API_AVAILABLE(ios(13.0)) bool UIKit_IsExternalDisplayScene(UIScene *scene);
+
 extern void UIKit_SetGameControllerInteraction(bool enabled);
 extern void UIKit_SetViewGameControllerInteraction(UIView *view, bool enabled);
 

--- a/src/video/uikit/SDL_uikitvideo.m
+++ b/src/video/uikit/SDL_uikitvideo.m
@@ -260,6 +260,38 @@ CGRect UIKit_ComputeViewFrame(SDL_Window *window, UIScreen *screen)
 }
 #endif // SDL_PLATFORM_VISIONOS
 
+bool UIKit_IsExternalDisplayScene(UIScene *scene)
+{
+    if (![scene isKindOfClass:[UIWindowScene class]]) {
+        return false;
+    }
+
+    UISceneSessionRole role = scene.session.role;
+
+    // iOS 16 renamed the AirPlay / Screen Mirroring role.
+#if (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 160000) || \
+    (defined(__TV_OS_VERSION_MAX_ALLOWED) && __TV_OS_VERSION_MAX_ALLOWED >= 160000)
+    if (@available(iOS 16.0, tvOS 16.0, *)) {
+        if (role == UIWindowSceneSessionRoleExternalDisplayNonInteractive) {
+            return true;
+        }
+    }
+#endif
+    // iOS 13-15 name (deprecated in 16, still sent by some configurations)
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+    if (role == UIWindowSceneSessionRoleExternalDisplay) {
+        return true;
+    }
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+    return false;
+}
+
 UIWindowScene *UIKit_GetActiveWindowScene(void)
 {
     if (@available(iOS 13.0, tvOS 13.0, *)) {
@@ -269,6 +301,9 @@ UIWindowScene *UIKit_GetActiveWindowScene(void)
         for (UIScene *scene in connectedScenes) {
             if ([scene isKindOfClass:[UIWindowScene class]]) {
                 UIWindowScene *windowScene = (UIWindowScene *)scene;
+                if (UIKit_IsExternalDisplayScene(windowScene)) {
+                    continue;
+                }
                 if (windowScene.activationState == UISceneActivationStateForegroundActive) {
                     return windowScene;
                 }
@@ -279,6 +314,9 @@ UIWindowScene *UIKit_GetActiveWindowScene(void)
         for (UIScene *scene in connectedScenes) {
             if ([scene isKindOfClass:[UIWindowScene class]]) {
                 UIWindowScene *windowScene = (UIWindowScene *)scene;
+                if (UIKit_IsExternalDisplayScene(windowScene)) {
+                    continue;
+                }
                 if (windowScene.activationState == UISceneActivationStateForegroundInactive) {
                     return windowScene;
                 }
@@ -288,7 +326,11 @@ UIWindowScene *UIKit_GetActiveWindowScene(void)
         // Last resort: return first window scene
         for (UIScene *scene in connectedScenes) {
             if ([scene isKindOfClass:[UIWindowScene class]]) {
-                return (UIWindowScene *)scene;
+                UIWindowScene *windowScene = (UIWindowScene *)scene;
+                if (UIKit_IsExternalDisplayScene(windowScene)) {
+                    continue;
+                }
+                return windowScene;
             }
         }
     }


### PR DESCRIPTION
Creating a UIWindow on an AirPlay / external display scene disables system Screen Mirroring and leaves the TV black after the launch screen is hidden. Leave those scenes empty so iOS keeps mirroring the device window.

Also ignore scene lifecycle events on those scenes, and don't pick them as the active window scene for SDL_CreateWindow.

Fixes #16161

- [ ] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
When Screen Mirroring starts, iOS connects a second scene (`UIWindowSceneSessionRoleExternalDisplayNonInteractive`, or the older `UIWindowSceneSessionRoleExternalDisplay` on iOS 13–15). If we put a window on it - which `willConnect` does today - iOS stops mirroring and the TV goes black.

This leaves that scene empty so the window stays on the device scene and iOS keeps duplicating the phone, same as 3.2. It also skips `SDL_CallMainFunction` / lifecycle events on that scene, and doesn't pick it as the active window scene.

Confirmed on device: iPhone -> Apple TV Screen Mirroring.

The patch was drafted with LLM assistance. I reviewed it and tested it on device.

## Existing Issue(s)
Fixes #16161
