### PR TITLE
fs: Use getexecpath() on OpenBSD for GetExePath().

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1225,6 +1225,7 @@ if(SDL_LIBC)
 
   if(NOT WINDOWS)
     check_symbol_exists(fdatasync "unistd.h" HAVE_FDATASYNC)
+    check_symbol_exists(getexecpath "unistd.h" HAVE_GETEXECPATH)
     check_symbol_exists(gethostname "unistd.h" HAVE_GETHOSTNAME)
     check_symbol_exists(getpagesize "unistd.h" HAVE_GETPAGESIZE)
     check_symbol_exists(getresgid "unistd.h" HAVE_GETRESGID)

--- a/src/filesystem/unix/SDL_sysfilesystem.c
+++ b/src/filesystem/unix/SDL_sysfilesystem.c
@@ -138,6 +138,15 @@ static char *GetExePath(void)
     }
 #endif
 #ifdef SDL_PLATFORM_OPENBSD
+#ifdef HAVE_GETEXECPATH
+    char fullpath[PATH_MAX];
+    if (getexecpath(fullpath, sizeof(fullpath)) == 0) {
+        result = SDL_strdup(fullpath);
+        if (!result) {
+            return NULL;
+        }
+    }
+#else
     // Please note that this will fail if the process was launched with a relative path and $PWD + the cwd have changed, or argv is altered. So don't do that. Or add a new sysctl to OpenBSD.
     char **cmdline;
     size_t len;
@@ -193,6 +202,7 @@ static char *GetExePath(void)
 
         SDL_free(cmdline);
     }
+#endif
 #endif
 
     // is a Linux-style /proc filesystem available?


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
Use getexecpath() on OpenBSD for GetExePath().