### PR TITLE
DOS: prevent audio mixing from starving the main thread

### DIFF
--- a/src/audio/dos/SDL_dosaudio_sb.c
+++ b/src/audio/dos/SDL_dosaudio_sb.c
@@ -170,6 +170,10 @@ static bool DOSSOUNDBLASTER_WaitDevice(SDL_AudioDevice *device)
     struct SDL_PrivateAudioData *hidden = device->hidden;
     const int size = hidden->ring_size;
 
+    // Slow mixing can keep the ring below capacity indefinitely. Yield even
+    // when there is room so the cooperative main thread can process events.
+    DOS_Yield();
+
     for (;;) {
         // Available space = ring_size - (write - read).
         // ring_write is ours (audio thread only), ring_read is advanced by


### PR DESCRIPTION
When mixing is slow enough that the Sound Blaster ring never fills, WaitDevice returns without yielding. The cooperative audio thread can then starve event processing.

Yield once before checking available space. The existing full-buffer wait remains unchanged.

Reproduced with F-15 SE2, DJGPP and DOSBox 0.74-3: startup appeared frozen inside SDL_PollEvent. The equivalent patch on SDL e442a9a restored input and game progress. This rebased submission has not been rebuilt or tested on physical DOS hardware.

@AJenbo