### PR TITLE
GPU: D3D12: set MultisampleEnable for multisampled pipelines

### DIFF
--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -3226,6 +3226,9 @@ static SDL_GPUGraphicsPipeline *D3D12_CreateGraphicsPipeline(
     psoDesc.SampleMask = 0xFFFFFFFF;
     psoDesc.SampleDesc.Count = SDLToD3D12_SampleCount[createinfo->multisample_state.sample_count];
     psoDesc.SampleDesc.Quality = (createinfo->multisample_state.sample_count > SDL_GPU_SAMPLECOUNT_1) ? D3D12_STANDARD_MULTISAMPLE_PATTERN : 0;
+    // Selects the quadrilateral line-rendering algorithm, which resolves against the
+    // target's samples. Without it, line primitives stay aliased on an MSAA target.
+    psoDesc.RasterizerState.MultisampleEnable = (createinfo->multisample_state.sample_count > SDL_GPU_SAMPLECOUNT_1) ? TRUE : FALSE;
 
     if (createinfo->target_info.has_depth_stencil_target) {
         psoDesc.DSVFormat = SDLToD3D12_DepthFormat[createinfo->target_info.depth_stencil_format];


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

`MultisampleEnable` is hardcoded to `FALSE` for every graphics pipeline, so line primitives stay on the aliased rasterization rule even when the pipeline targets more than one sample.

## Description

 Set it from `multisample_state.sample_count`, beside where `SampleDesc` is already filled in.
`AntialiasedLineEnable` stays `FALSE`: it only applies when `MultisampleEnable` is `FALSE`.

Measured on an RTX 4090 (driver 32.0.16.1088): before this, a `LINELIST` pipeline drawing into a 4x colour target produced output pixel-identical to the same draw at one sample; after it, the result matches what the same content renders to through Dawn, which sets the flag from the sample count. The issue also has an A/B on two triangle-only scenes that move slightly with it.

## Existing Issue(s)

Fixes #16182.
