### PR TITLE
More bindings and findings

### DIFF
--- a/src/events/scancodes_darwin.h
+++ b/src/events/scancodes_darwin.h
@@ -122,7 +122,7 @@ static const SDL_Scancode darwin_scancode_table[] = {
     /*  92 */   SDL_SCANCODE_KP_9,
     /*  93 */   SDL_SCANCODE_INTERNATIONAL3, // Cosmo_USB2ADB.c says "Yen (JIS)"
     /*  94 */   SDL_SCANCODE_INTERNATIONAL1, // Cosmo_USB2ADB.c says "Ro (JIS)"
-    /*  95 */   SDL_SCANCODE_KP_COMMA, // Cosmo_USB2ADB.c says ", JIS only"
+    /*  95 */   SDL_SCANCODE_INTERNATIONAL6, // Cosmo_USB2ADB.c says ", JIS only"
     /*  96 */   SDL_SCANCODE_F5,
     /*  97 */   SDL_SCANCODE_F6,
     /*  98 */   SDL_SCANCODE_F7,

--- a/src/events/scancodes_windows.h
+++ b/src/events/scancodes_windows.h
@@ -197,7 +197,7 @@ static const SDL_Scancode windows_scancode_table[] = {
     /*0xe028*/ SDL_SCANCODE_UNKNOWN,
     /*0xe029*/ SDL_SCANCODE_UNKNOWN,
     /*0xe02a*/ SDL_SCANCODE_UNKNOWN,
-    /*0xe02b*/ SDL_SCANCODE_UNKNOWN, // Brightness up & brughtness down on HP 250 G7 Notebook PC and HP Laptop 14-cm0xxx keyboards
+    /*0xe02b*/ SDL_SCANCODE_UNKNOWN, // Brightness up & brightness down on HP 250 G7 Notebook PC and HP Laptop 14-cm0xxx keyboards
     /*0xe02c*/ SDL_SCANCODE_MEDIA_EJECT,
     /*0xe02d*/ SDL_SCANCODE_UNKNOWN,
     /*0xe02e*/ SDL_SCANCODE_VOLUMEDOWN,

--- a/src/events/scancodes_windows.h
+++ b/src/events/scancodes_windows.h
@@ -208,7 +208,7 @@ static const SDL_Scancode windows_scancode_table[] = {
     /*0xe033*/ SDL_SCANCODE_UNKNOWN,
     /*0xe034*/ SDL_SCANCODE_UNKNOWN,
     /*0xe035*/ SDL_SCANCODE_KP_DIVIDE,
-    /*0xe036*/ SDL_SCANCODE_UNKNOWN,
+    /*0xe036*/ SDL_SCANCODE_RSHIFT, // see https://mojira.dev/MC-311424
     /*0xe037*/ SDL_SCANCODE_PRINTSCREEN,
     /*0xe038*/ SDL_SCANCODE_RALT,
     /*0xe039*/ SDL_SCANCODE_UNKNOWN,

--- a/src/events/scancodes_windows.h
+++ b/src/events/scancodes_windows.h
@@ -155,7 +155,7 @@ static const SDL_Scancode windows_scancode_table[] = {
     /*0x7e*/ SDL_SCANCODE_KP_COMMA,
     /*0x7f*/ SDL_SCANCODE_UNKNOWN,
     /*0xe000*/ SDL_SCANCODE_UNKNOWN,
-    /*0xe001*/ SDL_SCANCODE_UNKNOWN,
+    /*0xe001*/ SDL_SCANCODE_UNKNOWN, // Fn+Esc on HP 250 G7 Notebook PC and HP Laptop 14-cm0xxx keyboards
     /*0xe002*/ SDL_SCANCODE_UNKNOWN,
     /*0xe003*/ SDL_SCANCODE_UNKNOWN,
     /*0xe004*/ SDL_SCANCODE_UNKNOWN,
@@ -197,7 +197,7 @@ static const SDL_Scancode windows_scancode_table[] = {
     /*0xe028*/ SDL_SCANCODE_UNKNOWN,
     /*0xe029*/ SDL_SCANCODE_UNKNOWN,
     /*0xe02a*/ SDL_SCANCODE_UNKNOWN,
-    /*0xe02b*/ SDL_SCANCODE_UNKNOWN,
+    /*0xe02b*/ SDL_SCANCODE_UNKNOWN, // Brightness up & brughtness down on HP 250 G7 Notebook PC and HP Laptop 14-cm0xxx keyboards
     /*0xe02c*/ SDL_SCANCODE_MEDIA_EJECT,
     /*0xe02d*/ SDL_SCANCODE_UNKNOWN,
     /*0xe02e*/ SDL_SCANCODE_VOLUMEDOWN,


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

This fixes #16208 and adds some more comments to the Windows list for potential future new keycodes.

## Description
Following on from #16197: the keyboard in question (Microsoft Natural Ergonomic Keyboard 4000) has arrived, and it doesn't appear to send any new key codes to Windows at all; many keys are simply nonfunctional and cannot be picked up by any programs until you install the mouse and keyboard center software, in which case they may to combos of existing keys. On Linux, they are instead mapped to unique function keys, as well  as rarities such as KPLEFTPAREN and KPRIGHTPAREN.

However, I have also since tested built-in laptop keyboards, which turned up two unique scancodes that were not yet documented, so I've added these as comments to the Windows scancodes file.

As for Apple: I've made the judgement call to repoint the JIS-only comma from KP_COMMA to INTERNATIONAL6, since it seems to line up better with the existing mapping in Linux (#16168) and Windows.

## Existing Issue(s)
#16208