### PR TITLE
X11: cache raw mouse valuators by source device to fix "mouse stuck in middle"

### DIFF
--- a/src/video/x11/SDL_x11xinput2.c
+++ b/src/video/x11/SDL_x11xinput2.c
@@ -529,7 +529,7 @@ void X11_HandleXinput2Event(SDL_VideoDevice *_this, XGenericEventCookie *cookie)
             break; // Pens check for XI_Motion instead
         }
 
-        SDL_XInput2DeviceInfo *devinfo = xinput2_get_device_info(videodata, rawev->deviceid);
+        SDL_XInput2DeviceInfo *devinfo = xinput2_get_device_info(videodata, rawev->sourceid);
         if (!devinfo) {
             break; // oh well.
         }


### PR DESCRIPTION
- [ ] I confirm that I am the author of this code and release it to the SDL project under the zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description

Use the raw event's `sourceid` when querying and caching its XInput2 valuator metadata. An XWayland master pointer can deliver events from both an absolute pointer source and a relative pointer source. Caching metadata by the shared master `deviceid` lets the relative source inherit an absolute-axis classification. SDL then subtracts consecutive values that are already relative movements, reversing mouse-look movement as the user slows the mouse.

The source-specific lookup gives each source its own axis classification and previous-coordinate state. This remains a candidate correction pending maintainer review and multi-day gameplay testing.

## Validation

Observed in a running native CS2 session on GNOME Wayland using the SDL X11 backend:

- Incoming XInput events had `deviceid=2`, `sourceid=7`; source 7 advertised relative X/Y axes.
- Probes at the installed SDL library's actual classification branch found its cached device 2 entry had `relative[0]=0` and `relative[1]=0`.
- Across 218 samples per axis, the absolute-conversion branch ran 436 times; the relative passthrough branch never ran.
- Same-process boundary tracing showed correct XInput raw values becoming consecutive differences in the SDL events returned to CS2.

An isolated helper loaded the game's original SDL library with the dummy video backend, reconstructed the observed master-absolute/source-relative cache state, and fed synthetic raw events through its compiled X11 handler. A source-equivalent, one-byte local binary correction was assembled and tested against the exact same library:

## Existing Issue(s)

Related to #16163. The live branch trace confirms the absolute-conversion path requested in that issue; the exact first-event ordering on this machine was not captured.
