### PR TITLE
Remove uses of stpcpy()

### DIFF
--- a/src/video/wayland/SDL_waylanddatamanager.c
+++ b/src/video/wayland/SDL_waylanddatamanager.c
@@ -589,6 +589,8 @@ static void SelectionOfferNotifyFromMIMEs(SDL_WaylandDataDevice *data_device, bo
 
         // Second pass to fill.
         char *strPtr = (char *)(new_mime_types + num_formats + 1);
+        alloc_size -= (uintptr_t)strPtr - (uintptr_t)new_mime_types;
+
         item = NULL;
         int i = 0;
         wl_list_for_each(item, &offer->mimes, link) {
@@ -596,9 +598,10 @@ static void SelectionOfferNotifyFromMIMEs(SDL_WaylandDataDevice *data_device, bo
                 continue;
             }
 
-            new_mime_types[i] = strPtr;
-            strPtr = stpcpy(strPtr, item->mime_type) + 1;
-            i++;
+            new_mime_types[i++] = strPtr;
+            const size_t len = SDL_strlcpy(strPtr, item->mime_type, alloc_size) + 1;
+            strPtr += len;
+            alloc_size -= len;
         }
         new_mime_types[num_formats] = NULL;
     }

--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -937,11 +937,14 @@ static void X11_HandleClipboardEvent(SDL_VideoDevice *_this, const XEvent *xeven
             char **new_mime_types = SDL_AllocateTemporaryMemory(allocationsize);
             if (new_mime_types) {
                 char *strPtr = (char *)(new_mime_types + length + 1);
+                allocationsize -= (uintptr_t)strPtr - (uintptr_t)new_mime_types;
 
                 for (j = 0, patom = (Atom *)data; j < length; j++, patom++) {
                     char *atomStr = X11_XGetAtomName(display, *patom);
                     new_mime_types[j] = strPtr;
-                    strPtr = stpcpy(strPtr, atomStr) + 1;
+                    const size_t len = SDL_strlcpy(strPtr, atomStr, allocationsize) + 1;
+                    strPtr += len;
+                    allocationsize -= len;
                     X11_XFree(atomStr);
                 }
                 new_mime_types[length] = NULL;


### PR DESCRIPTION
This function was only standardized in POSIX.1-2008, is not part of any ISO C standard, and is generally considered unsafe. Use SDL_strlcpy() instead.

- [X] I confirm that I am the author of this code and release it to the SDL project under the zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").