### PR TITLE
Added support for the 8BitDo Ultimate 3 Wireless Controller for Xbox

### DIFF
--- a/src/joystick/controller_list.h
+++ b/src/joystick/controller_list.h
@@ -487,6 +487,7 @@ static const ControllerDescription_t arrControllers[] = {
 	{ MAKE_CONTROLLER_ID( 0x2dc8, 0x2002 ), k_eControllerType_XBoxOneController, NULL },	// 8BitDo Ultimate Wired Controller for Xbox
 	{ MAKE_CONTROLLER_ID( 0x2dc8, 0x3106 ), k_eControllerType_XBoxOneController, NULL },	// 8BitDo Ultimate Wired Controller. Windows, Android, Switch.
 	{ MAKE_CONTROLLER_ID( 0x2dc8, 0x310a ), k_eControllerType_XBoxOneController, NULL },	// 8BitDo Ultimate 2C Wireless Controller
+	{ MAKE_CONTROLLER_ID( 0x2dc8, 0x2072 ), k_eControllerType_XBoxOneController, NULL },	// 8BitDo Ultimate 3 Wireless Controller
 	{ MAKE_CONTROLLER_ID( 0x2e24, 0x0652 ), k_eControllerType_XBoxOneController, NULL },	// Hyperkin Duke
 	{ MAKE_CONTROLLER_ID( 0x2e24, 0x1618 ), k_eControllerType_XBoxOneController, NULL },	// Hyperkin Duke
 	{ MAKE_CONTROLLER_ID( 0x2e24, 0x1688 ), k_eControllerType_XBoxOneController, NULL },	// Hyperkin X91

--- a/src/joystick/controller_list.h
+++ b/src/joystick/controller_list.h
@@ -487,7 +487,7 @@ static const ControllerDescription_t arrControllers[] = {
 	{ MAKE_CONTROLLER_ID( 0x2dc8, 0x2002 ), k_eControllerType_XBoxOneController, NULL },	// 8BitDo Ultimate Wired Controller for Xbox
 	{ MAKE_CONTROLLER_ID( 0x2dc8, 0x3106 ), k_eControllerType_XBoxOneController, NULL },	// 8BitDo Ultimate Wired Controller. Windows, Android, Switch.
 	{ MAKE_CONTROLLER_ID( 0x2dc8, 0x310a ), k_eControllerType_XBoxOneController, NULL },	// 8BitDo Ultimate 2C Wireless Controller
-	{ MAKE_CONTROLLER_ID( 0x2dc8, 0x2072 ), k_eControllerType_XBoxOneController, NULL },	// 8BitDo Ultimate 3 Wireless Controller
+	{ MAKE_CONTROLLER_ID( 0x2dc8, 0x2072 ), k_eControllerType_XBoxOneController, NULL },	// 8BitDo Ultimate 3 Wireless Controller for Xbox
 	{ MAKE_CONTROLLER_ID( 0x2e24, 0x0652 ), k_eControllerType_XBoxOneController, NULL },	// Hyperkin Duke
 	{ MAKE_CONTROLLER_ID( 0x2e24, 0x1618 ), k_eControllerType_XBoxOneController, NULL },	// Hyperkin Duke
 	{ MAKE_CONTROLLER_ID( 0x2e24, 0x1688 ), k_eControllerType_XBoxOneController, NULL },	// Hyperkin X91


### PR DESCRIPTION
## Description

Adds the USB product ID for the **8BitDo Ultimate 3 Wireless Controller for Xbox** in 2.4G dongle mode, so SDL recognises it as an Xbox One controller.

## Details

The controller launched on 2026-08-31. In 2.4G dongle mode it enumerates on Windows as:

```
USB\VID_2DC8&PID_2072
```

Windows binds it under **Xbox Peripherals** (Xbox GIP driver) and it behaves correctly in `joy.cpl`, but SDL does not pick it up at all.

The cause is that `0x2072` is missing from `arrControllers[]` in `src/joystick/controller_list.h`. `GuessControllerType()` therefore returns unknown, so `SDL_IsJoystickXboxOne()` is false and `HIDAPI_DriverXboxOne_IsSupportedDevice()` — which is just `type == SDL_CONTROLLER_TYPE_XBOXONE` — declines the device.

Its siblings are already present a few lines above:

```c
{ MAKE_CONTROLLER_ID( 0x2dc8, 0x2002 ), k_eControllerType_XBoxOneController, NULL },	// 8BitDo Ultimate Wired Controller for Xbox
{ MAKE_CONTROLLER_ID( 0x2dc8, 0x3106 ), k_eControllerType_XBoxOneController, NULL },	// 8BitDo Ultimate Wired Controller. Windows, Android, Switch.
{ MAKE_CONTROLLER_ID( 0x2dc8, 0x310a ), k_eControllerType_XBoxOneController, NULL },	// 8BitDo Ultimate 2C Wireless Controller
```

Note that `USB_PRODUCT_8BITDO_ULTIMATE3` (`0x202f`) already exists in `usb_ids.h` and is handled by `SDL_hidapi_8bitdo.c`, but its own comment marks it `// mode switch to BT`. That covers the Bluetooth/D-input position only — the 2.4G dongle presents a different product ID and speaks the Xbox GIP protocol, so it belongs in the Xbox One table rather than the 8BitDo HIDAPI driver.

For reference, the Linux `xpad` driver classifies the equivalent sibling `0x200f` (Ultimate 3-mode Controller for Xbox) as `XTYPE_XBOXONE`.

## Testing

Windows 11, 8BitDo Ultimate 3 Wireless Controller for Xbox connected via its 2.4G dongle.