### PR TITLE
Fix build on PowerPC with uClibc

### DIFF
--- a/src/cpuinfo/SDL_cpuinfo.c
+++ b/src/cpuinfo/SDL_cpuinfo.c
@@ -80,6 +80,10 @@
 #include <sys/auxv.h>
 #endif
 
+#ifndef PPC_FEATURE_HAS_ALTIVEC
+#define PPC_FEATURE_HAS_ALTIVEC 0x10000000
+#endif
+
 #ifdef SDL_PLATFORM_RISCOS
 #include <kernel.h>
 #include <swis.h>


### PR DESCRIPTION
I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

PPC_FEATURE_HAS_ALTIVEC is not defined by all C libraries. The following error was raised while testing SDL3 in Buildroot with a PowerPC toolchain using uClibc-ng:

  src/cpuinfo/SDL_cpuinfo.c: In function 'SDL_GetAltiVecFeatures':
  src/cpuinfo/SDL_cpuinfo.c:351:37: error: 'PPC_FEATURE_HAS_ALTIVEC' undeclared (first use in this function)
    351 |     altivec = getauxval(AT_HWCAP) & PPC_FEATURE_HAS_ALTIVEC;
        |                                     ^~~~~~~~~~~~~~~~~~~~~~~

Provide a fallback definition when it is not defined.