### PR TITLE
Suggestion: add some error / log for any SDL thread 

### DIFF
--- a/src/thread/pthread/SDL_systhread.c
+++ b/src/thread/pthread/SDL_systhread.c
@@ -71,6 +71,16 @@ static void *RunThread(void *data)
     Android_JNI_SetupThread();
 #endif
     SDL_RunThread((SDL_Thread *)data);
+
+    {
+        const char *str = SDL_GetError();
+        if (str && str[0]) {
+            SDL_LogError(SDL_LOG_CATEGORY_SYSTEM, "An SDL thread ends (error=%s)", str);
+        } else {
+            SDL_LogDebug(SDL_LOG_CATEGORY_SYSTEM, "An SDL thread ends");
+        }
+    }
+
     return NULL;
 }
 


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Maybe we could have some log information when an SDL thread terminates : so we know when it terminates, with or without error. Otherwise, the error information that is "per thread" is somehow lost and can be unoticed. (whether this is a system or user thread).
it happens I use this sometime. ( and also like to check the Error status of the main thread when it ends).

This could activated with some pre-processor "#idef", or whatever ?
