### PR TITLE
pre-mingw-w64 MinGW toolchains don't ship with a intrin.h header

### DIFF
--- a/include/SDL3/SDL_assert.h
+++ b/include/SDL3/SDL_assert.h
@@ -131,7 +131,12 @@ extern "C" {
     extern void __cdecl __debugbreak(void);
     #define SDL_TriggerBreakpoint() __debugbreak()
 #elif defined(__MINGW32__)
+    #include <_mingw.h>
+    #ifdef __MINGW64_VERSION_MAJOR
     #include <intrin.h>
+    #else
+    extern void __cdecl __debugbreak(void);
+    #endif
     #define SDL_TriggerBreakpoint() __debugbreak()
 #elif defined(_MSC_VER) && defined(_M_IX86)
     #define SDL_TriggerBreakpoint() { _asm { int 0x03 }  }


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Existing Issue(s)
Fixes #16204
