### PR TITLE
PS2: fix textures rendering at half opacity

### DIFF
--- a/src/render/ps2/SDL_render_ps2.c
+++ b/src/render/ps2/SDL_render_ps2.c
@@ -118,7 +118,7 @@ static gs_rgbaq float_color_to_RGBAQ_tex(const SDL_FColor *color, float color_sc
     uint8_t colorR = (uint8_t)SDL_roundf(SDL_clamp(color->r * color_scale, 0.0f, 1.0f) * 127.0f);
     uint8_t colorG = (uint8_t)SDL_roundf(SDL_clamp(color->g * color_scale, 0.0f, 1.0f) * 127.0f);
     uint8_t colorB = (uint8_t)SDL_roundf(SDL_clamp(color->b * color_scale, 0.0f, 1.0f) * 127.0f);
-    uint8_t colorA = (uint8_t)SDL_roundf(SDL_clamp(color->a, 0.0f, 1.0f) * 63.0f);
+    uint8_t colorA = (uint8_t)SDL_roundf(SDL_clamp(color->a, 0.0f, 1.0f) * 127.0f);
 
     return color_to_RGBAQ(colorR, colorG, colorB, colorA, 0x00);
 }


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Fix textures rendering half-transparent when using any blend mode other than SDL_BLENDMODE_NONE on the PS2 backend.

## Description
Previously, float_color_to_RGBAQ_tex would multiply alpha by 63.0f.
This would result in texture opacity being mapped to a range of 0-63, and textures with the maximum alpha value would be rendered at only half opacity.
Changing this value to 127.0f to match the rest of the function fixes this issue as tested on an emulator (PCSX2).

This does not cause textures to turn black as it was described in [this comment](https://github.com/libsdl-org/SDL/issues/12395#issuecomment-3071182074).
Fully opaque textures render identically with SDL_BLENDMODE_BLEND as with SDL_BLENDMODE_NONE.

## Existing Issue(s)
Related to #12395