### PR TITLE
Split System Request from Print Screen in XF86 as well

### DIFF
--- a/src/events/scancodes_xfree86.h
+++ b/src/events/scancodes_xfree86.h
@@ -279,7 +279,7 @@ static const SDL_Scancode xfree86_scancode_table2[] = {
     /*  96, 0x060 */   SDL_SCANCODE_KP_ENTER,           // KP_Enter
     /*  97, 0x061 */   SDL_SCANCODE_RCTRL,              // Control_R
     /*  98, 0x062 */   SDL_SCANCODE_KP_DIVIDE,          // KP_Divide
-    /*  99, 0x063 */   SDL_SCANCODE_PRINTSCREEN,        // Print
+    /*  99, 0x063 */   SDL_SCANCODE_SYSREQ,             // Print
     /* 100, 0x064 */   SDL_SCANCODE_RALT,               // ISO_Level3_Shift, ALTGR, RALT
     /* 101, 0x065 */   SDL_SCANCODE_UNKNOWN,            // Linefeed
     /* 102, 0x066 */   SDL_SCANCODE_HOME,               // Home


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
It seems I missed this disparity in #16239. scancodes_linux.h maps key 99 to SDL_SCANCODE_SYSREQ and key 210 to SDL_SCANCODE_PRINTSCREEN, however scancodes_xfree86.h maps both to SDL_SCANCODE_PRINTSCREEN. This simply splits the two of them in the latter file to match Linux.

If these were both mapped to the same key on purpose, do let me know.

## Existing Issue(s)
None
