### PR TITLE
Add Wake Up key code for Windows

### DIFF
--- a/src/events/scancodes_windows.h
+++ b/src/events/scancodes_windows.h
@@ -187,7 +187,7 @@ static const SDL_Scancode windows_scancode_table[] = {
     /*0xe01e*/ SDL_SCANCODE_UNKNOWN,
     /*0xe01f*/ SDL_SCANCODE_UNKNOWN,
     /*0xe020*/ SDL_SCANCODE_MUTE,
-    /*0xe021*/ SDL_SCANCODE_UNKNOWN, // LaunchApp2; "Calculator" on Natural Multimedia Keyboard
+    /*0xe021*/ SDL_SCANCODE_UNKNOWN, // LaunchApp2; "Calculator" on Natural Multimedia Keyboard and on Turbo multimedia keyboards
     /*0xe022*/ SDL_SCANCODE_MEDIA_PLAY_PAUSE,
     /*0xe023*/ SDL_SCANCODE_UNKNOWN, // "Spell" on Natural Multimedia Keyboard
     /*0xe024*/ SDL_SCANCODE_MEDIA_STOP,
@@ -253,7 +253,7 @@ static const SDL_Scancode windows_scancode_table[] = {
     /*0xe060*/ SDL_SCANCODE_UNKNOWN,
     /*0xe061*/ SDL_SCANCODE_UNKNOWN,
     /*0xe062*/ SDL_SCANCODE_UNKNOWN,
-    /*0xe063*/ SDL_SCANCODE_UNKNOWN,
+    /*0xe063*/ SDL_SCANCODE_WAKE,  // "Wake Up" on Turbo multimedia keyboards
     /*0xe064*/ SDL_SCANCODE_UNKNOWN, // "My Pictures" on Natural Multimedia Keyboard
     /*0xe065*/ SDL_SCANCODE_AC_SEARCH,
     /*0xe066*/ SDL_SCANCODE_AC_BOOKMARKS,
@@ -261,8 +261,8 @@ static const SDL_Scancode windows_scancode_table[] = {
     /*0xe068*/ SDL_SCANCODE_AC_STOP,
     /*0xe069*/ SDL_SCANCODE_AC_FORWARD,
     /*0xe06a*/ SDL_SCANCODE_AC_BACK,
-    /*0xe06b*/ SDL_SCANCODE_UNKNOWN,    // LaunchApp1
-    /*0xe06c*/ SDL_SCANCODE_UNKNOWN,    // LaunchMail; "Mail" on Natural Multimedia Keyboard
+    /*0xe06b*/ SDL_SCANCODE_UNKNOWN,    // LaunchApp1; "My computer" on Turbo multimedia keyboards
+    /*0xe06c*/ SDL_SCANCODE_UNKNOWN,    // LaunchMail; "Mail" on Natural Multimedia Keyboard and on Turbo multimedia keyboards
     /*0xe06d*/ SDL_SCANCODE_MEDIA_SELECT,
     /*0xe06e*/ SDL_SCANCODE_UNKNOWN,
     /*0xe06f*/ SDL_SCANCODE_UNKNOWN,


### PR DESCRIPTION
Further test results following #16194 turned up this missing value

- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

The "Wake Up" power management is e063 and is now added to the scancode list.

## Description
Following the earlier test I decided to see how the buttons on the top row of another keyboard I have behave. Most appear to be correctly defined already, however the "Wake Up" button in specific remained absent, so I've included it as part of this change, alongside a comment for an application launcher button that doesn't appear to have an extant relevant keycode.

The specific model of keyboard I'm using, from what I can find online, appears to be generic PS/2 multimedia keyboard available with a number of different brandings, of which mine in specific goes by "TurboStar" - there are many others with the exact same arrangement of 21 media control buttons on the top row, and while the one I own is unlabelled, I've picked the button names from listings for the "iConcepts Direct Access Internet Multimedia Keyboard".

This should cover the keyboards I currently own, but I've ordered a more recent Microsoft keyboard model with some more buttons I don't think are covered yet, so there's still more to come.

## Existing Issue(s)
None, unless #16047 is fixed by adding a "My Computer" key code to SDL, in which we could add a binding for that as well