### PR TITLE
x11: Clear the internal selection data when updating the clipboard

### DIFF
--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -947,6 +947,9 @@ static void X11_HandleClipboardEvent(SDL_VideoDevice *_this, const XEvent *xeven
                 new_mime_types[length] = NULL;
 
                 SDL_SendClipboardUpdate(false, new_mime_types, length);
+
+                // Clear the internal selection source data, as it was invalided after updating the clipboard.
+                SDL_zero(videodata->clipboard);
             }
 
             if (data) {


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Clear the internal X11 clipboard selection data when updating the clipboard during SelectionNotify events, as it is invalid after the update. Otherwise, an out-of-date SelectionRequest can end up attempting to read the invalid data, and cause a crash.

Fixes #16245