### PR TITLE
[emscripten] Use `keyEvent->key` instead of deprecated `charCode`

### DIFF
--- a/src/video/emscripten/SDL_emscriptenevents.c
+++ b/src/video/emscripten/SDL_emscriptenevents.c
@@ -467,11 +467,10 @@ static EM_BOOL Emscripten_HandleKeyPress(int eventType, const EmscriptenKeyboard
     SDL_WindowData *window_data = (SDL_WindowData *)userData;
 
     if (SDL_TextInputActive(window_data->window)) {
-        char text[5];
-        char *end = SDL_UCS4ToUTF8(keyEvent->charCode, text);
-        *end = '\0';
-        SDL_SendKeyboardText(text);
-        return EM_TRUE;
+        if (SDL_utf8strlen(keyEvent->key) == 1) {
+            SDL_SendKeyboardText(keyEvent->key);
+            return EM_TRUE;
+        }
     }
     return EM_FALSE;
 }


### PR DESCRIPTION
`keyEvent->charCode` is deprecated in DOM Level 3 and marked deprecated in Emscripten's html5.h. Use `keyEvent->key` instead.