### PR TITLE
Fix DirectInput controllers when video driver is disabled

### DIFF
--- a/src/joystick/windows/SDL_dinputjoystick.c
+++ b/src/joystick/windows/SDL_dinputjoystick.c
@@ -791,10 +791,13 @@ bool SDL_DINPUT_JoystickOpen(SDL_Joystick *joystick, JoyStick_DeviceData *joysti
     }
 
     /* Acquire shared access. Exclusive access is required for forces,
-     * though. */
+     * though. But if there's no window handle (b/c the video driver
+     * is disabled) use non-exclusive and give up forces rather than
+     * fail to open.
+     */
     result =
         IDirectInputDevice8_SetCooperativeLevel(joystick->hwdata->InputDevice, SDL_HelperWindow,
-                                                DISCL_EXCLUSIVE |
+                                                (SDL_HelperWindow ? DISCL_EXCLUSIVE : DISCL_NONEXCLUSIVE) |
                                                     DISCL_BACKGROUND);
     if (FAILED(result)) {
         return SetDIerror("IDirectInputDevice8::SetCooperativeLevel", result);


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description

In SDL2, building without the video backend causes DirectInput controllers to not work.

The fix is to fallback to a non-exclusive mode when a window handle is not present.

I tested this change in SDL2 and it worked for me, but I saw the code looks very similar in SDL3. I didn't actually build this in SDL3 though as I'm not currently setup for it.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
