### PR TITLE
cocoa: Added SDL_HINT_MAC_USE_GCMOUSE.

### DIFF
--- a/include/SDL3/SDL_hints.h
+++ b/include/SDL3/SDL_hints.h
@@ -2838,6 +2838,26 @@ extern "C" {
 #define SDL_HINT_MAC_SCROLL_MOMENTUM "SDL_MAC_SCROLL_MOMENTUM"
 
 /**
+ * A variable controlling whether the GCMouse API will be used on macOS.
+ *
+ * On supported versions of macOS, GCMouse is usually a better way to
+ * read mouse input, but may cause problems in some scenarios (remote control
+ * software that wants to send non-GCMouse input events, etc).
+ *
+ * When GCMouse is disabled, SDL will use standard Cocoa mouse events.
+ *
+ * The variable can be set to the following values:
+ *
+ * - "0": GCMouse won't be used.
+ * - "1": GCMouse will be used if available. (default)
+ *
+ * This hint needs to be set before SDL_Init().
+ *
+ * \since This hint is available since SDL 3.6.0.
+ */
+#define SDL_HINT_MAC_USE_GCMOUSE "SDL_MAC_USE_GCMOUSE"
+
+/**
  * A variable controlling whether holding down a key will repeat the pressed
  * key or open the accents menu on macOS.
  *

--- a/src/video/cocoa/SDL_cocoamouse.m
+++ b/src/video/cocoa/SDL_cocoamouse.m
@@ -451,6 +451,10 @@ static void Cocoa_OnGCMouseDisconnected(GCMouse *mouse)
 
 void Cocoa_InitGCMouse(void)
 {
+    if (!SDL_GetHintBoolean(SDL_HINT_MAC_USE_GCMOUSE, true)) {
+        return;
+    }
+
     @autoreleasepool {
         // These APIs are available starting in macOS Big Sur, but we don't enable
         // GCMouse until Sonoma due to broken motion and button events on MacBooks


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

This adds a hint to turn off GCMouse support on macOS, in case it interferes in some way (notably: remote viewer software that wants to send fake mouse NSEvents, which we ignore if using GCMouse).

When turned off, we just use standard Cocoa mouse events, like we do on older macOS releases anyhow.

Reference Issue #16241.

