### PR TITLE
Update testgpurender_effects_grayscale.frag.hlsl

### DIFF
--- a/test/testgpurender_effects_grayscale.frag.hlsl
+++ b/test/testgpurender_effects_grayscale.frag.hlsl
@@ -13,7 +13,7 @@ struct PSOutput {
 PSOutput main(PSInput input) {
     PSOutput output;
     float4 color = u_texture.Sample(u_sampler, input.v_uv) * input.v_color;
-    float gray = color.r * 0.2126 + color.g * 0.7152 + color.r * 0.722;
+    float gray = color.r * 0.2126 + color.g * 0.7152 + color.b * 0.0722;
     output.o_color = float4(gray, gray, gray, color.a);
     return output;
 }


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
The formular did not use blue at all but red twice and the factor intended for blue was off.
