### PR TITLE
cocoa: route mouse buttons through NSEvent; GCMouse for raw motion only

### DIFF
--- a/src/video/cocoa/SDL_cocoamouse.m
+++ b/src/video/cocoa/SDL_cocoamouse.m
@@ -332,14 +332,6 @@ static bool Cocoa_SetGCMouseRelativeMode(bool enabled)
     return true;
 }
 
-static void Cocoa_OnGCMouseButtonChanged(SDL_MouseID mouseID, Uint8 button,
-                                         BOOL pressed)
-{
-    Uint64 timestamp = SDL_GetTicksNS();
-    SDL_SendMouseButton(timestamp, SDL_GetMouseFocus(), mouseID, button,
-                        pressed);
-}
-
 static void Cocoa_OnGCMouseConnected(GCMouse *mouse)
     API_AVAILABLE(macos(11.0))
 {
@@ -355,29 +347,11 @@ static void Cocoa_OnGCMouseConnected(GCMouse *mouse)
         SDL_SetAtomicInt(&cocoa_gcmouse_relative_mode, 1);
     }
 
-    mouse.mouseInput.leftButton.pressedChangedHandler =
-        ^(GCControllerButtonInput *button, float value, BOOL pressed) {
-            Cocoa_OnGCMouseButtonChanged(mouseID, SDL_BUTTON_LEFT, pressed);
-        };
-    mouse.mouseInput.middleButton.pressedChangedHandler =
-        ^(GCControllerButtonInput *button, float value, BOOL pressed) {
-            Cocoa_OnGCMouseButtonChanged(mouseID, SDL_BUTTON_MIDDLE, pressed);
-        };
-    mouse.mouseInput.rightButton.pressedChangedHandler =
-        ^(GCControllerButtonInput *button, float value, BOOL pressed) {
-            Cocoa_OnGCMouseButtonChanged(mouseID, SDL_BUTTON_RIGHT, pressed);
-        };
-
-    int auxiliary_button = SDL_BUTTON_X1;
-    for (GCControllerButtonInput *btn in mouse.mouseInput.auxiliaryButtons) {
-        const int current_button = auxiliary_button;
-        btn.pressedChangedHandler =
-            ^(GCControllerButtonInput *button, float value, BOOL pressed) {
-                Cocoa_OnGCMouseButtonChanged(mouseID, current_button, pressed);
-            };
-        ++auxiliary_button;
-    }
-
+    /* GCMouse is used for raw motion only. Button events are deliberately
+     * left to the NSEvent path in SDL_cocoawindow.m: wiring the GCMouse button
+     * callbacks here would require skipping NSEvent buttons when a GCMouse is
+     * present, which also silently drops synthetic clicks from remote-control
+     * and accessibility tools (they never reach GCMouse). */
     mouse.mouseInput.mouseMovedHandler =
         ^(GCMouseInput *mouseInput, float deltaX, float deltaY) {
             if (Cocoa_GCMouseRelativeMode()) {

--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -1725,10 +1725,11 @@ static NSCursor *Cocoa_GetDesiredCursor(void)
 
 static void Cocoa_SendMouseButtonClicks(SDL_Mouse *mouse, NSEvent *theEvent, SDL_Window *window, Uint8 button, bool down)
 {
-    // GCMouse handles button events directly, skip NSEvent path to avoid duplicates
-    if (Cocoa_HasGCMouse()) {
-        return;
-    }
+    // NSEvent button events are always delivered here. GCMouse no longer sends
+    // its own button events (see SDL_cocoamouse.m), so there is nothing to
+    // deduplicate against, and skipping this path would drop synthetic clicks
+    // from remote-control / accessibility tools, which never go through
+    // GCMouse at all.
 
     SDL_MouseID mouseID = SDL_DEFAULT_MOUSE_ID;
     //const int clicks = (int)[theEvent clickCount];


### PR DESCRIPTION
Fixes #16241

## Summary

GCMouse button callbacks (`pressedChangedHandler` on left/middle/right/X1/X2) duplicated the NSEvent button delivery, so `Cocoa_SendMouseButtonClicks` skipped the NSEvent path whenever a GCMouse was connected. That check dropped **every** NSEvent button event while a GCMouse device was present — including synthetic clicks from remote-control and accessibility tools (CGEvent/accessibility injection), which never go through `GCMouse` callbacks at all.

## Changes

- `src/video/cocoa/SDL_cocoamouse.m`: remove the left/middle/right/X1/X2 `pressedChangedHandler` registrations and the now-unused `Cocoa_OnGCMouseButtonChanged` helper. GCMouse stays wired for raw relative motion (its original purpose).
- `src/video/cocoa/SDL_cocoawindow.m`: always deliver NSEvent button events; drop the `Cocoa_HasGCMouse()` early-return. With the GCMouse button callbacks gone there is no duplicate source left, so the NSEvent path can deliver unconditionally.

## Testing

- GCMouse device connected + clicks injected via CGEvent: clicks reach the app only with this change.
- Real mouse buttons delivered via NSEvent as before.