### PR TITLE
Replace LocalAlloc/LocalFree with HeapAlloc/HeapFree

### DIFF
--- a/src/core/windows/gameinput/gameinput.cpp
+++ b/src/core/windows/gameinput/gameinput.cpp
@@ -132,7 +132,7 @@ public:
         {
             const size_t capacity = (m_capacity + count) * 2;
 
-            T* const data = static_cast<T*>(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, Capacity * sizeof(T)));
+            T* const data = static_cast<T*>(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, Capacity * sizeof(T))));
             RETURN_IF_NULL_ALLOC(data);
 
             if (m_data != nullptr)

--- a/src/core/windows/gameinput/gameinput.cpp
+++ b/src/core/windows/gameinput/gameinput.cpp
@@ -132,7 +132,7 @@ public:
         {
             const size_t capacity = (m_capacity + count) * 2;
 
-            T* const data = static_cast<T*>(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, Capacity * sizeof(T))));
+            T* const data = static_cast<T*>(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, Capacity * sizeof(T)));
             RETURN_IF_NULL_ALLOC(data);
 
             if (m_data != nullptr)

--- a/src/core/windows/gameinput/gameinput.cpp
+++ b/src/core/windows/gameinput/gameinput.cpp
@@ -121,7 +121,7 @@ public:
     {
         if (m_data != nullptr)
         {
-            LocalFree(m_data);
+            HeapFree(GetProcessHeap(), 0, m_data);
         }
     }
 
@@ -132,13 +132,13 @@ public:
         {
             const size_t capacity = (m_capacity + count) * 2;
 
-            T* const data = static_cast<T*>(LocalAlloc(LPTR, capacity * sizeof(T)));
+            T* const data = static_cast<T*>(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, Capacity * sizeof(T)));
             RETURN_IF_NULL_ALLOC(data);
 
             if (m_data != nullptr)
             {
                 memcpy_s(data, count * sizeof(T), m_data, m_count * sizeof(T));
-                LocalFree(m_data);
+                HeapFree(GetProcessHeap(), 0, m_data);
             }
 
             m_data = data;

--- a/src/core/windows/gameinput/gameinput.cpp
+++ b/src/core/windows/gameinput/gameinput.cpp
@@ -132,7 +132,7 @@ public:
         {
             const size_t capacity = (m_capacity + count) * 2;
 
-            T* const data = static_cast<T*>(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, Capacity * sizeof(T)));
+            T* const data = static_cast<T*>(HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, capacity * sizeof(T)));
             RETURN_IF_NULL_ALLOC(data);
 
             if (m_data != nullptr)


### PR DESCRIPTION


- [x] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replace Local Allocation functions with the modern Heap functions as suggested in https://learn.microsoft.com/en-us/windows/win32/memory/comparing-memory-allocation-methods

## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
No issues 
Just a suggestive improve