### PR TITLE
gpu: Fix some D3D12/Metal fence races

### DIFF
--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -7920,8 +7920,9 @@ static bool D3D12_INTERNAL_CleanCommandBuffer(
     return true;
 }
 
-static bool D3D12_Submit(
-    SDL_GPUCommandBuffer *commandBuffer)
+static bool D3D12_INTERNAL_Submit(
+    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUFence **fence)
 {
     D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
     D3D12Renderer *renderer = d3d12CommandBuffer->renderer;
@@ -7997,6 +7998,12 @@ static bool D3D12_Submit(
     if (!d3d12CommandBuffer->inFlightFence) {
         SDL_UnlockMutex(renderer->submitLock);
         return false;
+    }
+
+    // Return the fence while submitLock is held, another thread could
+    // recycle this command buffer as soon as the lock is released.
+    if (fence) {
+        *fence = (SDL_GPUFence *)d3d12CommandBuffer->inFlightFence;
     }
 
     // Mark that a fence should be signaled after command list execution
@@ -8097,15 +8104,22 @@ static bool D3D12_Submit(
     return result;
 }
 
+static bool D3D12_Submit(
+    SDL_GPUCommandBuffer *commandBuffer)
+{
+    return D3D12_INTERNAL_Submit(commandBuffer, NULL);
+}
+
 static SDL_GPUFence *D3D12_SubmitAndAcquireFence(
     SDL_GPUCommandBuffer *commandBuffer)
 {
     D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    SDL_GPUFence *fence = NULL;
     d3d12CommandBuffer->autoReleaseFence = false;
-    if (!D3D12_Submit(commandBuffer)) {
+    if (!D3D12_INTERNAL_Submit(commandBuffer, &fence)) {
         return NULL;
     }
-    return (SDL_GPUFence *)d3d12CommandBuffer->inFlightFence;
+    return fence;
 }
 
 static bool D3D12_Cancel(

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -4069,8 +4069,9 @@ static bool METAL_SetAllowedFramesInFlight(
 
 // Submission
 
-static bool METAL_Submit(
-    SDL_GPUCommandBuffer *commandBuffer)
+static bool METAL_INTERNAL_Submit(
+    SDL_GPUCommandBuffer *commandBuffer,
+    SDL_GPUFence **fence)
 {
     @autoreleasepool {
         MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
@@ -4081,6 +4082,12 @@ static bool METAL_Submit(
         if (!METAL_INTERNAL_AcquireFence(renderer, metalCommandBuffer)) {
             SDL_UnlockMutex(renderer->submitLock);
             return false;
+        }
+
+        // Return the fence while submitLock is held, another thread could
+        // recycle this command buffer as soon as the lock is released.
+        if (fence) {
+            *fence = (SDL_GPUFence *)metalCommandBuffer->fence;
         }
 
         // Enqueue present requests, if applicable
@@ -4129,15 +4136,22 @@ static bool METAL_Submit(
     }
 }
 
+static bool METAL_Submit(
+    SDL_GPUCommandBuffer *commandBuffer)
+{
+    return METAL_INTERNAL_Submit(commandBuffer, NULL);
+}
+
 static SDL_GPUFence *METAL_SubmitAndAcquireFence(
     SDL_GPUCommandBuffer *commandBuffer)
 {
     MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
+    SDL_GPUFence *fence = NULL;
     metalCommandBuffer->autoReleaseFence = false;
-    if (!METAL_Submit(commandBuffer)) {
+    if (!METAL_INTERNAL_Submit(commandBuffer, &fence)) {
         return NULL;
     }
-    return (SDL_GPUFence *)metalCommandBuffer->fence;
+    return fence;
 }
 
 static bool METAL_Cancel(

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -608,7 +608,6 @@ typedef struct MetalCommandBuffer
 
     // Fences
     MetalFence *fence;
-    bool autoReleaseFence;
 
     // Reference Counting
     MetalBuffer **usedBuffers;
@@ -2162,8 +2161,6 @@ static SDL_GPUCommandBuffer *METAL_AcquireCommandBuffer(
             commandBuffer->computeUniformBuffers[i] = NULL;
         }
 
-        commandBuffer->autoReleaseFence = true;
-
         SDL_UnlockMutex(renderer->acquireCommandBufferLock);
 
         return (SDL_GPUCommandBuffer *)commandBuffer;
@@ -3406,8 +3403,9 @@ static void METAL_ReleaseFence(
     SDL_GPUFence *fence)
 {
     MetalFence *metalFence = (MetalFence *)fence;
-    metalFence->commandBuffer = nil;
     if (SDL_AtomicDecRef(&metalFence->referenceCount)) {
+        // Nothing references the fence anymore, so the command buffer can go too.
+        metalFence->commandBuffer = nil;
         METAL_INTERNAL_ReleaseFenceToPool(
             (MetalRenderer *)driverData,
             (MetalFence *)fence);
@@ -3513,8 +3511,9 @@ static void METAL_INTERNAL_CleanCommandBuffer(
     commandBuffer->needComputeReadOnlyStorageTextureBind = false;
     SDL_zeroa(commandBuffer->needComputeUniformBufferBind);
 
-    // The fence is now available (unless SubmitAndAcquireFence was called)
-    if (commandBuffer->autoReleaseFence) {
+    // Drop the command buffer's reference to the fence. A cancelled
+    // command buffer never acquired one.
+    if (!cancel) {
         METAL_ReleaseFence(
             (SDL_GPURenderer *)renderer,
             (SDL_GPUFence *)commandBuffer->fence);
@@ -4084,9 +4083,10 @@ static bool METAL_INTERNAL_Submit(
             return false;
         }
 
-        // Return the fence while submitLock is held, another thread could
-        // recycle this command buffer as soon as the lock is released.
+        // Give the caller its own reference while submitLock is held, another
+        // thread could recycle this command buffer as soon as the lock is released.
         if (fence) {
+            (void)SDL_AtomicIncRef(&metalCommandBuffer->fence->referenceCount);
             *fence = (SDL_GPUFence *)metalCommandBuffer->fence;
         }
 
@@ -4145,9 +4145,7 @@ static bool METAL_Submit(
 static SDL_GPUFence *METAL_SubmitAndAcquireFence(
     SDL_GPUCommandBuffer *commandBuffer)
 {
-    MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
     SDL_GPUFence *fence = NULL;
-    metalCommandBuffer->autoReleaseFence = false;
     if (!METAL_INTERNAL_Submit(commandBuffer, &fence)) {
         return NULL;
     }
@@ -4160,7 +4158,6 @@ static bool METAL_Cancel(
     MetalCommandBuffer *metalCommandBuffer = (MetalCommandBuffer *)commandBuffer;
     MetalRenderer *renderer = metalCommandBuffer->renderer;
 
-    metalCommandBuffer->autoReleaseFence = false;
     SDL_LockMutex(renderer->submitLock);
     METAL_INTERNAL_CleanCommandBuffer(renderer, metalCommandBuffer, true);
     SDL_UnlockMutex(renderer->submitLock);


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
Two races in fence handling, found with a workload (my personal game project) that uploads textures from
several worker threads (`SubmitGPUCommandBufferAndAcquireFence` -> `WaitForGPUFences` -> `ReleaseGPUFence`)
while the main thread keeps submitting.

- **Metal:** `METAL_ReleaseFence` dropped the fence's `MTLCommandBuffer` reference
  without `submitLock`, while `METAL_Submit`'s cleanup loop may still be polling that
  command buffer's status through `submittedCommandBuffers` (use-after-free, regressed
  in 3561f8140). The reference is now kept until the fence is reused under the lock.
- **Metal and D3D12:** `SubmitAndAcquireFence` read the command buffer's fence after
  `Submit` had released `submitLock`. In that window, another thread's submit can see
  the buffer as completed, clean it and return it to the (LIFO) pool, and a third
  thread can re-acquire and resubmit it with a different fence, so the caller gets a
  fence it doesn't own (D3D12 hands back NULL). The fence is now handed to the caller
  while the lock is still held.

Vulkan doesn't need any changes, since its command buffers come from per-thread command
pools, so the only thread that can re-acquire the buffer is the one still inside `VULKAN_SubmitAndAcquireFence`.
It has no equivalent of the first race either, since `VulkanFenceHandle`/`VkFence` objects live until the device is destroyed.

The race can be more easily reproduced by inserting an artificial delay to `SubmitAndAcquireFence` like so (Metal/D3D12):
```c
if (!D3D12_Submit(commandBuffer)) {
    return NULL;
}
SDL_Delay(100);
return (SDL_GPUFence *)d3d12CommandBuffer->inFlightFence;
```

Note that I could only test this on my M4 MacBook Air (macOS 26), so Vulkan via KosmicKrisp, and D3D12 via vkd3d under Wine.

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
