### PR TITLE
Modified points.c example from i++ to ++i for performance reasons and K&R tradition.

### DIFF
--- a/examples/renderer/04-points/points.c
+++ b/examples/renderer/04-points/points.c
@@ -50,7 +50,7 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
     SDL_SetRenderLogicalPresentation(renderer, WINDOW_WIDTH, WINDOW_HEIGHT, SDL_LOGICAL_PRESENTATION_LETTERBOX);
 
     /* set up the data for a bunch of points. */
-    for (i = 0; i < SDL_arraysize(points); i++) {
+    for (i = 0; i < SDL_arraysize(points); ++i) {
         points[i].x = SDL_randf() * ((float) WINDOW_WIDTH);
         points[i].y = SDL_randf() * ((float) WINDOW_HEIGHT);
         point_speeds[i] = MIN_PIXELS_PER_SECOND + (SDL_randf() * (MAX_PIXELS_PER_SECOND - MIN_PIXELS_PER_SECOND));
@@ -78,7 +78,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
     int i;
 
     /* let's move all our points a little for a new frame. */
-    for (i = 0; i < SDL_arraysize(points); i++) {
+    for (i = 0; i < SDL_arraysize(points); ++i) {
         const float distance = elapsed * point_speeds[i];
         points[i].x += distance;
         points[i].y += distance;


### PR DESCRIPTION
- [x ] I confirm that I am the author of this code and release it to the SDL project under the zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
I simply modified the `for` loops to use `++i` instead of the modern convention of `i++` . I understand this change is minuscule and might be counter-intuitive to pragmatism. However I believe that if beginners such as myself are going to thoroughly study the examples it's a good starting point to use this convention. 

## Existing Issue(s)
Depending on compiler `i++` could be slower than `++i`.
