### PR TITLE
fs: Follow up to the initial getexecpath() support

### DIFF
--- a/include/build_config/SDL_build_config.h.cmake
+++ b/include/build_config/SDL_build_config.h.cmake
@@ -73,6 +73,7 @@
 #cmakedefine HAVE_DLOPEN 1
 #cmakedefine HAVE_MALLOC 1
 #cmakedefine HAVE_FDATASYNC 1
+#cmakedefine HAVE_GETEXECPATH 1
 #cmakedefine HAVE_GETENV 1
 #cmakedefine HAVE_GETHOSTNAME 1
 #cmakedefine HAVE_SETENV 1

--- a/src/filesystem/unix/SDL_sysfilesystem.c
+++ b/src/filesystem/unix/SDL_sysfilesystem.c
@@ -71,7 +71,7 @@ static char *readSymLink(const char *path)
     return NULL;
 }
 
-#ifdef SDL_PLATFORM_OPENBSD
+#if defined(SDL_PLATFORM_OPENBSD) && !defined(HAVE_GETEXECPATH)
 static char *search_path_for_binary(const char *bin)
 {
     const char *envr_real = SDL_getenv("PATH");


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Description
- Add missing CMake piece
- Fix logic to quiet warning