### PR TITLE
Support saving 1- and 4-bit MSB indexed surfaces as BMP

### DIFF
--- a/include/SDL3/SDL_surface.h
+++ b/include/SDL3/SDL_surface.h
@@ -594,10 +594,10 @@ extern SDL_DECLSPEC SDL_Surface * SDLCALL SDL_LoadBMP(const char *file);
 /**
  * Save a surface to a seekable SDL data stream in BMP format.
  *
- * Surfaces with a 24-bit, 32-bit and paletted 8-bit format get saved in the
+ * Surfaces with a 24-bit, 32-bit and paletted format get saved in the
  * BMP directly. Other RGB formats with 8-bit or higher get converted to a
  * 24-bit surface or, if they have an alpha mask or a colorkey, to a 32-bit
- * surface before they are saved. YUV and paletted 1-bit and 4-bit formats are
+ * surface before they are saved. YUV and LSB paletted 1-bit and 4-bit formats are
  * not supported.
  *
  * \param surface the SDL_Surface structure containing the image to be saved.
@@ -620,10 +620,10 @@ extern SDL_DECLSPEC bool SDLCALL SDL_SaveBMP_IO(SDL_Surface *surface, SDL_IOStre
 /**
  * Save a surface to a file in BMP format.
  *
- * Surfaces with a 24-bit, 32-bit and paletted 8-bit format get saved in the
+ * Surfaces with a 24-bit, 32-bit, paletted formats get saved in the
  * BMP directly. Other RGB formats with 8-bit or higher get converted to a
  * 24-bit surface or, if they have an alpha mask or a colorkey, to a 32-bit
- * surface before they are saved. YUV and paletted 1-bit and 4-bit formats are
+ * surface before they are saved. YUV and LSB paletted 1-bit and 4-bit formats are
  * not supported.
  *
  * \param surface the SDL_Surface structure containing the image to be saved.

--- a/src/video/SDL_bmp.c
+++ b/src/video/SDL_bmp.c
@@ -638,11 +638,17 @@ static bool InitBMPSaveState(BMPSaveState *state, SDL_Surface *surface)
     if (surface->palette && !state->save32bit) {
         if (SDL_BITSPERPIXEL(surface->format) == 8) {
             state->intermediate_surface = surface;
+        } else if (surface->format == SDL_PIXELFORMAT_INDEX1MSB || surface->format == SDL_PIXELFORMAT_INDEX4MSB) {
+            state->intermediate_surface = surface;
         } else {
             SDL_SetError("%u bpp BMP files not supported",
                          SDL_BITSPERPIXEL(surface->format));
             goto error;
         }
+    } else if (surface->format == SDL_PIXELFORMAT_INDEX1MSB || surface->format == SDL_PIXELFORMAT_INDEX4MSB) {
+        SDL_SetError("%u bpp BMP files require a palette",
+                     SDL_BITSPERPIXEL(surface->format));
+        goto error;
     } else if ((surface->format == SDL_PIXELFORMAT_BGR24 && !state->save32bit) ||
                (surface->format == SDL_PIXELFORMAT_BGRA32 && state->save32bit)) {
         state->intermediate_surface = surface;
@@ -726,7 +732,7 @@ static bool SDL_SaveBMP_IO_Internal(BMPSaveState *state, SDL_IOStream *dst, bool
     Uint32 bV5Reserved = 0;
 
     if (SDL_LockSurface(state->intermediate_surface)) {
-        const size_t bw = state->intermediate_surface->w * state->intermediate_surface->fmt->bytes_per_pixel;
+        const size_t bw = (state->intermediate_surface->w * SDL_BITSPERPIXEL(state->intermediate_surface->format) + 7) / 8;
 
         // Set the BMP file header values
         bfSize = 0; // We'll write this when we're done

--- a/src/video/SDL_surface.c
+++ b/src/video/SDL_surface.c
@@ -2781,9 +2781,11 @@ Uint32 SDL_MapSurfaceRGBA(SDL_Surface *surface, Uint8 r, Uint8 g, Uint8 b, Uint8
 bool SDL_ReadSurfacePixel(SDL_Surface *surface, int x, int y, Uint8 *r, Uint8 *g, Uint8 *b, Uint8 *a)
 {
     Uint32 pixel = 0;
+    Uint32 mask = 0xffffffff;
+    Uint32 shift = 0;
     size_t bytes_per_pixel;
     Uint8 unused;
-    Uint8 *p;
+    const Uint8 *p;
     bool result = false;
 
     if (r) {
@@ -2830,7 +2832,53 @@ bool SDL_ReadSurfacePixel(SDL_Surface *surface, int x, int y, Uint8 *r, Uint8 *g
         }
     }
 
-    p = (Uint8 *)surface->pixels + y * surface->pitch + x * bytes_per_pixel;
+    if (bytes_per_pixel == 0) {
+        switch (surface->format) {
+        case SDL_PIXELFORMAT_INDEX4MSB:
+            p = (Uint8 *)surface->pixels + y * surface->pitch + x / 2;
+            shift = 4 * (1 - (x & 0x1));
+            mask = 0xf << shift;
+            bytes_per_pixel = 1;
+            break;
+        case SDL_PIXELFORMAT_INDEX4LSB:
+            p = (Uint8 *)surface->pixels + y * surface->pitch + x / 2;
+            shift = 4 * (x & 0x1);
+            mask = 0xf << shift;
+            bytes_per_pixel = 1;
+            break;
+        case SDL_PIXELFORMAT_INDEX2MSB:
+            p = (Uint8 *)surface->pixels + y * surface->pitch + x / 4;
+            shift = 2 * (3 - (x & 0x3));
+            mask = 0x3 << shift;
+            bytes_per_pixel = 1;
+            break;
+        case SDL_PIXELFORMAT_INDEX2LSB:
+            p = (Uint8 *)surface->pixels + y * surface->pitch + x / 4;
+            shift = 2 * (x & 0x3);
+            mask = 0x3 << shift;
+            bytes_per_pixel = 1;
+            break;
+        case SDL_PIXELFORMAT_INDEX1MSB:
+            p = (Uint8 *)surface->pixels + y * surface->pitch + x / 8;
+            shift = 7 - (x & 0x7);
+            mask = 0x1 << shift;
+            bytes_per_pixel = 1;
+            break;
+        case SDL_PIXELFORMAT_INDEX1LSB:
+            p = (Uint8 *)surface->pixels + y * surface->pitch + x / 8;
+            shift = x & 0x7;
+            mask = 0x1 << shift;
+            bytes_per_pixel = 1;
+            break;
+        default:
+            if (SDL_MUSTLOCK(surface)) {
+                SDL_UnlockSurface(surface);
+            }
+            return SDL_SetError("Unsupported format with 0 bpp");
+        }
+    } else {
+        p = (Uint8 *)surface->pixels + y * surface->pitch + x * bytes_per_pixel;
+    }
 
     if (bytes_per_pixel <= sizeof(pixel) &&
         !SDL_ISPIXELFORMAT_FOURCC(surface->format) &&
@@ -2842,6 +2890,7 @@ bool SDL_ReadSurfacePixel(SDL_Surface *surface, int x, int y, Uint8 *r, Uint8 *g
 #else
         SDL_memcpy(&pixel, p, bytes_per_pixel);
 #endif
+        pixel = (pixel & mask) >> shift;
         SDL_GetRGBA(pixel, surface->fmt, surface->palette, r, g, b, a);
         result = true;
     } else if (SDL_ISPIXELFORMAT_FOURCC(surface->format)) {

--- a/test/testautomation_surface.c
+++ b/test/testautomation_surface.c
@@ -328,15 +328,10 @@ static int SDLCALL surface_testSaveLoad(void *arg)
     int ret;
     const char *sampleFilename = "testSaveLoad.tmp";
     SDL_Surface *face;
-    SDL_Surface *indexed_surface;
     SDL_Surface *rface;
-    SDL_Palette *palette;
-    SDL_Color colors[] = {
-        { 255, 0, 0, SDL_ALPHA_OPAQUE },    /* Red */
-        { 0, 255, 0, SDL_ALPHA_OPAQUE }     /* Green */
-    };
     SDL_IOStream *stream;
     Uint8 r, g, b, a;
+    Uint8 ref_r, ref_g, ref_b, ref_a;
 
     /* Create sample surface */
     face = SDLTest_ImageFace();
@@ -344,18 +339,6 @@ static int SDLCALL surface_testSaveLoad(void *arg)
     if (face == NULL) {
         return TEST_ABORTED;
     }
-
-    indexed_surface = SDL_CreateSurface(32, 32, SDL_PIXELFORMAT_INDEX8);
-    SDLTest_AssertCheck(indexed_surface != NULL, "SDL_CreateSurface(SDL_PIXELFORMAT_INDEX8)");
-
-    /* Delete test file; ignore errors */
-    SDL_RemovePath(sampleFilename);
-
-    /* Saving an indexed surface without palette as BMP fails */
-    ret = SDL_SaveBMP(indexed_surface, sampleFilename);
-    SDLTest_AssertPass("Call to SDL_SaveBMP() using an indexed surface without palette");
-    SDLTest_AssertCheck(ret == false, "Verify result of SDL_SaveBMP(indexed_surface without palette), expected: false, got: %i", ret);
-    SDLTest_AssertCheck(!SDL_GetPathInfo(sampleFilename, NULL), "No file is created after trying to save a indexed surface without palette");
 
     /* Delete test file; ignore errors */
     SDL_RemovePath(sampleFilename);
@@ -366,25 +349,25 @@ static int SDLCALL surface_testSaveLoad(void *arg)
     SDLTest_AssertCheck(ret == true, "Verify result from SDL_SaveBMP, expected: true, got: %i", ret);
     AssertFileExist(sampleFilename);
 
-    /* Load a BMP surface */
+    /* Load a indexed BMP surface */
     rface = SDL_LoadBMP(sampleFilename);
     SDLTest_AssertPass("Call to SDL_LoadBMP()");
     SDLTest_AssertCheck(rface != NULL, "Verify result from SDL_LoadBMP is not NULL");
     if (rface != NULL) {
         SDLTest_AssertCheck(face->w == rface->w, "Verify width of loaded surface, expected: %i, got: %i", face->w, rface->w);
         SDLTest_AssertCheck(face->h == rface->h, "Verify height of loaded surface, expected: %i, got: %i", face->h, rface->h);
+        SDL_ReadSurfacePixel(rface, 0, 0, &r, &g, &b, &a);
+        SDL_ReadSurfacePixel(face, 0, 0, &ref_r, &ref_g, &ref_b, &ref_a);
+        SDLTest_AssertCheck(r == ref_r &&
+                            g == ref_g &&
+                            b == ref_b &&
+                            a == ref_a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            ref_r, ref_g, ref_b, ref_a,
+                            r, g, b, a);
         SDL_DestroySurface(rface);
         rface = NULL;
     }
-
-    /* Delete test file; ignore errors */
-    SDL_RemovePath(sampleFilename);
-
-    /* Saving an indexed surface as PNG fails */
-    ret = SDL_SavePNG(indexed_surface, sampleFilename);
-    SDLTest_AssertPass("Call to SDL_SavePNG() using an indexed surface without palette");
-    SDLTest_AssertCheck(ret == false, "Verify result of SDL_SavePNG(indexed surface without palette), expected: false, got: %i", ret);
-    SDLTest_AssertCheck(ret == false, "Verify result of SDL_SavePNG(indexed surface without palette), expected: false, got: %i", ret);
 
     /* Delete test file; ignore errors */
     SDL_RemovePath(sampleFilename);
@@ -395,13 +378,145 @@ static int SDLCALL surface_testSaveLoad(void *arg)
     SDLTest_AssertCheck(ret == true, "Verify result from SDL_SavePNG, expected: true, got: %i", ret);
     AssertFileExist(sampleFilename);
 
-    /* Load a PNG surface */
-    rface = SDL_LoadPNG(sampleFilename);
-    SDLTest_AssertPass("Call to SDL_LoadPNG()");
-    SDLTest_AssertCheck(rface != NULL, "Verify result from SDL_LoadPNG is not NULL");
+    /* Delete test file; ignore errors */
+    SDL_RemovePath(sampleFilename);
+
+    stream = SDL_IOFromDynamicMem();
+    SDLTest_AssertCheck(stream != NULL, "Verify iostream is not NULL");
+    if (stream == NULL) {
+        return TEST_ABORTED;
+    }
+
+    /* Save a BMP surface */
+    ret = SDL_SaveBMP_IO(face, stream, false);
+    SDLTest_AssertPass("Call to SDL_SaveBMP_IO()");
+    SDLTest_AssertCheck(ret == true, "Verify result from SDL_SaveBMP_IO, expected: true, got: %i", ret);
+
+    SDL_SeekIO(stream, 0, SDL_IO_SEEK_SET);
+
+    /* Load a indexed BMP surface */
+    rface = SDL_LoadBMP_IO(stream, false);
+    SDLTest_AssertPass("Call to SDL_LoadBMP_IO()");
+    SDLTest_AssertCheck(rface != NULL, "Verify result from SDL_LoadBMP_IO is not NULL");
     if (rface != NULL) {
         SDLTest_AssertCheck(face->w == rface->w, "Verify width of loaded surface, expected: %i, got: %i", face->w, rface->w);
         SDLTest_AssertCheck(face->h == rface->h, "Verify height of loaded surface, expected: %i, got: %i", face->h, rface->h);
+        SDL_ReadSurfacePixel(rface, 0, 0, &r, &g, &b, &a);
+        SDL_ReadSurfacePixel(face, 0, 0, &ref_r, &ref_g, &ref_b, &ref_a);
+        SDLTest_AssertCheck(r == ref_r &&
+                            g == ref_g &&
+                            b == ref_b &&
+                            a == ref_a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            ref_r, ref_g, ref_b, ref_a,
+                            r, g, b, a);
+        SDL_DestroySurface(rface);
+        rface = NULL;
+    }
+
+    SDL_SeekIO(stream, 0, SDL_IO_SEEK_SET);
+
+    /* Save a PNG surface */
+    ret = SDL_SavePNG_IO(face, stream, false);
+    SDLTest_AssertPass("Call to SDL_SavePNG_IO()");
+    SDLTest_AssertCheck(ret == true, "Verify result from SDL_SavePNG_IO, expected: true, got: %i", ret);
+
+    SDL_CloseIO(stream);
+    SDL_DestroySurface(face);
+
+    return TEST_COMPLETED;
+}
+
+/**
+ * Tests 8-bit sprite saving and loading
+ */
+static int SDLCALL surface_testIndexed8SaveLoad(void *arg)
+{
+    int ret;
+    const char *sampleFilename = "testSaveLoad.tmp";
+    SDL_Surface *indexed_surface_nopal = NULL;
+    SDL_Surface *indexed_surface_pal = NULL;
+    SDL_Surface *rface;
+    SDL_Palette *palette;
+    const SDL_Color palette_colors[] = {
+        { 0x00, 0x00, 0x00, SDL_ALPHA_OPAQUE },    /* Black */
+        { 0xff, 0x00, 0x00, SDL_ALPHA_OPAQUE },    /* Red */
+        { 0x00, 0xff, 0x00, SDL_ALPHA_OPAQUE },    /* Green */
+        { 0x00, 0x00, 0xff, SDL_ALPHA_OPAQUE }     /* Blue */
+    };
+    SDL_IOStream *stream;
+    Uint8 r, g, b, a;
+
+    /* Create a 8-bit surface without palette */
+    indexed_surface_nopal = SDL_CreateSurface(32, 32, SDL_PIXELFORMAT_INDEX8);
+    SDLTest_AssertCheck(indexed_surface_nopal != NULL, "SDL_CreateSurface(SDL_PIXELFORMAT_INDEX8)");
+    if (!indexed_surface_nopal) {
+        return TEST_ABORTED;
+    }
+
+    /* Create a 8-bit surface with palette */
+    indexed_surface_pal = SDL_CreateSurface(3, 3, SDL_PIXELFORMAT_INDEX8);
+    SDLTest_AssertCheck(indexed_surface_pal != NULL, "Verify 8-bit surface is not NULL");
+    if (indexed_surface_pal == NULL) {
+        return TEST_ABORTED;
+    }
+    palette = SDL_CreatePalette(SDL_arraysize(palette_colors));
+    SDLTest_AssertCheck(palette != NULL, "Verify palette is not NULL");
+    if (palette == NULL) {
+        return TEST_ABORTED;
+    }
+    SDL_SetPaletteColors(palette, palette_colors, 0, SDL_arraysize(palette_colors));
+    SDL_SetSurfacePalette(indexed_surface_pal, palette);
+    SDL_DestroyPalette(palette);
+    /* Set a few pixels */
+    if (indexed_surface_pal) {
+        Uint8 *pixels = indexed_surface_pal->pixels;
+        pixels[0] = 2; /* Green */
+        pixels[(indexed_surface_pal->h - 1) * indexed_surface_pal->pitch + indexed_surface_pal->w - 1] = 3; /* Blue */
+    }
+
+    /* Delete test file; ignore errors */
+    SDL_RemovePath(sampleFilename);
+
+    /* Test saving an indexed surface without palette as BMP: should fail */
+    ret = SDL_SaveBMP(indexed_surface_nopal, sampleFilename);
+    SDLTest_AssertPass("Call to SDL_SaveBMP() using an indexed surface without palette");
+    SDLTest_AssertCheck(ret == false, "Verify result of SDL_SaveBMP(indexed surface without palette), expected: false, got: %i", ret);
+    SDLTest_AssertCheck(!SDL_GetPathInfo(sampleFilename, NULL), "No file is created after trying to save a indexed surface without palette");
+
+    /* Delete test file; ignore errors */
+    SDL_RemovePath(sampleFilename);
+
+    /* Test saving an indexed surface with palette as BMP: should succeed */
+    ret = SDL_SaveBMP(indexed_surface_pal, sampleFilename);
+    SDLTest_AssertPass("Call to SDL_SaveBMP()");
+    SDLTest_AssertCheck(ret == true, "Verify result from SDL_SaveBMP, expected: true, got: %i", ret);
+    AssertFileExist(sampleFilename);
+
+    /* Load a indexed BMP surface */
+    rface = SDL_LoadBMP(sampleFilename);
+    SDLTest_AssertPass("Call to SDL_LoadBMP()");
+    SDLTest_AssertCheck(rface != NULL, "Verify result from SDL_LoadBMP is not NULL");
+    if (rface != NULL) {
+        SDLTest_AssertCheck(indexed_surface_pal->w == rface->w, "Verify width of loaded surface, expected: %i, got: %i", indexed_surface_pal->w, rface->w);
+        SDLTest_AssertCheck(indexed_surface_pal->h == rface->h, "Verify height of loaded surface, expected: %i, got: %i", indexed_surface_pal->h, rface->h);
+        SDLTest_AssertCheck(rface->format == SDL_PIXELFORMAT_INDEX8, "Verify format of loaded surface, expected: %s, got: %s", SDL_GetPixelFormatName(indexed_surface_pal->format), SDL_GetPixelFormatName(rface->format));
+        SDL_ReadSurfacePixel(rface, 0, 0, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[2].r &&
+                            g == palette_colors[2].g &&
+                            b == palette_colors[2].b &&
+                            a == palette_colors[2].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[2].r, palette_colors[2].g, palette_colors[2].b, palette_colors[2].a,
+                            r, g, b, a);
+        SDL_ReadSurfacePixel(rface, rface->w - 1, rface->h - 1, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[3].r &&
+                            g == palette_colors[3].g &&
+                            b == palette_colors[3].b &&
+                            a == palette_colors[3].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[3].r, palette_colors[3].g, palette_colors[3].b, palette_colors[3].a,
+                            r, g, b, a);
         SDL_DestroySurface(rface);
         rface = NULL;
     }
@@ -409,60 +524,81 @@ static int SDLCALL surface_testSaveLoad(void *arg)
     /* Delete test file; ignore errors */
     SDL_RemovePath(sampleFilename);
 
-    /* Clean up */
-    SDL_DestroySurface(face);
-    face = NULL;
+    /* Test saving an indexed surface without palette as PNG: should fail */
+    ret = SDL_SavePNG(indexed_surface_nopal, sampleFilename);
+    SDLTest_AssertPass("Call to SDL_SavePNG() using an indexed surface without palette");
+    SDLTest_AssertCheck(ret == false, "Verify result of SDL_SavePNG(indexed surface without palette), expected: false, got: %i", ret);
 
-    /* Create an 8-bit image */
-    face = SDL_CreateSurface(1, 1, SDL_PIXELFORMAT_INDEX8);
-    SDLTest_AssertCheck(face != NULL, "Verify 8-bit surface is not NULL");
-    if (face == NULL) {
-        return TEST_ABORTED;
+    /* Delete test file; ignore errors */
+    SDL_RemovePath(sampleFilename);
+
+    /* Test saving an indexed surface with palette as PNG: should succeed */
+    ret = SDL_SavePNG(indexed_surface_pal, sampleFilename);
+    SDLTest_AssertPass("Call to SDL_SavePNG()");
+    SDLTest_AssertCheck(ret == true, "Verify result from SDL_SavePNG, expected: true, got: %i", ret);
+    AssertFileExist(sampleFilename);
+
+    /* Load a indexed PNG surface */
+    rface = SDL_LoadPNG(sampleFilename);
+    SDLTest_AssertPass("Call to SDL_LoadPNG()");
+    SDLTest_AssertCheck(rface != NULL, "Verify result from SDL_LoadPNG is not NULL");
+    if (rface != NULL) {
+        SDLTest_AssertCheck(indexed_surface_pal->w == rface->w, "Verify width of loaded surface, expected: %i, got: %i", indexed_surface_pal->w, rface->w);
+        SDLTest_AssertCheck(indexed_surface_pal->h == rface->h, "Verify height of loaded surface, expected: %i, got: %i", indexed_surface_pal->h, rface->h);
+        SDL_DestroySurface(rface);
+        rface = NULL;
     }
 
-    palette = SDL_CreatePalette(2);
-    SDLTest_AssertCheck(palette != NULL, "Verify palette is not NULL");
-    if (palette == NULL) {
-        return TEST_ABORTED;
-    }
-    SDL_SetPaletteColors(palette, colors, 0, SDL_arraysize(colors));
-    SDL_SetSurfacePalette(face, palette);
-    SDL_DestroyPalette(palette);
+    /* Delete test file; ignore errors */
+    SDL_RemovePath(sampleFilename);
 
-    /* Set a green pixel */
-    *(Uint8 *)face->pixels = 1;
-
-    /* Save and reload as a BMP */
     stream = SDL_IOFromDynamicMem();
     SDLTest_AssertCheck(stream != NULL, "Verify iostream is not NULL");
     if (stream == NULL) {
         return TEST_ABORTED;
     }
-    ret = SDL_SaveBMP_IO(indexed_surface, stream, false);
-    SDLTest_AssertCheck(ret == false, "Verify result from SDL_SaveBMP (indexed surface without palette), expected: false, got: %i", ret);
+
+    /* Cannot save a indexed surface without palette as a BMP */
+    ret = SDL_SaveBMP_IO(indexed_surface_nopal, stream, false);
+    SDLTest_AssertCheck(ret == false, "Verify result from SDL_SaveBMP_IO(indexed surface without palette), expected: false, got: %i", ret);
+
     SDL_SeekIO(stream, 0, SDL_IO_SEEK_SET);
-    ret = SDL_SaveBMP_IO(face, stream, false);
-    SDLTest_AssertPass("Call to SDL_SaveBMP()");
-    SDLTest_AssertCheck(ret == true, "Verify result from SDL_SaveBMP, expected: true, got: %i", ret);
+
+    /* Test saving a indexed surface with palette as a BMP */
+    ret = SDL_SaveBMP_IO(indexed_surface_pal, stream, false);
+    SDLTest_AssertPass("Call to SDL_SaveBMP_IO()");
+    SDLTest_AssertCheck(ret == true, "Verify result from SDL_SaveBMP_IO, expected: true, got: %i", ret);
+
     SDL_SeekIO(stream, 0, SDL_IO_SEEK_SET);
+
+    /* Test reloading the indexed BMP */
     rface = SDL_LoadBMP_IO(stream, false);
-    SDLTest_AssertPass("Call to SDL_LoadBMP()");
-    SDLTest_AssertCheck(rface != NULL, "Verify result from SDL_LoadBMP is not NULL");
+    SDLTest_AssertPass("Call to SDL_LoadBMP_IO()");
+    SDLTest_AssertCheck(rface != NULL, "Verify result from SDL_LoadBMP_IO is not NULL");
     if (rface != NULL) {
-        SDLTest_AssertCheck(face->w == rface->w, "Verify width of loaded surface, expected: %i, got: %i", face->w, rface->w);
-        SDLTest_AssertCheck(face->h == rface->h, "Verify height of loaded surface, expected: %i, got: %i", face->h, rface->h);
-        SDLTest_AssertCheck(rface->format == SDL_PIXELFORMAT_INDEX8, "Verify format of loaded surface, expected: %s, got: %s", SDL_GetPixelFormatName(face->format), SDL_GetPixelFormatName(rface->format));
+        SDLTest_AssertCheck(indexed_surface_pal->w == rface->w, "Verify width of loaded surface, expected: %i, got: %i", indexed_surface_pal->w, rface->w);
+        SDLTest_AssertCheck(indexed_surface_pal->h == rface->h, "Verify height of loaded surface, expected: %i, got: %i", indexed_surface_pal->h, rface->h);
+        SDLTest_AssertCheck(rface->format == SDL_PIXELFORMAT_INDEX8, "Verify format of loaded surface, expected: %s, got: %s", SDL_GetPixelFormatName(indexed_surface_pal->format), SDL_GetPixelFormatName(rface->format));
         SDL_ReadSurfacePixel(rface, 0, 0, &r, &g, &b, &a);
-        SDLTest_AssertCheck(r == colors[1].r &&
-                            g == colors[1].g &&
-                            b == colors[1].b &&
-                            a == colors[1].a,
+        SDLTest_AssertCheck(r == palette_colors[2].r &&
+                            g == palette_colors[2].g &&
+                            b == palette_colors[2].b &&
+                            a == palette_colors[2].a,
                             "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
-                            r, g, b, a,
-                            colors[1].r, colors[1].g, colors[1].b, colors[1].a);
+                            palette_colors[2].r, palette_colors[2].g, palette_colors[2].b, palette_colors[2].a,
+                            r, g, b, a);
+        SDL_ReadSurfacePixel(rface, rface->w - 1, rface->h - 1, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[3].r &&
+                            g == palette_colors[3].g &&
+                            b == palette_colors[3].b &&
+                            a == palette_colors[3].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[3].r, palette_colors[3].g, palette_colors[3].b, palette_colors[3].a,
+                            r, g, b, a);
         SDL_DestroySurface(rface);
         rface = NULL;
     }
+
     SDL_CloseIO(stream);
     stream = NULL;
 
@@ -472,36 +608,52 @@ static int SDLCALL surface_testSaveLoad(void *arg)
     if (stream == NULL) {
         return TEST_ABORTED;
     }
-    ret = SDL_SavePNG_IO(indexed_surface, stream, false);
+
+    /* Test saving a indexed surface without palette as a PNG: should fail */
+    ret = SDL_SavePNG_IO(indexed_surface_nopal, stream, false);
     SDLTest_AssertCheck(ret == false, "Verify result from SDL_SavePNG_IO (indexed surface without palette), expected: false, got: %i", ret);
+
     SDL_SeekIO(stream, 0, SDL_IO_SEEK_SET);
-    ret = SDL_SavePNG_IO(face, stream, false);
-    SDLTest_AssertPass("Call to SDL_SavePNG()");
-    SDLTest_AssertCheck(ret == true, "Verify result from SDL_SavePNG, expected: true, got: %i", ret);
+
+    /* Test saving a indexed surface with palette as a PNG: should succeed */
+    ret = SDL_SavePNG_IO(indexed_surface_pal, stream, false);
+    SDLTest_AssertPass("Call to SDL_SavePNG_IO()");
+    SDLTest_AssertCheck(ret == true, "Verify result from SDL_SavePNG_IO, expected: true, got: %i", ret);
+
     SDL_SeekIO(stream, 0, SDL_IO_SEEK_SET);
+
     rface = SDL_LoadPNG_IO(stream, false);
-    SDLTest_AssertPass("Call to SDL_LoadPNG()");
-    SDLTest_AssertCheck(rface != NULL, "Verify result from SDL_LoadPNG is not NULL");
+    SDLTest_AssertPass("Call to SDL_LoadPNG_IO()");
+    SDLTest_AssertCheck(rface != NULL, "Verify result from SDL_LoadPNG_IO is not NULL");
     if (rface != NULL) {
-        SDLTest_AssertCheck(face->w == rface->w, "Verify width of loaded surface, expected: %i, got: %i", face->w, rface->w);
-        SDLTest_AssertCheck(face->h == rface->h, "Verify height of loaded surface, expected: %i, got: %i", face->h, rface->h);
-        SDLTest_AssertCheck(rface->format == SDL_PIXELFORMAT_INDEX8, "Verify format of loaded surface, expected: %s, got: %s", SDL_GetPixelFormatName(face->format), SDL_GetPixelFormatName(rface->format));
+        SDLTest_AssertCheck(indexed_surface_pal->w == rface->w, "Verify width of loaded surface, expected: %i, got: %i", indexed_surface_pal->w, rface->w);
+        SDLTest_AssertCheck(indexed_surface_pal->h == rface->h, "Verify height of loaded surface, expected: %i, got: %i", indexed_surface_pal->h, rface->h);
+        SDLTest_AssertCheck(rface->format == SDL_PIXELFORMAT_INDEX8, "Verify format of loaded surface, expected: %s, got: %s", SDL_GetPixelFormatName(indexed_surface_pal->format), SDL_GetPixelFormatName(rface->format));
         SDL_ReadSurfacePixel(rface, 0, 0, &r, &g, &b, &a);
-        SDLTest_AssertCheck(r == colors[1].r &&
-                            g == colors[1].g &&
-                            b == colors[1].b &&
-                            a == colors[1].a,
+        SDLTest_AssertCheck(r == palette_colors[2].r &&
+                            g == palette_colors[2].g &&
+                            b == palette_colors[2].b &&
+                            a == palette_colors[2].a,
                             "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
-                            r, g, b, a,
-                            colors[1].r, colors[1].g, colors[1].b, colors[1].a);
+                            palette_colors[2].r, palette_colors[2].g, palette_colors[2].b, palette_colors[2].a,
+                            r, g, b, a);
+        SDL_ReadSurfacePixel(rface, rface->w - 1, rface->h - 1, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[3].r &&
+                            g == palette_colors[3].g &&
+                            b == palette_colors[3].b &&
+                            a == palette_colors[3].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[3].r, palette_colors[3].g, palette_colors[3].b, palette_colors[3].a,
+                            r, g, b, a);
         SDL_DestroySurface(rface);
         rface = NULL;
     }
+
     SDL_CloseIO(stream);
     stream = NULL;
 
-    SDL_DestroySurface(indexed_surface);
-    SDL_DestroySurface(face);
+    SDL_DestroySurface(indexed_surface_nopal);
+    SDL_DestroySurface(indexed_surface_pal);
 
     return TEST_COMPLETED;
 }
@@ -2141,7 +2293,11 @@ static const SDLTest_TestCaseReference surfaceTestInvalidFormat = {
 };
 
 static const SDLTest_TestCaseReference surfaceTestSaveLoad = {
-    surface_testSaveLoad, "surface_testSaveLoad", "Tests sprite saving and loading.", TEST_ENABLED
+    surface_testSaveLoad, "surface_testSaveLoad", "Test saving and loading RGBA sprites as BMP and PNG.", TEST_ENABLED
+};
+
+static const SDLTest_TestCaseReference surfaceTestIndex8SaveLoad = {
+    surface_testIndexed8SaveLoad, "surface_testIndexed8SaveLoad", "Test saving and loading 8-bit indexed sprites as BMP and PNG.", TEST_ENABLED
 };
 
 static const SDLTest_TestCaseReference surfaceTestBlitZeroSource = {
@@ -2268,6 +2424,7 @@ static const SDLTest_TestCaseReference surfaceTest16BitTo32Bit = {
 static const SDLTest_TestCaseReference *surfaceTests[] = {
     &surfaceTestInvalidFormat,
     &surfaceTestSaveLoad,
+    &surfaceTestIndex8SaveLoad,
     &surfaceTestBlitZeroSource,
     &surfaceTestBlit,
     &surfaceTestBlitTiled,

--- a/test/testautomation_surface.c
+++ b/test/testautomation_surface.c
@@ -659,6 +659,601 @@ static int SDLCALL surface_testIndexed8SaveLoad(void *arg)
 }
 
 /**
+ * Tests 4-bit sprite saving and loading
+ */
+static int SDLCALL surface_testIndexed4SaveLoad(void *arg)
+{
+    int ret;
+    const char *sampleFilename = "testSaveLoad.tmp";
+    SDL_Surface *indexed_surface_nopal = NULL;
+    SDL_Surface *indexed_surface_pal = NULL;
+    SDL_Surface *rface;
+    SDL_Palette *palette;
+    const SDL_Color palette_colors[] = {
+        { 0x00, 0x00, 0x00, SDL_ALPHA_OPAQUE },    /* Black */
+        { 0xff, 0x00, 0x00, SDL_ALPHA_OPAQUE },    /* Red */
+        { 0x00, 0xff, 0x00, SDL_ALPHA_OPAQUE },    /* Green */
+        { 0x00, 0x00, 0xff, SDL_ALPHA_OPAQUE }     /* Blue */
+    };
+    SDL_IOStream *stream;
+    Uint8 r, g, b, a;
+
+    /* Create a 4-bit MSB surface without palette */
+    indexed_surface_nopal = SDL_CreateSurface(32, 32, SDL_PIXELFORMAT_INDEX4MSB);
+    SDLTest_AssertCheck(indexed_surface_nopal != NULL, "SDL_CreateSurface(SDL_PIXELFORMAT_INDEX4MSB)");
+    if (!indexed_surface_nopal) {
+        return TEST_ABORTED;
+    }
+
+    /* Create a 4-bit MSB surface with palette */
+    indexed_surface_pal = SDL_CreateSurface(4, 4, SDL_PIXELFORMAT_INDEX4MSB);
+    SDLTest_AssertCheck(indexed_surface_pal != NULL, "Verify 4-bit surface is not NULL");
+    if (indexed_surface_pal == NULL) {
+        return TEST_ABORTED;
+    }
+    palette = SDL_CreatePalette(SDL_arraysize(palette_colors));
+    SDLTest_AssertCheck(palette != NULL, "Verify palette is not NULL");
+    if (palette == NULL) {
+        return TEST_ABORTED;
+    }
+    SDL_SetPaletteColors(palette, palette_colors, 0, SDL_arraysize(palette_colors));
+    SDL_SetSurfacePalette(indexed_surface_pal, palette);
+    SDL_DestroyPalette(palette);
+    /* Set a few pixels */
+    if (indexed_surface_pal) {
+        Uint8 *pixels = indexed_surface_pal->pixels;
+        /* (0,0) => Green, (1,0) => Red */
+        pixels[0] = (2 << 4) | (1 << 0);
+
+        /* (w-2,h-1) => Blue, (w-1,h-1) => Red */
+        pixels[(indexed_surface_pal->h - 1) * indexed_surface_pal->pitch + (indexed_surface_pal->w - 1) / 2] = (3 << 4) | (1 << 0);
+    }
+
+    /* Delete test file; ignore errors */
+    SDL_RemovePath(sampleFilename);
+
+    /* Test saving an indexed surface without palette as BMP: should fail */
+    ret = SDL_SaveBMP(indexed_surface_nopal, sampleFilename);
+    SDLTest_AssertPass("Call to SDL_SaveBMP() using an indexed surface without palette");
+    SDLTest_AssertCheck(ret == false, "Verify result of SDL_SaveBMP(indexed surface without palette), expected: false, got: %i", ret);
+    SDLTest_AssertCheck(!SDL_GetPathInfo(sampleFilename, NULL), "No file is created after trying to save a indexed surface without palette");
+
+    /* Delete test file; ignore errors */
+    SDL_RemovePath(sampleFilename);
+
+    /* Test saving an indexed surface with palette as BMP: should succeed */
+    ret = SDL_SaveBMP(indexed_surface_pal, sampleFilename);
+    SDLTest_AssertPass("Call to SDL_SaveBMP()");
+    SDLTest_AssertCheck(ret == true, "Verify result from SDL_SaveBMP, expected: true, got: %i", ret);
+    AssertFileExist(sampleFilename);
+
+    /* Load a indexed BMP surface */
+    rface = SDL_LoadBMP(sampleFilename);
+    SDLTest_AssertPass("Call to SDL_LoadBMP() (%s)", SDL_GetError());
+    SDLTest_AssertCheck(rface != NULL, "Verify result from SDL_LoadBMP is not NULL");
+    if (rface != NULL) {
+        SDLTest_AssertCheck(indexed_surface_pal->w == rface->w, "Verify width of loaded surface, expected: %i, got: %i", indexed_surface_pal->w, rface->w);
+        SDLTest_AssertCheck(indexed_surface_pal->h == rface->h, "Verify height of loaded surface, expected: %i, got: %i", indexed_surface_pal->h, rface->h);
+        SDLTest_AssertCheck(rface->format == SDL_PIXELFORMAT_INDEX4MSB, "Verify format of loaded surface, expected: %s, got: %s", SDL_GetPixelFormatName(indexed_surface_pal->format), SDL_GetPixelFormatName(rface->format));
+        SDL_ReadSurfacePixel(rface, 0, 0, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[2].r &&
+                            g == palette_colors[2].g &&
+                            b == palette_colors[2].b &&
+                            a == palette_colors[2].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[2].r, palette_colors[2].g, palette_colors[2].b, palette_colors[2].a,
+                            r, g, b, a);
+        SDL_ReadSurfacePixel(rface, 1, 0, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[1].r &&
+                            g == palette_colors[1].g &&
+                            b == palette_colors[1].b &&
+                            a == palette_colors[1].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[1].r, palette_colors[1].g, palette_colors[1].b, palette_colors[1].a,
+                            r, g, b, a);
+        SDL_ReadSurfacePixel(rface, rface->w - 2, rface->h - 1, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[3].r &&
+                            g == palette_colors[3].g &&
+                            b == palette_colors[3].b &&
+                            a == palette_colors[3].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[3].r, palette_colors[3].g, palette_colors[3].b, palette_colors[3].a,
+                            r, g, b, a);
+        SDL_ReadSurfacePixel(rface, rface->w - 1, rface->h - 1, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[1].r &&
+                            g == palette_colors[1].g &&
+                            b == palette_colors[1].b &&
+                            a == palette_colors[1].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[1].r, palette_colors[1].g, palette_colors[1].b, palette_colors[1].a,
+                            r, g, b, a);
+        SDL_DestroySurface(rface);
+        rface = NULL;
+    }
+
+    /* Delete test file; ignore errors */
+    SDL_RemovePath(sampleFilename);
+
+    /* Test saving an indexed surface without palette as PNG: should fail */
+    ret = SDL_SavePNG(indexed_surface_nopal, sampleFilename);
+    SDLTest_AssertPass("Call to SDL_SavePNG() using an indexed surface without palette");
+    SDLTest_AssertCheck(ret == false, "Verify result of SDL_SavePNG(indexed surface without palette), expected: false, got: %i", ret);
+
+    /* Delete test file; ignore errors */
+    SDL_RemovePath(sampleFilename);
+
+    /* Test saving an indexed surface with palette as PNG: should succeed */
+    ret = SDL_SavePNG(indexed_surface_pal, sampleFilename);
+    SDLTest_AssertPass("Call to SDL_SavePNG()");
+    SDLTest_AssertCheck(ret == true, "Verify result from SDL_SavePNG, expected: true, got: %i", ret);
+    AssertFileExist(sampleFilename);
+
+    /* Load a indexed PNG surface */
+    rface = SDL_LoadPNG(sampleFilename);
+    SDLTest_AssertPass("Call to SDL_LoadPNG()");
+    SDLTest_AssertCheck(rface != NULL, "Verify result from SDL_LoadPNG is not NULL");
+    if (rface != NULL) {
+        SDLTest_AssertCheck(indexed_surface_pal->w == rface->w, "Verify width of loaded surface, expected: %i, got: %i", indexed_surface_pal->w, rface->w);
+        SDLTest_AssertCheck(indexed_surface_pal->h == rface->h, "Verify height of loaded surface, expected: %i, got: %i", indexed_surface_pal->h, rface->h);
+        SDL_DestroySurface(rface);
+        rface = NULL;
+    }
+
+    /* Delete test file; ignore errors */
+    SDL_RemovePath(sampleFilename);
+
+    stream = SDL_IOFromDynamicMem();
+    SDLTest_AssertCheck(stream != NULL, "Verify iostream is not NULL");
+    if (stream == NULL) {
+        return TEST_ABORTED;
+    }
+
+    /* Cannot save a indexed surface without palette as a BMP */
+    ret = SDL_SaveBMP_IO(indexed_surface_nopal, stream, false);
+    SDLTest_AssertCheck(ret == false, "Verify result from SDL_SaveBMP_IO(indexed surface without palette), expected: false, got: %i", ret);
+
+    SDL_SeekIO(stream, 0, SDL_IO_SEEK_SET);
+
+    /* Test saving a indexed surface with palette as a BMP */
+    ret = SDL_SaveBMP_IO(indexed_surface_pal, stream, false);
+    SDLTest_AssertPass("Call to SDL_SaveBMP_IO()");
+    SDLTest_AssertCheck(ret == true, "Verify result from SDL_SaveBMP_IO, expected: true, got: %i", ret);
+
+    SDL_SeekIO(stream, 0, SDL_IO_SEEK_SET);
+
+    /* Test reloading the indexed BMP */
+    rface = SDL_LoadBMP_IO(stream, false);
+    SDLTest_AssertPass("Call to SDL_LoadBMP_IO()");
+    SDLTest_AssertCheck(rface != NULL, "Verify result from SDL_LoadBMP_IO is not NULL");
+    if (rface != NULL) {
+        SDLTest_AssertCheck(indexed_surface_pal->w == rface->w, "Verify width of loaded surface, expected: %i, got: %i", indexed_surface_pal->w, rface->w);
+        SDLTest_AssertCheck(indexed_surface_pal->h == rface->h, "Verify height of loaded surface, expected: %i, got: %i", indexed_surface_pal->h, rface->h);
+        SDLTest_AssertCheck(rface->format == SDL_PIXELFORMAT_INDEX4MSB, "Verify format of loaded surface, expected: %s, got: %s", SDL_GetPixelFormatName(indexed_surface_pal->format), SDL_GetPixelFormatName(rface->format));
+        SDL_ReadSurfacePixel(rface, 0, 0, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[2].r &&
+                            g == palette_colors[2].g &&
+                            b == palette_colors[2].b &&
+                            a == palette_colors[2].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[2].r, palette_colors[2].g, palette_colors[2].b, palette_colors[2].a,
+                            r, g, b, a);
+        SDL_ReadSurfacePixel(rface, 1, 0, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[1].r &&
+                            g == palette_colors[1].g &&
+                            b == palette_colors[1].b &&
+                            a == palette_colors[1].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[1].r, palette_colors[1].g, palette_colors[1].b, palette_colors[1].a,
+                            r, g, b, a);
+        SDL_ReadSurfacePixel(rface, rface->w - 2, rface->h - 1, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[3].r &&
+                            g == palette_colors[3].g &&
+                            b == palette_colors[3].b &&
+                            a == palette_colors[3].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[3].r, palette_colors[3].g, palette_colors[3].b, palette_colors[3].a,
+                            r, g, b, a);
+        SDL_ReadSurfacePixel(rface, rface->w - 1, rface->h - 1, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[1].r &&
+                            g == palette_colors[1].g &&
+                            b == palette_colors[1].b &&
+                            a == palette_colors[1].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[1].r, palette_colors[1].g, palette_colors[1].b, palette_colors[1].a,
+                            r, g, b, a);
+        SDL_DestroySurface(rface);
+        rface = NULL;
+    }
+
+    SDL_CloseIO(stream);
+    stream = NULL;
+
+    /* Save and reload as a PNG */
+    stream = SDL_IOFromDynamicMem();
+    SDLTest_AssertCheck(stream != NULL, "Verify iostream is not NULL");
+    if (stream == NULL) {
+        return TEST_ABORTED;
+    }
+
+    /* Test saving a indexed surface without palette as a PNG: should fail */
+    ret = SDL_SavePNG_IO(indexed_surface_nopal, stream, false);
+    SDLTest_AssertCheck(ret == false, "Verify result from SDL_SavePNG_IO (indexed surface without palette), expected: false, got: %i", ret);
+
+    SDL_SeekIO(stream, 0, SDL_IO_SEEK_SET);
+
+    /* Test saving a indexed surface with palette as a PNG: should succeed */
+    ret = SDL_SavePNG_IO(indexed_surface_pal, stream, false);
+    SDLTest_AssertPass("Call to SDL_SavePNG_IO()");
+    SDLTest_AssertCheck(ret == true, "Verify result from SDL_SavePNG_IO, expected: true, got: %i", ret);
+
+    SDL_SeekIO(stream, 0, SDL_IO_SEEK_SET);
+
+    rface = SDL_LoadPNG_IO(stream, false);
+    SDLTest_AssertPass("Call to SDL_LoadPNG_IO()");
+    SDLTest_AssertCheck(rface != NULL, "Verify result from SDL_LoadPNG_IO is not NULL");
+    if (rface != NULL) {
+        SDLTest_AssertCheck(indexed_surface_pal->w == rface->w, "Verify width of loaded surface, expected: %i, got: %i", indexed_surface_pal->w, rface->w);
+        SDLTest_AssertCheck(indexed_surface_pal->h == rface->h, "Verify height of loaded surface, expected: %i, got: %i", indexed_surface_pal->h, rface->h);
+        SDLTest_AssertCheck(rface->format == SDL_PIXELFORMAT_INDEX8, "Verify format of loaded surface, expected: %s, got: %s", SDL_GetPixelFormatName(indexed_surface_pal->format), SDL_GetPixelFormatName(rface->format));
+        SDL_ReadSurfacePixel(rface, 0, 0, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[2].r &&
+                            g == palette_colors[2].g &&
+                            b == palette_colors[2].b &&
+                            a == palette_colors[2].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[2].r, palette_colors[2].g, palette_colors[2].b, palette_colors[2].a,
+                            r, g, b, a);
+        SDL_ReadSurfacePixel(rface, 1, 0, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[1].r &&
+                            g == palette_colors[1].g &&
+                            b == palette_colors[1].b &&
+                            a == palette_colors[1].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[1].r, palette_colors[1].g, palette_colors[1].b, palette_colors[1].a,
+                            r, g, b, a);
+        SDL_ReadSurfacePixel(rface, rface->w - 2, rface->h - 1, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[3].r &&
+                            g == palette_colors[3].g &&
+                            b == palette_colors[3].b &&
+                            a == palette_colors[3].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[3].r, palette_colors[3].g, palette_colors[3].b, palette_colors[3].a,
+                            r, g, b, a);
+        SDL_ReadSurfacePixel(rface, rface->w - 1, rface->h - 1, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[1].r &&
+                            g == palette_colors[1].g &&
+                            b == palette_colors[1].b &&
+                            a == palette_colors[1].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[1].r, palette_colors[1].g, palette_colors[1].b, palette_colors[1].a,
+                            r, g, b, a);
+        SDL_DestroySurface(rface);
+        rface = NULL;
+    }
+
+    SDL_CloseIO(stream);
+    stream = NULL;
+
+    SDL_DestroySurface(indexed_surface_nopal);
+    SDL_DestroySurface(indexed_surface_pal);
+
+    return TEST_COMPLETED;
+}
+
+/**
+ * Tests 1-bit sprite saving and loading
+ */
+static int SDLCALL surface_testIndexed1SaveLoad(void *arg)
+{
+    int ret;
+    const char *sampleFilename = "testSaveLoad.tmp";
+    SDL_Surface *indexed_surface_nopal = NULL;
+    SDL_Surface *indexed_surface_pal = NULL;
+    SDL_Surface *rface;
+    SDL_Palette *palette;
+    const SDL_Color palette_colors[] = {
+        { 0x00, 0x00, 0xff, SDL_ALPHA_OPAQUE },    /* Blue */
+        { 0xff, 0x00, 0x00, SDL_ALPHA_OPAQUE },    /* Red */
+    };
+    SDL_IOStream *stream;
+    Uint8 r, g, b, a;
+
+    /* Create a 1-bit MSB surface without palette */
+    indexed_surface_nopal = SDL_CreateSurface(32, 32, SDL_PIXELFORMAT_INDEX1MSB);
+    SDLTest_AssertCheck(indexed_surface_nopal != NULL, "SDL_CreateSurface(SDL_PIXELFORMAT_INDEX1MSB)");
+    if (!indexed_surface_nopal) {
+        return TEST_ABORTED;
+    }
+
+    /* Create a 1-bit MSB surface with palette */
+    indexed_surface_pal = SDL_CreateSurface(16, 16, SDL_PIXELFORMAT_INDEX1MSB);
+    SDLTest_AssertCheck(indexed_surface_pal != NULL, "Verify 1-bit surface is not NULL");
+    if (indexed_surface_pal == NULL) {
+        return TEST_ABORTED;
+    }
+    palette = SDL_CreatePalette(SDL_arraysize(palette_colors));
+    SDLTest_AssertCheck(palette != NULL, "Verify palette is not NULL");
+    if (palette == NULL) {
+        return TEST_ABORTED;
+    }
+    SDL_SetPaletteColors(palette, palette_colors, 0, SDL_arraysize(palette_colors));
+    SDL_SetSurfacePalette(indexed_surface_pal, palette);
+    SDL_DestroyPalette(palette);
+    /* Set a few pixels */
+    if (indexed_surface_pal) {
+        Uint8 *pixels = indexed_surface_pal->pixels;
+        /* (0,0) => Red, (1,0) => Blue, (2,0) => Blue, (3,0) => Red, (4,0) => Blue, (5,0) => Blue, (6,0) => Red, (7,0) => Red */
+        pixels[0] = (1 << 7) | (0 << 6) | (0 << 5) | (1 << 4) | (0 << 3) | (0 << 2) | (1 << 1) | (1 << 0);
+
+        /* (w-8,h-1) => Red, (w-7,h-1) => Blue, (w-6,h-1) => Blue, (w-5,h-1) => Red, (w-4,h-1) => Blue, (w-3,h-1) => Blue, (w-2,h-1) => Red, (w-1,h-1) => Blue */
+        pixels[(indexed_surface_pal->h - 1) * indexed_surface_pal->pitch + (indexed_surface_pal->w - 1) / 8] = (1 << 7) | (0 << 6) | (0 << 5) | (1 << 4) | (0 << 3) | (0 << 2) | (1 << 1) | (0 << 1);
+    }
+    ret = SDL_ReadSurfacePixel(indexed_surface_pal, 0, 0, &r, &g, &b, &a);
+    SDLTest_AssertCheck(r == palette_colors[1].r && g == palette_colors[1].g && b == palette_colors[1].b && a == palette_colors[1].a, "Check input color[0,0], got (%d,%d,%d,%d)", r, g, b, a);
+    ret = SDL_ReadSurfacePixel(indexed_surface_pal, 1, 0, &r, &g, &b, &a);
+    SDLTest_AssertCheck(r == palette_colors[0].r && g == palette_colors[0].g && b == palette_colors[0].b && a == palette_colors[0].a, "Check input color[1,0], got (%d,%d,%d,%d)", r, g, b, a);
+    ret = SDL_ReadSurfacePixel(indexed_surface_pal, 2, 0, &r, &g, &b, &a);
+    SDLTest_AssertCheck(r == palette_colors[0].r && g == palette_colors[0].g && b == palette_colors[0].b && a == palette_colors[0].a, "Check input color[2,0], got (%d,%d,%d,%d)", r, g, b, a);
+    ret = SDL_ReadSurfacePixel(indexed_surface_pal, 3, 0, &r, &g, &b, &a);
+    SDLTest_AssertCheck(r == palette_colors[1].r && g == palette_colors[1].g && b == palette_colors[1].b && a == palette_colors[1].a, "Check input color[3,0], got (%d,%d,%d,%d)", r, g, b, a);
+    ret = SDL_ReadSurfacePixel(indexed_surface_pal, 4, 0, &r, &g, &b, &a);
+    SDLTest_AssertCheck(r == palette_colors[0].r && g == palette_colors[0].g && b == palette_colors[0].b && a == palette_colors[0].a, "Check input color[4,0], got (%d,%d,%d,%d)", r, g, b, a);
+    ret = SDL_ReadSurfacePixel(indexed_surface_pal, 5, 0, &r, &g, &b, &a);
+    SDLTest_AssertCheck(r == palette_colors[0].r && g == palette_colors[0].g && b == palette_colors[0].b && a == palette_colors[0].a, "Check input color[5,0], got (%d,%d,%d,%d)", r, g, b, a);
+    ret = SDL_ReadSurfacePixel(indexed_surface_pal, 6, 0, &r, &g, &b, &a);
+    SDLTest_AssertCheck(r == palette_colors[1].r && g == palette_colors[1].g && b == palette_colors[1].b && a == palette_colors[1].a, "Check input color[6,0], got (%d,%d,%d,%d)", r, g, b, a);
+    ret = SDL_ReadSurfacePixel(indexed_surface_pal, 7, 0, &r, &g, &b, &a);
+    SDLTest_AssertCheck(r == palette_colors[1].r && g == palette_colors[1].g && b == palette_colors[1].b && a == palette_colors[1].a, "Check input color[7,0], got (%d,%d,%d,%d)", r, g, b, a);
+
+    ret = SDL_ReadSurfacePixel(indexed_surface_pal, indexed_surface_pal->w - 8, indexed_surface_pal->h - 1, &r, &g, &b, &a);
+    SDLTest_AssertCheck(r == palette_colors[1].r && g == palette_colors[1].g && b == palette_colors[1].b && a == palette_colors[1].a, "Check input color[w-8,h-1], got (%d,%d,%d,%d)", r, g, b, a);
+    ret = SDL_ReadSurfacePixel(indexed_surface_pal, indexed_surface_pal->w - 7, indexed_surface_pal->h - 1, &r, &g, &b, &a);
+    SDLTest_AssertCheck(r == palette_colors[0].r && g == palette_colors[0].g && b == palette_colors[0].b && a == palette_colors[0].a, "Check input color[w-7,h-1], got (%d,%d,%d,%d)", r, g, b, a);
+    ret = SDL_ReadSurfacePixel(indexed_surface_pal, indexed_surface_pal->w - 6, indexed_surface_pal->h - 1, &r, &g, &b, &a);
+    SDLTest_AssertCheck(r == palette_colors[0].r && g == palette_colors[0].g && b == palette_colors[0].b && a == palette_colors[0].a, "Check input color[w-6,h-1], got (%d,%d,%d,%d)", r, g, b, a);
+    ret = SDL_ReadSurfacePixel(indexed_surface_pal, indexed_surface_pal->w - 5, indexed_surface_pal->h - 1, &r, &g, &b, &a);
+    SDLTest_AssertCheck(r == palette_colors[1].r && g == palette_colors[1].g && b == palette_colors[1].b && a == palette_colors[1].a, "Check input color[w-5,h-1], got (%d,%d,%d,%d)", r, g, b, a);
+    ret = SDL_ReadSurfacePixel(indexed_surface_pal, indexed_surface_pal->w - 4, indexed_surface_pal->h - 1, &r, &g, &b, &a);
+    SDLTest_AssertCheck(r == palette_colors[0].r && g == palette_colors[0].g && b == palette_colors[0].b && a == palette_colors[0].a, "Check input color[w-4,h-1], got (%d,%d,%d,%d)", r, g, b, a);
+    ret = SDL_ReadSurfacePixel(indexed_surface_pal, indexed_surface_pal->w - 3, indexed_surface_pal->h - 1, &r, &g, &b, &a);
+    SDLTest_AssertCheck(r == palette_colors[0].r && g == palette_colors[0].g && b == palette_colors[0].b && a == palette_colors[0].a, "Check input color[w-3,h-1], got (%d,%d,%d,%d)", r, g, b, a);
+    ret = SDL_ReadSurfacePixel(indexed_surface_pal, indexed_surface_pal->w - 2, indexed_surface_pal->h - 1, &r, &g, &b, &a);
+    SDLTest_AssertCheck(r == palette_colors[1].r && g == palette_colors[1].g && b == palette_colors[1].b && a == palette_colors[1].a, "Check input color[w-2,h-1], got (%d,%d,%d,%d)", r, g, b, a);;
+    ret = SDL_ReadSurfacePixel(indexed_surface_pal, indexed_surface_pal->w - 1, indexed_surface_pal->h - 1, &r, &g, &b, &a);
+    SDLTest_AssertCheck(r == palette_colors[0].r && g == palette_colors[0].g && b == palette_colors[0].b && a == palette_colors[0].a, "Check input color[w-1,h-1], got (%d,%d,%d,%d)", r, g, b, a);
+
+    /* Delete test file; ignore errors */
+    SDL_RemovePath(sampleFilename);
+
+    /* Test saving an indexed surface without palette as BMP: should fail */
+    ret = SDL_SaveBMP(indexed_surface_nopal, sampleFilename);
+    SDLTest_AssertPass("Call to SDL_SaveBMP() using an indexed surface without palette");
+    SDLTest_AssertCheck(ret == false, "Verify result of SDL_SaveBMP(indexed surface without palette), expected: false, got: %i", ret);
+    SDLTest_AssertCheck(!SDL_GetPathInfo(sampleFilename, NULL), "No file is created after trying to save a indexed surface without palette");
+
+    /* Delete test file; ignore errors */
+    SDL_RemovePath(sampleFilename);
+
+    /* Test saving an indexed surface with palette as BMP: should succeed */
+    ret = SDL_SaveBMP(indexed_surface_pal, sampleFilename);
+    SDLTest_AssertPass("Call to SDL_SaveBMP()");
+    SDLTest_AssertCheck(ret == true, "Verify result from SDL_SaveBMP, expected: true, got: %i", ret);
+    AssertFileExist(sampleFilename);
+
+    /* Load a indexed BMP surface */
+    rface = SDL_LoadBMP(sampleFilename);
+    SDLTest_AssertPass("Call to SDL_LoadBMP() (%s)", SDL_GetError());
+    SDLTest_AssertCheck(rface != NULL, "Verify result from SDL_LoadBMP is not NULL");
+    if (rface != NULL) {
+        SDLTest_AssertCheck(indexed_surface_pal->w == rface->w, "Verify width of loaded surface, expected: %i, got: %i", indexed_surface_pal->w, rface->w);
+        SDLTest_AssertCheck(indexed_surface_pal->h == rface->h, "Verify height of loaded surface, expected: %i, got: %i", indexed_surface_pal->h, rface->h);
+        SDLTest_AssertCheck(rface->format == SDL_PIXELFORMAT_INDEX1MSB, "Verify format of loaded surface, expected: %s, got: %s", SDL_GetPixelFormatName(indexed_surface_pal->format), SDL_GetPixelFormatName(rface->format));
+        SDL_ReadSurfacePixel(rface, 0, 0, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[1].r &&
+                            g == palette_colors[1].g &&
+                            b == palette_colors[1].b &&
+                            a == palette_colors[1].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[1].r, palette_colors[1].g, palette_colors[1].b, palette_colors[1].a,
+                            r, g, b, a);
+        SDL_ReadSurfacePixel(rface, 1, 0, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[0].r &&
+                            g == palette_colors[0].g &&
+                            b == palette_colors[0].b &&
+                            a == palette_colors[0].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[0].r, palette_colors[0].g, palette_colors[0].b, palette_colors[0].a,
+                            r, g, b, a);
+        SDL_ReadSurfacePixel(rface, rface->w - 2, rface->h - 1, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[1].r &&
+                            g == palette_colors[1].g &&
+                            b == palette_colors[1].b &&
+                            a == palette_colors[1].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[1].r, palette_colors[1].g, palette_colors[1].b, palette_colors[1].a,
+                            r, g, b, a);
+        SDL_ReadSurfacePixel(rface, rface->w - 1, rface->h - 1, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[0].r &&
+                            g == palette_colors[0].g &&
+                            b == palette_colors[0].b &&
+                            a == palette_colors[0].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[0].r, palette_colors[0].g, palette_colors[0].b, palette_colors[0].a,
+                            r, g, b, a);
+        SDL_DestroySurface(rface);
+        rface = NULL;
+    }
+
+    /* Delete test file; ignore errors */
+    SDL_RemovePath(sampleFilename);
+
+    /* Test saving an indexed surface without palette as PNG: should fail */
+    ret = SDL_SavePNG(indexed_surface_nopal, sampleFilename);
+    SDLTest_AssertPass("Call to SDL_SavePNG() using an indexed surface without palette");
+    SDLTest_AssertCheck(ret == false, "Verify result of SDL_SavePNG(indexed surface without palette), expected: false, got: %i", ret);
+
+    /* Delete test file; ignore errors */
+    SDL_RemovePath(sampleFilename);
+
+    /* Test saving an indexed surface with palette as PNG: should succeed */
+    ret = SDL_SavePNG(indexed_surface_pal, sampleFilename);
+    SDLTest_AssertPass("Call to SDL_SavePNG()");
+    SDLTest_AssertCheck(ret == true, "Verify result from SDL_SavePNG, expected: true, got: %i", ret);
+    AssertFileExist(sampleFilename);
+
+    /* Load a indexed PNG surface */
+    rface = SDL_LoadPNG(sampleFilename);
+    SDLTest_AssertPass("Call to SDL_LoadPNG()");
+    SDLTest_AssertCheck(rface != NULL, "Verify result from SDL_LoadPNG is not NULL");
+    if (rface != NULL) {
+        SDLTest_AssertCheck(indexed_surface_pal->w == rface->w, "Verify width of loaded surface, expected: %i, got: %i", indexed_surface_pal->w, rface->w);
+        SDLTest_AssertCheck(indexed_surface_pal->h == rface->h, "Verify height of loaded surface, expected: %i, got: %i", indexed_surface_pal->h, rface->h);
+        SDL_DestroySurface(rface);
+        rface = NULL;
+    }
+
+    /* Delete test file; ignore errors */
+    SDL_RemovePath(sampleFilename);
+
+    stream = SDL_IOFromDynamicMem();
+    SDLTest_AssertCheck(stream != NULL, "Verify iostream is not NULL");
+    if (stream == NULL) {
+        return TEST_ABORTED;
+    }
+
+    /* Cannot save a indexed surface without palette as a BMP */
+    ret = SDL_SaveBMP_IO(indexed_surface_nopal, stream, false);
+    SDLTest_AssertCheck(ret == false, "Verify result from SDL_SaveBMP_IO(indexed surface without palette), expected: false, got: %i", ret);
+
+    SDL_SeekIO(stream, 0, SDL_IO_SEEK_SET);
+
+    /* Test saving a indexed surface with palette as a BMP */
+    ret = SDL_SaveBMP_IO(indexed_surface_pal, stream, false);
+    SDLTest_AssertPass("Call to SDL_SaveBMP_IO()");
+    SDLTest_AssertCheck(ret == true, "Verify result from SDL_SaveBMP_IO, expected: true, got: %i", ret);
+
+    SDL_SeekIO(stream, 0, SDL_IO_SEEK_SET);
+
+    /* Test reloading the indexed BMP */
+    rface = SDL_LoadBMP_IO(stream, false);
+    SDLTest_AssertPass("Call to SDL_LoadBMP_IO()");
+    SDLTest_AssertCheck(rface != NULL, "Verify result from SDL_LoadBMP_IO is not NULL");
+    if (rface != NULL) {
+        SDLTest_AssertCheck(indexed_surface_pal->w == rface->w, "Verify width of loaded surface, expected: %i, got: %i", indexed_surface_pal->w, rface->w);
+        SDLTest_AssertCheck(indexed_surface_pal->h == rface->h, "Verify height of loaded surface, expected: %i, got: %i", indexed_surface_pal->h, rface->h);
+        SDLTest_AssertCheck(rface->format == SDL_PIXELFORMAT_INDEX1MSB, "Verify format of loaded surface, expected: %s, got: %s", SDL_GetPixelFormatName(indexed_surface_pal->format), SDL_GetPixelFormatName(rface->format));
+        SDL_ReadSurfacePixel(rface, 0, 0, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[1].r &&
+                            g == palette_colors[1].g &&
+                            b == palette_colors[1].b &&
+                            a == palette_colors[1].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[1].r, palette_colors[1].g, palette_colors[1].b, palette_colors[1].a,
+                            r, g, b, a);
+        SDL_ReadSurfacePixel(rface, 1, 0, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[0].r &&
+                            g == palette_colors[0].g &&
+                            b == palette_colors[0].b &&
+                            a == palette_colors[0].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[0].r, palette_colors[0].g, palette_colors[0].b, palette_colors[0].a,
+                            r, g, b, a);
+        SDL_ReadSurfacePixel(rface, rface->w - 2, rface->h - 1, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[1].r &&
+                            g == palette_colors[1].g &&
+                            b == palette_colors[1].b &&
+                            a == palette_colors[1].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[1].r, palette_colors[1].g, palette_colors[1].b, palette_colors[1].a,
+                            r, g, b, a);
+        SDL_ReadSurfacePixel(rface, rface->w - 1, rface->h - 1, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[0].r &&
+                            g == palette_colors[0].g &&
+                            b == palette_colors[0].b &&
+                            a == palette_colors[0].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[0].r, palette_colors[0].g, palette_colors[0].b, palette_colors[0].a,
+                            r, g, b, a);
+        SDL_DestroySurface(rface);
+        rface = NULL;
+    }
+
+    SDL_CloseIO(stream);
+    stream = NULL;
+
+    /* Save and reload as a PNG */
+    stream = SDL_IOFromDynamicMem();
+    SDLTest_AssertCheck(stream != NULL, "Verify iostream is not NULL");
+    if (stream == NULL) {
+        return TEST_ABORTED;
+    }
+
+    /* Test saving a indexed surface without palette as a PNG: should fail */
+    ret = SDL_SavePNG_IO(indexed_surface_nopal, stream, false);
+    SDLTest_AssertCheck(ret == false, "Verify result from SDL_SavePNG_IO (indexed surface without palette), expected: false, got: %i", ret);
+
+    SDL_SeekIO(stream, 0, SDL_IO_SEEK_SET);
+
+    /* Test saving a indexed surface with palette as a PNG: should succeed */
+    ret = SDL_SavePNG_IO(indexed_surface_pal, stream, false);
+    SDLTest_AssertPass("Call to SDL_SavePNG_IO()");
+    SDLTest_AssertCheck(ret == true, "Verify result from SDL_SavePNG_IO, expected: true, got: %i", ret);
+
+    SDL_SeekIO(stream, 0, SDL_IO_SEEK_SET);
+
+    rface = SDL_LoadPNG_IO(stream, false);
+    SDLTest_AssertPass("Call to SDL_LoadPNG_IO()");
+    SDLTest_AssertCheck(rface != NULL, "Verify result from SDL_LoadPNG_IO is not NULL");
+    if (rface != NULL) {
+        SDLTest_AssertCheck(indexed_surface_pal->w == rface->w, "Verify width of loaded surface, expected: %i, got: %i", indexed_surface_pal->w, rface->w);
+        SDLTest_AssertCheck(indexed_surface_pal->h == rface->h, "Verify height of loaded surface, expected: %i, got: %i", indexed_surface_pal->h, rface->h);
+        SDLTest_AssertCheck(rface->format == SDL_PIXELFORMAT_INDEX8, "Verify format of loaded surface, expected: %s, got: %s", SDL_GetPixelFormatName(indexed_surface_pal->format), SDL_GetPixelFormatName(rface->format));
+        SDL_ReadSurfacePixel(rface, 0, 0, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[1].r &&
+                            g == palette_colors[1].g &&
+                            b == palette_colors[1].b &&
+                            a == palette_colors[1].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[1].r, palette_colors[1].g, palette_colors[1].b, palette_colors[1].a,
+                            r, g, b, a);
+        SDL_ReadSurfacePixel(rface, 1, 0, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[0].r &&
+                            g == palette_colors[0].g &&
+                            b == palette_colors[0].b &&
+                            a == palette_colors[0].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[0].r, palette_colors[0].g, palette_colors[0].b, palette_colors[0].a,
+                            r, g, b, a);
+        SDL_ReadSurfacePixel(rface, rface->w - 2, rface->h - 1, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[1].r &&
+                            g == palette_colors[1].g &&
+                            b == palette_colors[1].b &&
+                            a == palette_colors[1].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[1].r, palette_colors[1].g, palette_colors[1].b, palette_colors[1].a,
+                            r, g, b, a);
+        SDL_ReadSurfacePixel(rface, rface->w - 1, rface->h - 1, &r, &g, &b, &a);
+        SDLTest_AssertCheck(r == palette_colors[0].r &&
+                            g == palette_colors[0].g &&
+                            b == palette_colors[0].b &&
+                            a == palette_colors[0].a,
+                            "Verify color of loaded surface, expected: %d,%d,%d,%d, got: %d,%d,%d,%d",
+                            palette_colors[0].r, palette_colors[0].g, palette_colors[0].b, palette_colors[0].a,
+                            r, g, b, a);
+        SDL_DestroySurface(rface);
+        rface = NULL;
+    }
+
+    SDL_CloseIO(stream);
+    stream = NULL;
+
+    SDL_DestroySurface(indexed_surface_nopal);
+    SDL_DestroySurface(indexed_surface_pal);
+
+    return TEST_COMPLETED;
+}
+
+/**
  *  Tests tiled blitting.
  */
 static int SDLCALL surface_testBlitTiled(void *arg)
@@ -2300,6 +2895,14 @@ static const SDLTest_TestCaseReference surfaceTestIndex8SaveLoad = {
     surface_testIndexed8SaveLoad, "surface_testIndexed8SaveLoad", "Test saving and loading 8-bit indexed sprites as BMP and PNG.", TEST_ENABLED
 };
 
+static const SDLTest_TestCaseReference surfaceTestIndex4SaveLoad = {
+    surface_testIndexed4SaveLoad, "surface_testIndexed4SaveLoad", "Test saving and loading 4-bit indexed sprites as BMP.", TEST_ENABLED
+};
+
+static const SDLTest_TestCaseReference surfaceTestIndex1SaveLoad = {
+    surface_testIndexed1SaveLoad, "surface_testIndexed1SaveLoad", "Test saving and loading 1-bit indexed sprites as BMP.", TEST_ENABLED
+};
+
 static const SDLTest_TestCaseReference surfaceTestBlitZeroSource = {
     surface_testBlitZeroSource, "surface_testBlitZeroSource", "Tests blitting from a zero sized source rectangle", TEST_ENABLED
 };
@@ -2425,6 +3028,8 @@ static const SDLTest_TestCaseReference *surfaceTests[] = {
     &surfaceTestInvalidFormat,
     &surfaceTestSaveLoad,
     &surfaceTestIndex8SaveLoad,
+    &surfaceTestIndex4SaveLoad,
+    &surfaceTestIndex1SaveLoad,
     &surfaceTestBlitZeroSource,
     &surfaceTestBlit,
     &surfaceTestBlitTiled,


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Only 1-bit and 4-bit MSB indexed surfaces are supported.
  1-bit LSB surfaces would have to be bit flipped, and 4-bit surfaces nibble swapped. 
- While writing tests, I noticed `SDL_ReadSurfacePixel` does not support 1-bit, 2-bit or 4-bit indexed surfaces, so I fixed that as well.

Here's a little app showing what it generates:
```c
#include <SDL3/SDL.h>

static void write_bmp_1bit(void)
{
    SDL_Surface *surface = SDL_CreateSurface(128, 128, SDL_PIXELFORMAT_INDEX1MSB);
    SDL_Palette *pal = SDL_CreateSurfacePalette(surface);

    const SDL_Color colors[2] = {
        {0xff, 0xff, 0xff, 0xff, },
        {0x00, 0x00, 0x00, 0xff, },
    };

    SDL_SetPaletteColors(pal, colors, 0, 2);

    for (int y = 0; y < surface->h; ++y) {
        Uint8 *row = (Uint8 *)surface->pixels + y * surface->pitch;
        for (int x = 0; x < surface->w; x += 8) {
            Uint8 p0 = (Uint8)((((x+0) + y) & 0xf) >= 8);
            Uint8 p1 = (Uint8)((((x+1) + y) & 0xf) >= 8);
            Uint8 p2 = (Uint8)((((x+2) + y) & 0xf) >= 8);
            Uint8 p3 = (Uint8)((((x+3) + y) & 0xf) >= 8);
            Uint8 p4 = (Uint8)((((x+4) + y) & 0xf) >= 8);
            Uint8 p5 = (Uint8)((((x+5) + y) & 0xf) >= 8);
            Uint8 p6 = (Uint8)((((x+6) + y) & 0xf) >= 8);
            Uint8 p7 = (Uint8)((((x+7) + y) & 0xf) >= 8);
            row[x / 8] = (p0 << 7) | (p1 << 6) | (p2 << 5) | (p3 << 4) | (p4 << 3) | (p5 << 2) | (p6 << 1) | (p7 << 0);
        }
    }

    const char *filename = "pattern_1bit.bmp";
    if (SDL_SaveBMP(surface, filename)) {
        SDL_Log("Wrote %s", filename);
    } else {
        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_SaveBMP failed (%s)", SDL_GetError());
    }
    SDL_DestroySurface(surface);
}
static void write_bmp_4bit(void)
{
    SDL_Surface *surface = SDL_CreateSurface(128, 128, SDL_PIXELFORMAT_INDEX4MSB);
    SDL_Palette *pal = SDL_CreateSurfacePalette(surface);

    const SDL_Color colors[16] = {
        {0xff, 0xff, 0xff, 0xff, },
        {0xee, 0xee, 0xee, 0xff, },
        {0xdd, 0xdd, 0xdd, 0xff, },
        {0xcc, 0xcc, 0xcc, 0xff, },
        {0xbb, 0xbb, 0xbb, 0xff, },
        {0xaa, 0xaa, 0xaa, 0xff, },
        {0x99, 0x99, 0x99, 0xff, },
        {0x88, 0x88, 0x88, 0xff, },
        {0x77, 0x77, 0x77, 0xff, },
        {0x66, 0x66, 0x66, 0xff, },
        {0x55, 0x55, 0x55, 0xff, },
        {0x44, 0x44, 0x44, 0xff, },
        {0x33, 0x33, 0x33, 0xff, },
        {0x22, 0x22, 0x22, 0xff, },
        {0x11, 0x11, 0x11, 0xff, },
        {0x00, 0x00, 0x00, 0xff, },
    };

    SDL_SetPaletteColors(pal, colors, 0, 16);

    for (int y = 0; y < surface->h; ++y) {
        Uint8 *row = (Uint8 *)surface->pixels + y * surface->pitch;
        for (int x = 0; x < surface->w; x += 2) {
            Uint8 p0 = (Uint8)(((x + 0) + y) & 0xf);
            Uint8 p1 = (Uint8)(((x + 1) + y) & 0xf);
            row[x / 2] = (p0 << 4) | (p1 << 0);
        }
    }

    const char *filename = "pattern_4bit.bmp";
    if (SDL_SaveBMP(surface, filename)) {
        SDL_Log("Wrote %s", filename);
    } else {
        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_SaveBMP failed (%s)", SDL_GetError());
    }
    SDL_DestroySurface(surface);
}

int main(void)
{
    SDL_Init(0);

    write_bmp_1bit();
    write_bmp_4bit();

    SDL_Quit();
    return 0;
}
```

1-bit BMP:
[pattern_1bit.bmp](https://github.com/user-attachments/files/31577010/pattern_1bit.bmp)

4-bit BMP:
[pattern_4bit.bmp](https://github.com/user-attachments/files/31577017/pattern_4bit.bmp)



## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
