### PR TITLE
wayland: guard null clipboard offer

### DIFF
--- a/src/video/wayland/SDL_waylanddatamanager.c
+++ b/src/video/wayland/SDL_waylanddatamanager.c
@@ -599,7 +599,9 @@ void Wayland_DataOfferNotifyFromMIMEs(SDL_WaylandDataOffer *offer, bool check_or
         new_mime_types[nformats] = NULL;
     }
 
-    SetCurrentClipboardOffer(offer);
+    if (offer) {
+        SetCurrentClipboardOffer(offer);
+    }
     SDL_SendClipboardUpdate(false, new_mime_types, nformats);
 }
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description

The Wayland selection callback can invoke `Wayland_DataOfferNotifyFromMIMEs(NULL, ...)` when the compositor clears the clipboard selection. The function already handles a null offer while collecting MIME types, but subsequently passed that null pointer unconditionally to `SetCurrentClipboardOffer()`, which dereferences it.

This caused a reproducible segmentation fault in the Wayland event pump:

```text
Wayland_DataOfferNotifyFromMIMEs
libffi
libwayland-client
Wayland_PumpEvents
SDL_WaitEventTimeoutNS
````

## Existing Issue(s)

No existing issue found for this specific null dereference.