### PR TITLE
x11: Don't suppress mouse buttons when lacking keyboard focus

### DIFF
--- a/src/video/x11/SDL_x11xinput2.c
+++ b/src/video/x11/SDL_x11xinput2.c
@@ -629,7 +629,7 @@ void X11_HandleXinput2Event(SDL_VideoDevice *_this, XGenericEventCookie *cookie)
                 /* Ignore slave button events on non-focused windows, as they can arrive before FocusIn events,
                  * or result in focus being incorrectly set while a grab is active.
                  */
-                if (SDL_GetMouseFocus() != windowdata->window || SDL_GetKeyboardFocus() != windowdata->window) {
+                if (SDL_GetMouseFocus() != windowdata->window) {
                     break;
                 }
 


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

The window may not have keyboard focus when using remote control tools, so drop the keyboard focus requirement. Tested not to regress clickthrough suppression (#15523).

Fixes #16242