### PR TITLE
joystick: Add VKB Gladiator NXT Evo to device list

### DIFF
--- a/src/joystick/SDL_joystick.c
+++ b/src/joystick/SDL_joystick.c
@@ -477,6 +477,7 @@ static Uint32 initial_flightstick_devices[] = {
     MAKE_VIDPID(0x10f5, 0x7084), // Turtle Beach VelocityOne
     MAKE_VIDPID(0x231d, 0x0126), // Gunfighter Mk.III 'Space Combat Edition' (right)
     MAKE_VIDPID(0x231d, 0x0127), // Gunfighter Mk.III 'Space Combat Edition' (left)
+    MAKE_VIDPID(0x231d, 0x0200), // VKB Gladiator NXT Evo (grip)
     MAKE_VIDPID(0x3344, 0x4391), // VIRPIL Controls R-VPC Stick MT-50CM3
     MAKE_VIDPID(0x3344, 0x8390), // VIRPIL Controls L-VPC Stick MT-50CM3
     MAKE_VIDPID(0x362c, 0x0001), // Yawman Arrow


### PR DESCRIPTION
Adds VID:PID 0x231d:0x0200 (VKB Gladiator NXT Evo grip) to the flight stick list, next to the same vendor devices. Verified working through generic Linux HID/evdev driver; this only fixes SDL_GetJoystickType() classification.