### PR TITLE
wayland: Don't presume that the window is non-resizable when hidden

### DIFF
--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -398,7 +398,8 @@ static void ConfigureWindowGeometry(SDL_Window *window)
             viewport_height = data->requested.pixel_height;
         }
 
-        if (data->viewport && data->waylandData->subcompositor && !data->floating && !data->is_fullscreen) {
+        if (data->shell_surface_status != WAYLAND_SHELL_SURFACE_STATUS_HIDDEN &&
+            data->viewport && data->waylandData->subcompositor && !data->floating && !data->is_fullscreen) {
             int min_width, min_height, max_width, max_height;
             if (window->flags & SDL_WINDOW_RESIZABLE) {
                 min_width = window->min_w;


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Don't presume that the window requires fixed size handling until the object exists and a configure event sets the state. Fixes setting an initial size on a hidden window (regression from fcb5ef8a9ccb8b005f81de06a192c1c1c83549cc).

Fixes #16143 

