### PR TITLE
wayland: honor SDL_WINDOW_NOT_FOCUSABLE on regular toplevels

### DIFF
--- a/src/video/wayland/SDL_waylandevents.c
+++ b/src/video/wayland/SDL_waylandevents.c
@@ -556,6 +556,24 @@ int Wayland_WaitEventTimeout(SDL_VideoDevice *_this, Sint64 timeoutNS)
     return 1;
 }
 
+/* Apply a keyboard focus withdrawal that keyboard_handle_leave deferred. Called once the
+ * whole event batch has been processed, so that a focus handover between two windows is
+ * not visible to the application as a focus loss.
+ */
+static void Wayland_SeatResolvePendingKeyboardFocus(SDL_WaylandSeat *seat)
+{
+    if (seat->keyboard.focus_lost_pending) {
+        seat->keyboard.focus_lost_pending = false;
+
+        if (seat->keyboard.sdl_focus) {
+            if (SDL_GetKeyboardFocus() == seat->keyboard.sdl_focus) {
+                SDL_SetKeyboardFocus(NULL);
+            }
+            seat->keyboard.sdl_focus = NULL;
+        }
+    }
+}
+
 void Wayland_PumpEvents(SDL_VideoDevice *_this)
 {
     SDL_VideoData *d = _this->internal;
@@ -623,8 +641,10 @@ void Wayland_PumpEvents(SDL_VideoDevice *_this)
     }
 
     if (ret >= 0) {
-        // Synthesize key repeat events.
         wl_list_for_each (seat, &d->seat_list, link) {
+            Wayland_SeatResolvePendingKeyboardFocus(seat);
+
+            // Synthesize key repeat events.
             if (seat->keyboard.repeat.key) {
                 Wayland_SeatSetKeymap(seat);
 
@@ -2094,7 +2114,32 @@ static void keyboard_handle_enter(void *data, struct wl_keyboard *keyboard,
     seat->keyboard.focus = window;
 
     // Restore the keyboard focus to the child popup that was holding it
-    SDL_SetKeyboardFocus(window->sdlwindow->keyboard_focus ? window->sdlwindow->keyboard_focus : window->sdlwindow);
+    SDL_Window *keyboard_focus = window->sdlwindow->keyboard_focus ? window->sdlwindow->keyboard_focus : window->sdlwindow;
+
+    /* A window flagged as not focusable can't decline keyboard focus at the protocol level:
+     * xdg-shell gives a client no way to refuse it, and compositors hand it to whichever
+     * toplevel of the active application was mapped last. Honor the flag where SDL can, by
+     * leaving the application's focus where it was. The compositor's idea of focus is
+     * untouched, and key events still go to whichever window holds SDL focus, so an output
+     * only window revealed late no longer steals focus from the window in use.
+     */
+    seat->keyboard.focus_lost_pending = false;
+    if (keyboard_focus->flags & SDL_WINDOW_NOT_FOCUSABLE) {
+        /* Keep the focus the application already had. If it had none -- the compositor
+         * came back to this client through the window that declines focus -- fall back to
+         * the last window that did hold it, so that the key events which are about to
+         * arrive are not delivered to a window the application declared output only.
+         */
+        if (!seat->keyboard.sdl_focus && seat->keyboard.last_focusable &&
+            !(seat->keyboard.last_focusable->flags & (SDL_WINDOW_HIDDEN | SDL_WINDOW_NOT_FOCUSABLE))) {
+            seat->keyboard.sdl_focus = seat->keyboard.last_focusable;
+            SDL_SetKeyboardFocus(seat->keyboard.sdl_focus);
+        }
+    } else {
+        seat->keyboard.sdl_focus = keyboard_focus;
+        seat->keyboard.last_focusable = keyboard_focus;
+        SDL_SetKeyboardFocus(keyboard_focus);
+    }
 
     // Update the keyboard grab and any relative pointer grabs related to this keyboard focus.
     Wayland_SeatUpdateKeyboardGrab(seat);
@@ -2159,20 +2204,17 @@ static void keyboard_handle_leave(void *data, struct wl_keyboard *keyboard,
     // Stop key repeat before clearing keyboard focus
     seat->keyboard.repeat.key = 0;
 
-    SDL_Window *keyboard_focus = SDL_GetKeyboardFocus();
-
-    // The keyboard focus may be a child popup
-    while (keyboard_focus && SDL_WINDOW_IS_POPUP(keyboard_focus)) {
-        keyboard_focus = keyboard_focus->parent;
-    }
-
-    const bool had_focus = keyboard_focus && window->sdlwindow == keyboard_focus;
+    const bool had_focus = seat->keyboard.sdl_focus != NULL;
     seat->keyboard.focus = NULL;
     --window->keyboard_focus_count;
 
-    // Only relinquish focus if this window has the active focus, and no other keyboards have focus on the window.
+    /* Only relinquish focus if this seat granted it, and no other keyboards have focus on
+     * the window. The actual withdrawal is deferred to the end of the event batch, because
+     * focus moving from one window to another arrives as a leave followed by an enter, and
+     * the destination may be a window that declines focus.
+     */
     if (!window->keyboard_focus_count && had_focus) {
-        SDL_SetKeyboardFocus(NULL);
+        seat->keyboard.focus_lost_pending = true;
     }
 
     // Release the keyboard grab and any relative pointer grabs related to this keyboard focus.
@@ -2447,6 +2489,7 @@ static void Wayland_SeatDestroyKeyboard(SDL_WaylandSeat *seat)
     // Make sure focus is removed from a surface before the keyboard is destroyed.
     if (seat->keyboard.focus) {
         keyboard_handle_leave(seat, seat->keyboard.wl_keyboard, 0, seat->keyboard.focus->surface);
+        Wayland_SeatResolvePendingKeyboardFocus(seat);
     }
 
     SDL_RemoveKeyboard(seat->keyboard.sdl_id);
@@ -3569,8 +3612,17 @@ void Wayland_DisplayRemoveWindowReferencesFromSeats(SDL_VideoData *display, SDL_
     SDL_WaylandSeat *seat;
     wl_list_for_each (seat, &display->seat_list, link)
     {
+        // These can point at a window that never had, or no longer has, the seat's focus.
+        if (seat->keyboard.sdl_focus == window->sdlwindow) {
+            seat->keyboard.sdl_focus = NULL;
+        }
+        if (seat->keyboard.last_focusable == window->sdlwindow) {
+            seat->keyboard.last_focusable = NULL;
+        }
+
         if (seat->keyboard.focus == window) {
             keyboard_handle_leave(seat, seat->keyboard.wl_keyboard, 0, window->surface);
+            Wayland_SeatResolvePendingKeyboardFocus(seat);
         }
 
         if (seat->pointer.focus == window) {

--- a/src/video/wayland/SDL_waylandevents_c.h
+++ b/src/video/wayland/SDL_waylandevents_c.h
@@ -136,6 +136,25 @@ typedef struct SDL_WaylandSeat
         struct zwp_input_timestamps_v1 *timestamps;
         struct zwp_keyboard_shortcuts_inhibitor_v1 *key_inhibitor;
         SDL_WindowData *focus;
+
+        /* The window the application was told holds this seat's keyboard focus. It can
+         * differ from 'focus' above when the compositor focuses a window that declined
+         * focus, in which case the application keeps the focus it already had.
+         */
+        SDL_Window *sdl_focus;
+
+        /* The last window of this application that legitimately held this seat's keyboard
+         * focus. Used as the destination when the compositor focuses a window that
+         * declines focus: the client is focused as far as the compositor is concerned, so
+         * key events will arrive and have to be delivered somewhere sensible.
+         */
+        SDL_Window *last_focusable;
+
+        /* Set when this seat's keyboard focus was withdrawn, and resolved at the end of
+         * the event batch: focus moving between two windows arrives as a leave followed
+         * by an enter, and the application should not see a focus change in between.
+         */
+        bool focus_lost_pending;
         SDL_Keymap **sdl_keymap;
         char *current_locale;
 

--- a/src/video/wayland/SDL_waylandwindow.c
+++ b/src/video/wayland/SDL_waylandwindow.c
@@ -3656,7 +3656,22 @@ bool Wayland_SetWindowFocusable(SDL_VideoDevice *_this, SDL_Window *window, bool
         return true;
     }
 
-    return SDL_SetError("wayland: focus can only be toggled on popup menu windows");
+    /* Regular toplevels: the compositor decides who holds keyboard focus and the protocol
+     * offers no way to decline it, so the flag is honored inside SDL when focus arrives
+     * (see keyboard_handle_enter). All that is left here is to bring the current state in
+     * line, in case the compositor has already given this window focus.
+     */
+    if (!(window->flags & SDL_WINDOW_HIDDEN)) {
+        if (!focusable) {
+            if (SDL_GetKeyboardFocus() == window) {
+                SDL_SetKeyboardFocus(NULL);
+            }
+        } else if (window->internal->keyboard_focus_count) {
+            SDL_SetKeyboardFocus(window);
+        }
+    }
+
+    return true;
 }
 
 void Wayland_ShowWindowSystemMenu(SDL_Window *window, int x, int y)


### PR DESCRIPTION
### The problem

`SDL_WINDOW_NOT_FOCUSABLE` is only implemented for popup menus on Wayland. On a regular
toplevel it is accepted at creation, stays visible in `SDL_GetWindowFlags()`, and does
nothing — while `SDL_SetWindowFocusable()` on the same window fails with
*"wayland: focus can only be toggled on popup menu windows"*. So the runtime path is
honest about not supporting this and the creation path silently isn't.

X11 has honored it since forever, through `WM_HINTS.input` (`SDL_x11window.c`), so this is
also a difference in behaviour between the two Linux backends for the same flag.

Where it bites: an application with one interactive window and several output only ones
(a second screen, a status display, a score view) that are revealed lazily. Each one takes
keyboard focus away from the window the user is actually working in as it maps. That is
what [vpinball/vpinball#3621](https://github.com/vpinball/vpinball/pull/3621) was about —
the maintainers were right to say the fix did not belong in an application, which is why
I'm bringing it here.

### The fix

xdg-shell gives a client no way to decline keyboard focus, and compositors hand it to the
last mapped toplevel of the active application. So honor the flag where SDL can: don't
tell the application that such a window took focus. The compositor's view of focus is
untouched, and since `keyboard_handle_key` dispatches through `SDL_GetKeyboardFocus()`,
key events still reach whichever window does hold SDL focus.

Two consequences worth calling out, because they are the non-obvious part:

**The focus withdrawal has to be deferred.** Focus moving between two windows arrives as
`leave` then `enter`, so `keyboard_handle_leave` cannot clear focus on the spot any more —
the destination may be a window that declines it. It now flags the withdrawal and
`Wayland_PumpEvents` resolves it once the batch is processed. A side benefit: an
application no longer sees a spurious focus loss when the compositor hands focus between
two of its own windows.

**There has to be a fallback.** When the compositor returns to the client *through* the
window that declines focus, the client is focused as far as the compositor is concerned
and key events will arrive. Dropping them would be wrong, so they go to the last window
that legitimately held focus.

`Wayland_SetWindowFocusable()` no longer fails on regular toplevels, since the same
mechanism covers the runtime path too.

### Testing

A six-step scenario on GNOME/Mutter (NVIDIA), run against this branch, against `main`, and
against the X11 backend as the reference for what the flag is supposed to do:

| | main / X11 | main / Wayland | this / Wayland |
|---|---|---|---|
| 1. main window mapped → focused | PASS | PASS | PASS |
| 2. output only window revealed late → focus unchanged | PASS | **FAIL** | PASS |
| 3. another application takes focus → focus lost | PASS | PASS | PASS |
| 4. that application exits → focus back on the main window | PASS | **FAIL** | PASS |
| 5. a second focusable window mapped → focus moves to it | PASS | PASS | PASS |
| 6. hiding the output only window → focus unchanged | PASS | PASS | PASS |

So Wayland goes from 4/6 to 6/6 and now matches X11 on all six.

Popup focus handling goes through the same enter/leave path and is unchanged in the
scenarios above, but it is the part I would most like a second pair of eyes on.

Draft because I would rather agree on the approach before polishing — in particular
whether the deferred withdrawal is acceptable, and whether the fallback destination is
the behaviour you want.
