### PR TITLE
GPU: Add SDL_CopyGPUTextureToBuffer and SDL_CopyGPUBufferToTexture

### DIFF
--- a/include/SDL3/SDL_gpu.h
+++ b/include/SDL3/SDL_gpu.h
@@ -4314,6 +4314,26 @@ extern SDL_DECLSPEC void SDLCALL SDL_CopyGPUTextureToTexture(
     bool cycle);
 
 /**
+ * Performs a texture-to-buffer copy.
+ *
+ * This copy occurs on the GPU timeline. You may assume the copy has finished
+ * in subsequent commands.
+ *
+ * \param copy_pass a copy pass handle.
+ * \param source a source texture region.
+ * \param destination a destination buffer location.
+ * \param cycle if true, cycles the destination buffer if the destination
+ *              buffer is bound, otherwise overwrites the data.
+ *
+ * \since This function is available since SDL 3.4.18.
+ */
+extern SDL_DECLSPEC void SDLCALL SDL_CopyGPUTextureToBuffer(
+    SDL_GPUCopyPass *copy_pass,
+    const SDL_GPUTextureRegion *source,
+    const SDL_GPUBufferLocation *destination,
+    bool cycle);
+
+/**
  * Performs a buffer-to-buffer copy.
  *
  * This copy occurs on the GPU timeline. You may assume the copy has finished
@@ -4333,6 +4353,26 @@ extern SDL_DECLSPEC void SDLCALL SDL_CopyGPUBufferToBuffer(
     const SDL_GPUBufferLocation *source,
     const SDL_GPUBufferLocation *destination,
     Uint32 size,
+    bool cycle);
+
+/**
+ * Performs a buffer-to-texture copy.
+ *
+ * This copy occurs on the GPU timeline. You may assume the copy has finished
+ * in subsequent commands.
+ *
+ * \param copy_pass a copy pass handle.
+ * \param source a source buffer region.
+ * \param destination a destination texture region.
+ * \param cycle if true, cycles the destination texture if it is already bound,
+ *              otherwise overwrites the data.
+ *
+ * \since This function is available since SDL 3.4.18.
+ */
+extern SDL_DECLSPEC void SDLCALL SDL_CopyGPUBufferToTexture(
+    SDL_GPUCopyPass *copy_pass,
+    const SDL_GPUBufferLocation *source,
+    const SDL_GPUTextureRegion *destination,
     bool cycle);
 
 /**

--- a/src/dynapi/SDL_dynapi.exports
+++ b/src/dynapi/SDL_dynapi.exports
@@ -1307,3 +1307,5 @@ _SDL_SetJoystickSensorEnabled
 _SDL_JoystickSensorEnabled
 _SDL_GetJoystickSensorDataRate
 _SDL_GetJoystickSensorData
+_SDL_CopyGPUTextureToBuffer
+_SDL_CopyGPUBufferToTexture

--- a/src/dynapi/SDL_dynapi.sym
+++ b/src/dynapi/SDL_dynapi.sym
@@ -1308,6 +1308,8 @@ SDL3_0.0.0 {
     SDL_JoystickSensorEnabled;
     SDL_GetJoystickSensorDataRate;
     SDL_GetJoystickSensorData;
+    SDL_CopyGPUTextureToBuffer;
+    SDL_CopyGPUBufferToTexture;
     # extra symbols go here (don't modify this line)
   local: *;
 };

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -1334,3 +1334,5 @@
 #define SDL_JoystickSensorEnabled SDL_JoystickSensorEnabled_REAL
 #define SDL_GetJoystickSensorDataRate SDL_GetJoystickSensorDataRate_REAL
 #define SDL_GetJoystickSensorData SDL_GetJoystickSensorData_REAL
+#define SDL_CopyGPUTextureToBuffer SDL_CopyGPUTextureToBuffer_REAL
+#define SDL_CopyGPUBufferToTexture SDL_CopyGPUBufferToTexture_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -1342,3 +1342,5 @@ SDL_DYNAPI_PROC(bool,SDL_SetJoystickSensorEnabled,(SDL_Joystick *a,SDL_SensorTyp
 SDL_DYNAPI_PROC(bool,SDL_JoystickSensorEnabled,(SDL_Joystick *a,SDL_SensorType b),(a,b),return)
 SDL_DYNAPI_PROC(float,SDL_GetJoystickSensorDataRate,(SDL_Joystick *a,SDL_SensorType b),(a,b),return)
 SDL_DYNAPI_PROC(bool,SDL_GetJoystickSensorData,(SDL_Joystick *a,SDL_SensorType b,float *c,int d),(a,b,c,d),return)
+SDL_DYNAPI_PROC(void,SDL_CopyGPUTextureToBuffer,(SDL_GPUCopyPass *a,const SDL_GPUTextureRegion *b,const SDL_GPUBufferLocation *c,bool d),(a,b,c,d),)
+SDL_DYNAPI_PROC(void,SDL_CopyGPUBufferToTexture,(SDL_GPUCopyPass *a,const SDL_GPUBufferLocation *b,const SDL_GPUTextureRegion *c,bool d),(a,b,c,d),)

--- a/src/gpu/SDL_gpu.c
+++ b/src/gpu/SDL_gpu.c
@@ -2923,6 +2923,44 @@ void SDL_CopyGPUTextureToTexture(
         cycle);
 }
 
+void SDL_CopyGPUTextureToBuffer(
+    SDL_GPUCopyPass *copy_pass,
+    const SDL_GPUTextureRegion *source,
+    const SDL_GPUBufferLocation *destination,
+    bool cycle)
+{
+    CHECK_PARAM(copy_pass == NULL) {
+        SDL_InvalidParamError("copy_pass");
+        return;
+    }
+    CHECK_PARAM(source == NULL) {
+        SDL_InvalidParamError("source");
+        return;
+    }
+    CHECK_PARAM(destination == NULL) {
+        SDL_InvalidParamError("destination");
+        return;
+    }
+
+    if (COPYPASS_DEVICE->debug_mode) {
+        CHECK_COPYPASS
+        if (source->texture == NULL) {
+            SDL_assert_release(!"Source texture cannot be NULL!");
+            return;
+        }
+        if (destination->buffer == NULL) {
+            SDL_assert_release(!"Destination buffer cannot be NULL!");
+            return;
+        }
+    }
+
+    COPYPASS_DEVICE->CopyTextureToBuffer(
+        COPYPASS_COMMAND_BUFFER,
+        source,
+        destination,
+        cycle);
+}
+
 void SDL_CopyGPUBufferToBuffer(
     SDL_GPUCopyPass *copy_pass,
     const SDL_GPUBufferLocation *source,
@@ -2960,6 +2998,44 @@ void SDL_CopyGPUBufferToBuffer(
         source,
         destination,
         size,
+        cycle);
+}
+
+void SDL_CopyGPUBufferToTexture(
+    SDL_GPUCopyPass *copy_pass,
+    const SDL_GPUBufferLocation *source,
+    const SDL_GPUTextureRegion *destination,
+    bool cycle)
+{
+    CHECK_PARAM(copy_pass == NULL) {
+        SDL_InvalidParamError("copy_pass");
+        return;
+    }
+    CHECK_PARAM(source == NULL) {
+        SDL_InvalidParamError("source");
+        return;
+    }
+    CHECK_PARAM(destination == NULL) {
+        SDL_InvalidParamError("destination");
+        return;
+    }
+
+    if (COPYPASS_DEVICE->debug_mode) {
+        CHECK_COPYPASS
+        if (source->buffer == NULL) {
+            SDL_assert_release(!"Source buffer cannot be NULL!");
+            return;
+        }
+        if (destination->texture == NULL) {
+            SDL_assert_release(!"Destination texture cannot be NULL!");
+            return;
+        }
+    }
+
+    COPYPASS_DEVICE->CopyBufferToTexture(
+        COPYPASS_COMMAND_BUFFER,
+        source,
+        destination,
         cycle);
 }
 

--- a/src/gpu/SDL_sysgpu.h
+++ b/src/gpu/SDL_sysgpu.h
@@ -988,11 +988,23 @@ struct SDL_GPUDevice
         Uint32 d,
         bool cycle);
 
+    void (*CopyTextureToBuffer)(
+        SDL_GPUCommandBuffer *commandBuffer,
+        const SDL_GPUTextureRegion *source,
+        const SDL_GPUBufferLocation *destination,
+        bool cycle);
+
     void (*CopyBufferToBuffer)(
         SDL_GPUCommandBuffer *commandBuffer,
         const SDL_GPUBufferLocation *source,
         const SDL_GPUBufferLocation *destination,
         Uint32 size,
+        bool cycle);
+
+    void (*CopyBufferToTexture)(
+        SDL_GPUCommandBuffer *commandBuffer,
+        const SDL_GPUBufferLocation *source,
+        const SDL_GPUTextureRegion *destination,
         bool cycle);
 
     void (*GenerateMipmaps)(
@@ -1192,7 +1204,9 @@ struct SDL_GPUDevice
     ASSIGN_DRIVER_FUNC(DownloadFromTexture, name)           \
     ASSIGN_DRIVER_FUNC(DownloadFromBuffer, name)            \
     ASSIGN_DRIVER_FUNC(CopyTextureToTexture, name)          \
+    ASSIGN_DRIVER_FUNC(CopyTextureToBuffer, name)           \
     ASSIGN_DRIVER_FUNC(CopyBufferToBuffer, name)            \
+    ASSIGN_DRIVER_FUNC(CopyBufferToTexture, name)           \
     ASSIGN_DRIVER_FUNC(GenerateMipmaps, name)               \
     ASSIGN_DRIVER_FUNC(EndCopyPass, name)                   \
     ASSIGN_DRIVER_FUNC(Blit, name)                          \

--- a/src/gpu/d3d12/SDL_gpu_d3d12.c
+++ b/src/gpu/d3d12/SDL_gpu_d3d12.c
@@ -6230,6 +6230,73 @@ static void D3D12_CopyTextureToTexture(
         destinationSubresource->parent);
 }
 
+static void D3D12_CopyTextureToBuffer(
+    SDL_GPUCommandBuffer *commandBuffer,
+    const SDL_GPUTextureRegion *source,
+    const SDL_GPUBufferLocation *destination,
+    bool cycle)
+{
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12_TEXTURE_COPY_LOCATION sourceLocation;
+    D3D12_TEXTURE_COPY_LOCATION destinationLocation;
+    D3D12BufferContainer *destinationContainer = (D3D12BufferContainer *)destination->buffer;
+
+    D3D12Buffer *destinationBuffer = D3D12_INTERNAL_PrepareBufferForWrite(
+        d3d12CommandBuffer,
+        destinationContainer,
+        cycle,
+        D3D12_RESOURCE_STATE_COPY_DEST);
+
+    D3D12TextureSubresource *sourceSubresource = D3D12_INTERNAL_FetchTextureSubresource(
+        (D3D12TextureContainer *)source->texture,
+        source->layer,
+        source->mip_level);
+
+    D3D12_INTERNAL_TextureSubresourceTransitionFromDefaultUsage(
+        d3d12CommandBuffer,
+        D3D12_RESOURCE_STATE_COPY_SOURCE,
+        sourceSubresource);
+
+    sourceLocation.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+    sourceLocation.SubresourceIndex = sourceSubresource->index;
+    sourceLocation.pResource = sourceSubresource->parent->resource;
+
+    D3D12_BOX sourceBox = {
+        source->x,
+        source->y,
+        source->z,
+        source->x + source->w,
+        source->y + source->h,
+        source->z + source->d
+    };
+
+    // FIXME: what if pitch is not 256-aligned?
+    // FIXME: depth-stencil planes?
+    destinationLocation.Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
+    destinationLocation.PlacedFootprint.Footprint.Format = SDLToD3D12_TextureFormat[sourceSubresource->parent->container->header.info.format];
+    destinationLocation.PlacedFootprint.Footprint.Width = source->w;
+    destinationLocation.PlacedFootprint.Footprint.Height = source->h;
+    destinationLocation.PlacedFootprint.Footprint.Depth = source->d;
+    destinationLocation.PlacedFootprint.Footprint.RowPitch = BytesPerRow(source->w, sourceSubresource->parent->container->header.info.format);
+
+    ID3D12GraphicsCommandList_CopyTextureRegion(
+        d3d12CommandBuffer->graphicsCommandList,
+        &destinationLocation,
+        0,
+        0,
+        0,
+        &sourceLocation,
+        &sourceBox);
+
+    D3D12_INTERNAL_TextureSubresourceTransitionToDefaultUsage(
+        d3d12CommandBuffer,
+        D3D12_RESOURCE_STATE_COPY_SOURCE,
+        sourceSubresource);
+
+    D3D12_INTERNAL_TrackTexture(d3d12CommandBuffer, sourceSubresource->parent);
+    D3D12_INTERNAL_TrackBuffer(d3d12CommandBuffer, destinationBuffer);
+}
+
 static void D3D12_CopyBufferToBuffer(
     SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUBufferLocation *source,
@@ -6273,6 +6340,67 @@ static void D3D12_CopyBufferToBuffer(
 
     D3D12_INTERNAL_TrackBuffer(d3d12CommandBuffer, sourceBuffer);
     D3D12_INTERNAL_TrackBuffer(d3d12CommandBuffer, destinationBuffer);
+}
+
+static void D3D12_CopyBufferToTexture(
+    SDL_GPUCommandBuffer *commandBuffer,
+    const SDL_GPUBufferLocation *source,
+    const SDL_GPUTextureRegion *destination,
+    bool cycle)
+{
+    D3D12CommandBuffer *d3d12CommandBuffer = (D3D12CommandBuffer *)commandBuffer;
+    D3D12_TEXTURE_COPY_LOCATION sourceLocation;
+    D3D12_TEXTURE_COPY_LOCATION destinationLocation;
+
+    D3D12Buffer *sourceBuffer = ((D3D12BufferContainer *)source->buffer)->activeBuffer;
+
+    D3D12_INTERNAL_BufferTransitionFromDefaultUsage(
+        d3d12CommandBuffer,
+        D3D12_RESOURCE_STATE_COPY_SOURCE,
+        sourceBuffer);
+
+    D3D12TextureSubresource *destinationSubresource = D3D12_INTERNAL_PrepareTextureSubresourceForWrite(
+        d3d12CommandBuffer,
+        (D3D12TextureContainer *)destination->texture,
+        destination->layer,
+        destination->mip_level,
+        cycle,
+        D3D12_RESOURCE_STATE_COPY_DEST);
+
+    // FIXME: what if pitch is not 256-aligned?
+    // FIXME: depth-stencil planes?
+    sourceLocation.Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
+    sourceLocation.PlacedFootprint.Footprint.Format = SDLToD3D12_TextureFormat[destinationSubresource->parent->container->header.info.format];
+    sourceLocation.PlacedFootprint.Footprint.Width = destination->w;
+    sourceLocation.PlacedFootprint.Footprint.Height = destination->h;
+    sourceLocation.PlacedFootprint.Footprint.Depth = destination->d;
+    sourceLocation.PlacedFootprint.Footprint.RowPitch = BytesPerRow(destination->w, destinationSubresource->parent->container->header.info.format);
+
+    destinationLocation.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+    destinationLocation.SubresourceIndex = destinationSubresource->index;
+    destinationLocation.pResource = destinationSubresource->parent->resource;
+
+    ID3D12GraphicsCommandList_CopyTextureRegion(
+        d3d12CommandBuffer->graphicsCommandList,
+        &destinationLocation,
+        destination->x,
+        destination->y,
+        destination->z,
+        &sourceLocation,
+        NULL);
+
+    D3D12_INTERNAL_BufferTransitionToDefaultUsage(
+        d3d12CommandBuffer,
+        D3D12_RESOURCE_STATE_COPY_SOURCE,
+        sourceBuffer);
+
+    D3D12_INTERNAL_TextureTransitionToDefaultUsage(
+        d3d12CommandBuffer,
+        D3D12_RESOURCE_STATE_COPY_DEST,
+        destinationSubresource->parent);
+
+    D3D12_INTERNAL_TrackBuffer(d3d12CommandBuffer, sourceBuffer);
+    D3D12_INTERNAL_TrackTexture(d3d12CommandBuffer, destinationSubresource->parent);
 }
 
 static void D3D12_DownloadFromTexture(

--- a/src/gpu/vulkan/SDL_gpu_vulkan.c
+++ b/src/gpu/vulkan/SDL_gpu_vulkan.c
@@ -2608,9 +2608,9 @@ static void VULKAN_INTERNAL_TrackUniformBuffer(
  * These indicate the current usage of that resource on the command buffer.
  * The transition from one usage mode to another indicates how the barrier should be constructed.
  *
- * For buffer reads, read usage modes can be combined. 
+ * For buffer reads, read usage modes can be combined.
  * This can be a useful shortcut in certain cases, like when reading GLTF data.
- * 
+ *
  * Pipeline barriers cannot be inserted during a render pass, but they can be inserted
  * during a compute or copy pass.
  *
@@ -2913,13 +2913,13 @@ static VulkanBufferUsageModeFlags VULKAN_INTERNAL_DefaultBufferUsageMode(
 
     if (buffer->usage & SDL_GPU_BUFFERUSAGE_VERTEX) {
         flags |= VULKAN_BUFFER_USAGE_MODE_VERTEX_READ;
-    } 
+    }
     if (buffer->usage & SDL_GPU_BUFFERUSAGE_INDEX) {
         flags |= VULKAN_BUFFER_USAGE_MODE_INDEX_READ;
     }
     if (buffer->usage & SDL_GPU_BUFFERUSAGE_INDIRECT) {
         flags |= VULKAN_BUFFER_USAGE_MODE_INDIRECT;
-    } 
+    }
     if (buffer->usage & SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ) {
         flags |= VULKAN_BUFFER_USAGE_MODE_GRAPHICS_STORAGE_READ;
     }
@@ -2930,7 +2930,7 @@ static VulkanBufferUsageModeFlags VULKAN_INTERNAL_DefaultBufferUsageMode(
     // If no read flags are set, read-write can be the default.
     if (!flags && buffer->usage & SDL_GPU_BUFFERUSAGE_COMPUTE_STORAGE_WRITE) {
         flags = VULKAN_BUFFER_USAGE_MODE_COMPUTE_STORAGE_READ_WRITE;
-    } 
+    }
 
     if (!flags) {
         SDL_LogError(SDL_LOG_CATEGORY_GPU, "Buffer has no default usage mode!");
@@ -9214,6 +9214,74 @@ static void VULKAN_CopyTextureToTexture(
     SDL_UnlockRWLock(renderer->defragLock);
 }
 
+static void VULKAN_CopyTextureToBuffer(
+    SDL_GPUCommandBuffer *commandBuffer,
+    const SDL_GPUTextureRegion *source,
+    const SDL_GPUBufferLocation *destination,
+    bool cycle)
+{
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
+    VulkanTextureSubresource *srcSubresource;
+    VulkanBufferContainer *dstContainer = (VulkanBufferContainer *)destination->buffer;
+    VkBufferImageCopy copyDetails;
+
+    SDL_LockRWLockForReading(renderer->defragLock);
+
+    srcSubresource = VULKAN_INTERNAL_FetchTextureSubresource(
+        (VulkanTextureContainer *)source->texture,
+        source->layer,
+        source->mip_level);
+
+    VulkanBuffer *dstBuffer = VULKAN_INTERNAL_PrepareBufferForWrite(
+        renderer,
+        vulkanCommandBuffer,
+        dstContainer,
+        cycle,
+        VULKAN_BUFFER_USAGE_MODE_COPY_DESTINATION);
+
+    VULKAN_INTERNAL_TextureTransitionFromDefaultUsage(
+        renderer,
+        vulkanCommandBuffer,
+        VULKAN_TEXTURE_USAGE_MODE_COPY_SOURCE,
+        srcSubresource->parent);
+
+    copyDetails.imageOffset.x = source->x;
+    copyDetails.imageOffset.y = source->y;
+    copyDetails.imageOffset.z = source->z;
+    copyDetails.imageExtent.width = source->w;
+    copyDetails.imageExtent.height = source->h;
+    copyDetails.imageExtent.depth = source->d;
+    copyDetails.imageSubresource.aspectMask = srcSubresource->parent->aspectFlags;
+    copyDetails.imageSubresource.baseArrayLayer = source->layer;
+    copyDetails.imageSubresource.layerCount = 1;
+    copyDetails.imageSubresource.mipLevel = source->mip_level;
+    copyDetails.bufferOffset = destination->offset;
+    copyDetails.bufferRowLength = 0;    // assume tightly packed
+    copyDetails.bufferImageHeight = 0;  // assume tightly packed
+
+    renderer->vkCmdCopyImageToBuffer(
+        vulkanCommandBuffer->commandBuffer,
+        srcSubresource->parent->image,
+        VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+        dstBuffer->buffer,
+        1,
+        &copyDetails);
+
+    VULKAN_INTERNAL_TextureSubresourceTransitionToDefaultUsage(
+        renderer,
+        vulkanCommandBuffer,
+        VULKAN_TEXTURE_USAGE_MODE_COPY_SOURCE,
+        srcSubresource);
+
+    VULKAN_INTERNAL_TrackTexture(vulkanCommandBuffer, srcSubresource->parent);
+    VULKAN_INTERNAL_TrackBuffer(vulkanCommandBuffer, dstBuffer);
+    VULKAN_INTERNAL_TrackTextureTransfer(vulkanCommandBuffer, srcSubresource->parent);
+    VULKAN_INTERNAL_TrackBufferTransfer(vulkanCommandBuffer, dstBuffer);
+
+    SDL_UnlockRWLock(renderer->defragLock);
+}
+
 static void VULKAN_CopyBufferToBuffer(
     SDL_GPUCommandBuffer *commandBuffer,
     const SDL_GPUBufferLocation *source,
@@ -9269,6 +9337,78 @@ static void VULKAN_CopyBufferToBuffer(
     VULKAN_INTERNAL_TrackBuffer(vulkanCommandBuffer, dstBuffer);
     VULKAN_INTERNAL_TrackBufferTransfer(vulkanCommandBuffer, srcContainer->activeBuffer);
     VULKAN_INTERNAL_TrackBufferTransfer(vulkanCommandBuffer, dstBuffer);
+
+    SDL_UnlockRWLock(renderer->defragLock);
+}
+
+static void VULKAN_CopyBufferToTexture(
+    SDL_GPUCommandBuffer *commandBuffer,
+    const SDL_GPUBufferLocation *source,
+    const SDL_GPUTextureRegion *destination,
+    bool cycle)
+{
+    VulkanCommandBuffer *vulkanCommandBuffer = (VulkanCommandBuffer *)commandBuffer;
+    VulkanRenderer *renderer = vulkanCommandBuffer->renderer;
+    VulkanTextureSubresource *dstSubresource;
+    VkBufferImageCopy copyDetails;
+
+    SDL_LockRWLockForReading(renderer->defragLock);
+
+    VulkanBuffer *srcBuffer = ((VulkanBufferContainer *)source->buffer)->activeBuffer;
+
+    VULKAN_INTERNAL_BufferTransitionFromDefaultUsage(
+        renderer,
+        vulkanCommandBuffer,
+        VULKAN_BUFFER_USAGE_MODE_COPY_SOURCE,
+        srcBuffer);
+
+    dstSubresource = VULKAN_INTERNAL_PrepareTextureSubresourceForWrite(
+        renderer,
+        vulkanCommandBuffer,
+        (VulkanTextureContainer *)destination->texture,
+        destination->layer,
+        destination->mip_level,
+        cycle,
+        VULKAN_TEXTURE_USAGE_MODE_COPY_DESTINATION);
+
+    copyDetails.imageExtent.width = destination->w;
+    copyDetails.imageExtent.height = destination->h;
+    copyDetails.imageExtent.depth = destination->d;
+    copyDetails.imageOffset.x = destination->x;
+    copyDetails.imageOffset.y = destination->y;
+    copyDetails.imageOffset.z = destination->z;
+    copyDetails.imageSubresource.aspectMask = dstSubresource->parent->aspectFlags;
+    copyDetails.imageSubresource.baseArrayLayer = destination->layer;
+    copyDetails.imageSubresource.layerCount = 1;
+    copyDetails.imageSubresource.mipLevel = destination->mip_level;
+    copyDetails.bufferOffset = source->offset;
+    copyDetails.bufferRowLength = 0;   // assume tightly packed
+    copyDetails.bufferImageHeight = 0; // assume tightly packed
+
+    renderer->vkCmdCopyBufferToImage(
+        vulkanCommandBuffer->commandBuffer,
+        srcBuffer->buffer,
+        dstSubresource->parent->image,
+        VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+        1,
+        &copyDetails);
+
+    VULKAN_INTERNAL_BufferTransitionToDefaultUsage(
+        renderer,
+        vulkanCommandBuffer,
+        VULKAN_BUFFER_USAGE_MODE_COPY_SOURCE,
+        srcBuffer);
+
+    VULKAN_INTERNAL_TextureTransitionToDefaultUsage(
+        renderer,
+        vulkanCommandBuffer,
+        VULKAN_TEXTURE_USAGE_MODE_COPY_DESTINATION,
+        dstSubresource->parent);
+
+    VULKAN_INTERNAL_TrackBuffer(vulkanCommandBuffer, srcBuffer);
+    VULKAN_INTERNAL_TrackTexture(vulkanCommandBuffer, dstSubresource->parent);
+    VULKAN_INTERNAL_TrackBufferTransfer(vulkanCommandBuffer, srcBuffer);
+    VULKAN_INTERNAL_TrackTextureTransfer(vulkanCommandBuffer, dstSubresource->parent);
 
     SDL_UnlockRWLock(renderer->defragLock);
 }


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
GPU-timelined texture-to-buffer and buffer-to-texture copies can be useful, so we should expose that capability.

I still need to investigate what expected behavior would be when copying depth data from depth-stencil textures.

D3D12's horrible design continues to be a delight. We'll need to figure out a workaround for the 256-byte alignment requirement. 

## Existing Issue(s)
Resolves https://github.com/libsdl-org/SDL/issues/16248

## TODO
- [ ] How do we want to handle stencil data in depth-stencil textures?
- [ ] Metal implementation
- [ ] NDA implementation
- [ ] Alignment workaround for D3D12