### PR TITLE
misc: Added SDL_EncodeURL.

### DIFF
--- a/include/SDL3/SDL_misc.h
+++ b/include/SDL3/SDL_misc.h
@@ -71,6 +71,49 @@ extern "C" {
  */
 extern SDL_DECLSPEC bool SDLCALL SDL_OpenURL(const char *url);
 
+
+/**
+ * Encode a string for use in a URL.
+ *
+ * This encodes a string according to RFC3986 section 2, using
+ * "percent-encoding," which is the act of turning a single byte into a
+ * three-character sequence. For example, a space character (ASCII 32, or 0x20)
+ * is converted into the string "%20".
+ *
+ * Only certain bytes are encoded. What RFC3986 calls "unreserved characters"
+ * are not: low-ASCII alphanumeric chars, and four others: `=._~`.
+ *
+ * While using UTF-8 is encouraged, this function does not care if the string
+ * is well-formed UTF-8; it will treat the string as individual bytes to
+ * encode, with some of those bytes being unreserved characters.
+ *
+ * This function's primary use is encoding strings for use as parameters
+ * appended to a URL passed to SDL_OpenURL(), however, this can _also_ be
+ * useful on some systems for passing a filesystem path with a "file://"
+ * prefix to that function to launch a file manager. In such cases, it would
+ * be better if '/' and '\\' aren't encoded, so one can pass a null-terminated
+ * list of characters to `no_encode_chars` to add to the list of characters
+ * that aren't encoded:
+ *
+ * ```c
+ * char *encoded = SDL_EncodeURL(MyFilePath, "/\\");
+ * ```
+ *
+ * These characters will be added to the normal "unreserved characters" list
+ * and not encoded. Passing NULL is valid and adds no characters to the list.
+ *
+ * \param str the string to encode.
+ * \param no_encode_chars a string of extra characters that are not to be encoded.
+ * \returns the encoded string or NULL on failure; call SDL_GetError() for more
+ *          information. This should be freed with SDL_free() when it is no
+ *          longer needed.
+ *
+ * \threadsafety It is safe to call this function from any thread.
+ *
+ * \since This function is available since SDL 3.6.0.
+ */
+extern SDL_DECLSPEC char * SDLCALL SDL_EncodeURL(const char *str, const char *no_encode_chars);
+
 /* Ends C function definitions when using C++ */
 #ifdef __cplusplus
 }

--- a/src/dynapi/SDL_dynapi.exports
+++ b/src/dynapi/SDL_dynapi.exports
@@ -1307,3 +1307,4 @@ _SDL_SetJoystickSensorEnabled
 _SDL_JoystickSensorEnabled
 _SDL_GetJoystickSensorDataRate
 _SDL_GetJoystickSensorData
+_SDL_EncodeURL

--- a/src/dynapi/SDL_dynapi.sym
+++ b/src/dynapi/SDL_dynapi.sym
@@ -1308,6 +1308,7 @@ SDL3_0.0.0 {
     SDL_JoystickSensorEnabled;
     SDL_GetJoystickSensorDataRate;
     SDL_GetJoystickSensorData;
+    SDL_EncodeURL;
     # extra symbols go here (don't modify this line)
   local: *;
 };

--- a/src/dynapi/SDL_dynapi_overrides.h
+++ b/src/dynapi/SDL_dynapi_overrides.h
@@ -1334,3 +1334,4 @@
 #define SDL_JoystickSensorEnabled SDL_JoystickSensorEnabled_REAL
 #define SDL_GetJoystickSensorDataRate SDL_GetJoystickSensorDataRate_REAL
 #define SDL_GetJoystickSensorData SDL_GetJoystickSensorData_REAL
+#define SDL_EncodeURL SDL_EncodeURL_REAL

--- a/src/dynapi/SDL_dynapi_procs.h
+++ b/src/dynapi/SDL_dynapi_procs.h
@@ -1342,3 +1342,4 @@ SDL_DYNAPI_PROC(bool,SDL_SetJoystickSensorEnabled,(SDL_Joystick *a,SDL_SensorTyp
 SDL_DYNAPI_PROC(bool,SDL_JoystickSensorEnabled,(SDL_Joystick *a,SDL_SensorType b),(a,b),return)
 SDL_DYNAPI_PROC(float,SDL_GetJoystickSensorDataRate,(SDL_Joystick *a,SDL_SensorType b),(a,b),return)
 SDL_DYNAPI_PROC(bool,SDL_GetJoystickSensorData,(SDL_Joystick *a,SDL_SensorType b,float *c,int d),(a,b,c,d),return)
+SDL_DYNAPI_PROC(char*,SDL_EncodeURL,(const char *a,const char *b),(a,b),return)

--- a/src/misc/SDL_url.c
+++ b/src/misc/SDL_url.c
@@ -29,3 +29,47 @@ bool SDL_OpenURL(const char *url)
     }
     return SDL_SYS_OpenURL(url);
 }
+
+char *SDL_EncodeURL(const char *str, const char *no_encode_chars)
+{
+    const size_t slen = SDL_strlen(str) + 1;
+    size_t allocation = slen + 64;   // at least this long plus a little more, in case one allocation covers it.
+    size_t dsti = 0;
+    char *retval = (char *) SDL_malloc(allocation);
+    if (!retval) {
+        return NULL;
+    }
+
+    for (size_t i = 0; i < slen; i++) {
+        if (dsti >= (allocation - 4)) {
+            allocation += 64;
+            char *ptr = (char *) SDL_realloc(retval, allocation);
+            if (!ptr) {
+                SDL_free(retval);
+                return NULL;
+            }
+            retval = ptr;
+        }
+
+        const char ch = str[i];
+
+        if ( ((ch >= 'A') && (ch <= 'Z')) || ((ch >= 'a') && (ch <= 'z')) ||
+             ((ch >= '0') && (ch <= '9')) ||
+             ((ch == '=') || (ch == '.') || (ch == '_') || (ch == '~') || (ch == '\0')) ||
+             (no_encode_chars && (SDL_strchr(no_encode_chars, ch) != NULL)) ) {
+            retval[dsti++] = ch;  // unreserved char, null terminator char, or explicitly requested not to encode.
+        } else {
+            SDL_snprintf(&retval[dsti], 4, "%%%02X", (unsigned int) ch);
+            dsti += 3;
+        }
+    }
+
+    // shrink the allocation, if possible.
+    char *ptr = (char *) SDL_realloc(retval, SDL_strlen(retval) + 1);
+    if (ptr) {
+        retval = ptr;
+    }
+
+    return retval;
+}
+

--- a/test/testurl.c
+++ b/test/testurl.c
@@ -13,14 +13,25 @@
 #include <SDL3/SDL_main.h>
 #include <SDL3/SDL_test.h>
 
-static void tryOpenURL(const char *url)
+static void tryOpenURL(const char *url, bool urlencode, const char *no_encode_chars)
 {
+    char *encoded = NULL;
+    if (urlencode) {
+        encoded = SDL_EncodeURL(url, no_encode_chars);
+        if (!encoded) {
+            SDL_Log("URL encoding failed! %s", SDL_GetError());
+        }
+        url = encoded;
+    }
+
     SDL_Log("Opening '%s' ...", url);
     if (SDL_OpenURL(url)) {
         SDL_Log("  success!");
     } else {
         SDL_Log("  failed! %s", SDL_GetError());
     }
+
+    SDL_free(encoded);
 }
 
 int main(int argc, char **argv)
@@ -28,6 +39,8 @@ int main(int argc, char **argv)
     const char *url = NULL;
     SDLTest_CommonState *state = SDLTest_CommonCreateState(argv, 0);
     bool use_gui = false;
+    bool urlencode = false;
+    const char *no_encode_chars = NULL;
 
     /* Parse commandline */
     for (int i = 1; i < argc;) {
@@ -41,11 +54,19 @@ int main(int argc, char **argv)
             } else if (SDL_strcasecmp(argv[i], "--gui") == 0) {
                 use_gui = true;
                 consumed = 1;
+            } else if (SDL_strcasecmp(argv[i], "--urlencode") == 0) {
+                urlencode = true;
+                consumed = 1;
+            } else if (SDL_strcasecmp(argv[i], "--no-encode-chars") == 0) {
+                no_encode_chars = argv[i + 1];
+                consumed = 2;
             }
         }
         if (consumed <= 0) {
             static const char *options[] = {
-                "[--gui]"
+                "[--gui]",
+                "[--urlencode]",
+                "[--no-encode-chars ...]",
                 "[URL [...]]",
                 NULL,
             };
@@ -61,7 +82,7 @@ int main(int argc, char **argv)
     }
 
     if (!use_gui) {
-        tryOpenURL(url);
+        tryOpenURL(url, urlencode, no_encode_chars);
     } else {
         SDL_Event event;
         bool quit = false;
@@ -70,7 +91,7 @@ int main(int argc, char **argv)
             while (SDL_PollEvent(&event)) {
                 if (event.type == SDL_EVENT_KEY_DOWN) {
                     if (event.key.key == SDLK_SPACE) {
-                        tryOpenURL(url);
+                        tryOpenURL(url, urlencode, no_encode_chars);
                     } else if (event.key.key == SDLK_ESCAPE) {
                         quit = true;
                     }


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Adds a way to encode URL strings, for use with SDL_OpenURL(), etc. Generally you would encode either just the params and append them to a URL (`"https://example.com?my_param=" + SDL_EncodeURL(SomeUntrustedString, NULL)`), or the whole string for a `file:///` path (`file:/// + SDL_EncodeURL(SomeUntrustedPath, "\\/")`).

Can be seen in action with:

```bash
./test/testurl file:///Some Path/That Has Spaces --urlencode --no-encode-chars ':/'
```

(Although strictly speaking, you would want to encode the path with just '/' in no-encode-chars and prepend "file://" directly, but this is just a test program.)

Fixes #16254.


