### PR TITLE
Fix `SDL_PLATFORM_UNI` typo in migration guide

### DIFF
--- a/docs/README-migration.md
+++ b/docs/README-migration.md
@@ -1307,7 +1307,7 @@ The following platform preprocessor macros have been renamed:
 | `__RISCOS__`      | `SDL_PLATFORM_RISCOS`     |
 | `__SOLARIS__`     | `SDL_PLATFORM_SOLARIS`    |
 | `__TVOS__`        | `SDL_PLATFORM_TVOS`       |
-| `__unix__`        | `SDL_PLATFORM_UNI`        |
+| `__unix__`        | `SDL_PLATFORM_UNIX`       |
 | `__VITA__`        | `SDL_PLATFORM_VITA`       |
 | `__WIN32__`       | `SDL_PLATFORM_WIN32`      |
 | `__WINGDK__`      | `SDL_PLATFORM_WINGDK`     |


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
The [migration guide](https://wiki.libsdl.org/SDL3/README-migration#sdl_platformh) says `__unix__` should be replaced by `SDL_PLATFORM_UNI`. That doesn't actually exist, it seems like it's supposed to be `SDL_PLATFORM_UNIX`.