### PR TITLE
events: Add pinch event category

### DIFF
--- a/src/events/SDL_categories.c
+++ b/src/events/SDL_categories.c
@@ -144,6 +144,11 @@ SDL_EventCategory SDL_GetEventCategory(Uint32 type)
     case SDL_EVENT_FINGER_MOTION:
         return SDL_EVENTCATEGORY_TFINGER;
 
+    case SDL_EVENT_PINCH_BEGIN:
+    case SDL_EVENT_PINCH_UPDATE:
+    case SDL_EVENT_PINCH_END:
+        return SDL_EVENTCATEGORY_PINCH;
+
     case SDL_EVENT_CLIPBOARD_UPDATE:
         return SDL_EVENTCATEGORY_CLIPBOARD;
 
@@ -246,6 +251,9 @@ SDL_Window *SDL_GetWindowFromEvent(const SDL_Event *event)
         break;
     case SDL_EVENTCATEGORY_RENDER:
         windowID = event->render.windowID;
+        break;
+    case SDL_EVENTCATEGORY_PINCH:
+        windowID = event->pinch.windowID;
         break;
     default:
         // < 0  -> invalid event type (error is set by SDL_GetEventCategory)

--- a/src/events/SDL_categories_c.h
+++ b/src/events/SDL_categories_c.h
@@ -65,6 +65,7 @@ typedef enum SDL_EventCategory
     SDL_EVENTCATEGORY_CLIPBOARD,
     SDL_EVENTCATEGORY_RENDER,
     SDL_EVENTCATEGORY_NOTIFICATION,
+    SDL_EVENTCATEGORY_PINCH,
 } SDL_EventCategory;
 
 extern SDL_EventCategory SDL_GetEventCategory(Uint32 type);


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Needed to allow SDL_GetWindowFromEvent() to work with pinch events.