### PR TITLE
x11: don't require keyboard focus for slave pointer button events

### DIFF
--- a/src/video/x11/SDL_x11xinput2.c
+++ b/src/video/x11/SDL_x11xinput2.c
@@ -626,10 +626,12 @@ void X11_HandleXinput2Event(SDL_VideoDevice *_this, XGenericEventCookie *cookie)
             int x_ticks = 0, y_ticks = 0;
 
             if (xev->deviceid != videodata->xinput_master_pointer_device) {
-                /* Ignore slave button events on non-focused windows, as they can arrive before FocusIn events,
+                /* Ignore slave button events on windows that don't have mouse focus, as they can arrive before FocusIn events,
                  * or result in focus being incorrectly set while a grab is active.
+                 * Keyboard focus is not required here: remote control tools inject clicks via virtual slave devices
+                 * (XTEST/uinput) while the window may not have keyboard focus, and requiring it drops those clicks.
                  */
-                if (SDL_GetMouseFocus() != windowdata->window || SDL_GetKeyboardFocus() != windowdata->window) {
+                if (SDL_GetMouseFocus() != windowdata->window) {
                     break;
                 }
 


### PR DESCRIPTION
Fixes #16242

## Summary

XInput2 slave button events follow the **pointer** focus, not the keyboard focus. Commit `ef9a5b704` added a keyboard-focus requirement to suppress click-through during grabs, but it also drops legitimate clicks from remote-control and accessibility tools: those inject button events via virtual slave devices (XTEST/uinput) while the window may not have keyboard focus.

## Changes

`src/video/x11/SDL_x11xinput2.c`: in the XI_ButtonPress/XI_ButtonRelease slave-device branch, keep the mouse-focus check (that is what guards the grab/click-through case) and drop the keyboard-focus requirement:

```c
if (SDL_GetMouseFocus() != windowdata->window) {
    break;
}
```

Keyboard focus is still required where it actually matters — e.g. relative mouse motion is gated on `SDL_GetKeyboardFocus()` in the same file.

## Testing

- SDL app without keyboard focus + XTEST-injected click: click is dropped without this change, delivered with it.
- Grab/click-through behavior (the case `ef9a5b704` protected) still works — the mouse-focus check remains.