### PR TITLE
Suppress deprecation warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,10 @@ xcuserdata
 *.xcworkspace
 Xcode/build.xcconfig
 
+# for SwiftPM
+.build/
+.swiftpm/
+
 # for Visual Studio Code
 .vscode/
 

--- a/src/camera/coremedia/SDL_camera_coremedia.m
+++ b/src/camera/coremedia/SDL_camera_coremedia.m
@@ -583,7 +583,11 @@ static void COREMEDIA_DetectDevices(void)
             AVCaptureDeviceTypeBuiltInTripleCamera,
             AVCaptureDeviceTypeBuiltInUltraWideCamera,
             #else
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+            // Deprecated in macOS 14.0; its replacement, AVCaptureDeviceTypeExternal, doesn't exist before then.
             AVCaptureDeviceTypeExternalUnknown,
+#pragma clang diagnostic pop
             #endif
             AVCaptureDeviceTypeBuiltInWideAngleCamera
         ];

--- a/src/dialog/cocoa/SDL_cocoadialog.m
+++ b/src/dialog/cocoa/SDL_cocoadialog.m
@@ -153,7 +153,11 @@ void SDL_SYS_ShowFileDialogWithProperties(SDL_FileDialogType type, SDL_DialogFil
             if (@available(macOS 11.0, *)) {
                 [dialog setAllowedContentTypes:types];
             } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                // Deprecated in macOS 12.0; its replacement, -setAllowedContentTypes:, doesn't exist before macOS 11.0.
                 [dialog setAllowedFileTypes:types];
+#pragma clang diagnostic pop
             }
         }
     }

--- a/src/gpu/metal/SDL_gpu_metal.m
+++ b/src/gpu/metal/SDL_gpu_metal.m
@@ -4610,6 +4610,12 @@ static SDL_GPUDevice *METAL_CreateDevice(bool debugMode, bool preferLowPower, SD
             props,
             SDL_PROP_GPU_DEVICE_CREATE_METAL_ALLOW_MACFAMILY1_BOOLEAN,
             false);
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        // MTLGPUFamilyMac1 and the MTLFeatureSet APIs are deprecated as of macOS 13.0,
+        // but there is no replacement for the Mac1 family, and supportsFamily: doesn't
+        // exist before macOS 10.15.
         if (@available(macOS 10.15, *)) {
             hasHardwareSupport = allowMacFamily1 ?
                 [device supportsFamily:MTLGPUFamilyMac1] :
@@ -4619,6 +4625,7 @@ static SDL_GPUDevice *METAL_CreateDevice(bool debugMode, bool preferLowPower, SD
                 [device supportsFeatureSet:MTLFeatureSet_macOS_GPUFamily1_v4] :
                 [device supportsFeatureSet:MTLFeatureSet_macOS_GPUFamily2_v1];
         }
+#pragma clang diagnostic pop
 #elif defined(SDL_PLATFORM_VISIONOS)
         hasHardwareSupport = true;
 #else

--- a/src/notification/cocoa/SDL_cocoanotification.m
+++ b/src/notification/cocoa/SDL_cocoanotification.m
@@ -51,7 +51,10 @@
     if (@available(macOS 11, iOS 14, *)) {
         completionHandler(UNNotificationPresentationOptionBanner + UNNotificationPresentationOptionSound);
     } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         completionHandler(UNNotificationPresentationOptionAlert + UNNotificationPresentationOptionSound);
+#pragma clang diagnostic pop
     }
 }
 
@@ -97,13 +100,16 @@ static bool ShouldEnableNotifications(void)
      * FIXME: These functions are deprecated, find a modern way.
      */
     CFBundleRef bundle = CFBundleGetMainBundle();
-    CFURLRef bundleUrl = CFBundleCopyBundleURL(bundle);
+    CFURLRef bundleUrl = CFBundleCopyBundleURL(bundle); // FIXME: This is a leak!
 
     CFStringRef uti;
-    if (CFURLCopyResourcePropertyForKey(bundleUrl, kCFURLTypeIdentifierKey, &uti, NULL) &&
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    if (CFURLCopyResourcePropertyForKey(bundleUrl, kCFURLTypeIdentifierKey, &uti, NULL) /* FIXME: This is a leak! */ &&
         uti && UTTypeConformsTo(uti, kUTTypeApplicationBundle)) {
         return true;
     }
+#pragma clang diagnostic pop
 
     return false;
 #else

--- a/src/tray/cocoa/SDL_tray.m
+++ b/src/tray/cocoa/SDL_tray.m
@@ -109,7 +109,13 @@ struct SDL_Tray {
     }
 
     if (show_menu && self.tray->menu) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        // Deprecated in macOS 10.14 in favor of NSStatusItem's menu property, but that
+        // makes AppKit show the menu itself on every click, which would bypass the
+        // click callbacks above that can suppress showing the menu.
         [self.tray->statusItem popUpStatusItemMenu:self.tray->menu->nsmenu];
+#pragma clang diagnostic pop
     }
 }
 

--- a/src/video/cocoa/SDL_cocoaclipboard.m
+++ b/src/video/cocoa/SDL_cocoaclipboard.m
@@ -58,7 +58,10 @@ provideDataForType:(NSPasteboardType)type
         CFStringRef mimeType;
         const void *callbackData;
         NSData *data;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         mimeType = UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)type, kUTTagClassMIMEType);
+#pragma clang diagnostic pop
         callbackData = m_callback(m_userdata, [(__bridge NSString *)mimeType UTF8String], &size);
         CFRelease(mimeType);
         if (callbackData == NULL || size == 0) {
@@ -178,7 +181,10 @@ bool Cocoa_SetClipboardData(SDL_VideoDevice *_this)
         if (_this->clipboard_callback) {
             for (int i = 0; i < _this->num_clipboard_mime_types; i++) {
                 CFStringRef mimeType = CFStringCreateWithCString(NULL, _this->clipboard_mime_types[i], kCFStringEncodingUTF8);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 CFStringRef utiType = UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, mimeType, NULL);
+#pragma clang diagnostic pop
                 CFRelease(mimeType);
 
                 [utiTypes addObject: (__bridge NSString *)utiType];
@@ -221,7 +227,10 @@ static CFStringRef GetUTIType(const char *tag)
     CFStringRef utiType;
     if (IsMimeType(tag)) {
         CFStringRef mimeType = CFStringCreateWithCString(NULL, tag, kCFStringEncodingUTF8);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         utiType = UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, mimeType, NULL);
+#pragma clang diagnostic pop
         CFRelease(mimeType);
     } else {
         utiType = CFStringCreateWithCString(NULL, tag, kCFStringEncodingUTF8);

--- a/src/video/cocoa/SDL_cocoaevents.m
+++ b/src/video/cocoa/SDL_cocoaevents.m
@@ -327,7 +327,12 @@ static void Cocoa_DispatchEvent(NSEvent *theEvent)
     if (!SDL_GetHintBoolean(SDL_HINT_MAC_BACKGROUND_APP, background_app_default)) {
         // Get more aggressive for Catalina: activate the Dock first so we definitely reset all activation state.
         for (NSRunningApplication *i in [NSRunningApplication runningApplicationsWithBundleIdentifier:@"com.apple.dock"]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+            // Deprecated in macOS 10.14. I'm not sure that this should even be called anymore on that platform, but still can if the was migrated from
+            // macOS <14.0.
             [i activateWithOptions:NSApplicationActivateIgnoringOtherApps];
+#pragma clang diagnostic pop
             break;
         }
         SDL_Delay(300); // !!! FIXME: this isn't right.

--- a/src/video/cocoa/SDL_cocoamodes.m
+++ b/src/video/cocoa/SDL_cocoamodes.m
@@ -138,7 +138,10 @@ static bool HasValidDisplayModeFlags(CGDisplayModeRef vidmode)
 static Uint32 GetDisplayModePixelFormat(CGDisplayModeRef vidmode)
 {
     // This API is deprecated in 10.11 with no good replacement (as of 10.15).
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     CFStringRef fmt = CGDisplayModeCopyPixelEncoding(vidmode);
+#pragma clang diagnostic pop
     Uint32 pixelformat = SDL_PIXELFORMAT_UNKNOWN;
 
     if (CFStringCompare(fmt, CFSTR(IO32BitDirectPixels),
@@ -294,7 +297,10 @@ static char *Cocoa_GetDisplayName(CGDirectDisplayID displayID)
     }
 
     // This API is deprecated in 10.9 with no good replacement (as of 10.15).
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     io_service_t servicePort = CGDisplayIOServicePort(displayID);
+#pragma clang diagnostic pop
     CFDictionaryRef deviceInfo = IODisplayCreateInfoDictionary(servicePort, kIODisplayOnlyPreferredName);
     NSDictionary *localizedNames = [(__bridge NSDictionary *)deviceInfo objectForKey:[NSString stringWithUTF8String:kDisplayProductName]];
     char *displayName = NULL;

--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -223,7 +223,18 @@
     }
     @autoreleasepool {
         NSPasteboard *pasteboard = [sender draggingPasteboard];
-        NSString *desiredType = [pasteboard availableTypeFromArray:@[ NSFilenamesPboardType, NSPasteboardTypeString ]];
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+        // Deprecated in macOS 10.14 in favor of NSPasteboardTypeFileURL, which requires
+        // reading multiple pasteboard items instead of a single filenames plist.
+        NSString *filenamesType = NSFilenamesPboardType;
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+        NSString *desiredType = [pasteboard availableTypeFromArray:@[ filenamesType, NSPasteboardTypeString ]];
         SDL_Window *sdlwindow = [self findSDLWindow];
         NSData *pboardData;
         id pboardPlist;
@@ -247,7 +258,7 @@
         if (pboardData == nil) {
             return NO;
         }
-        SDL_assert([desiredType isEqualToString:NSFilenamesPboardType] ||
+        SDL_assert([desiredType isEqualToString:filenamesType] ||
                    [desiredType isEqualToString:NSPasteboardTypeString]);
 
         pboardString = [pasteboard stringForType:desiredType];
@@ -262,7 +273,7 @@
         }
         // Use SendDropPosition to update the mouse location
 
-        if ([desiredType isEqualToString:NSFilenamesPboardType]) {
+        if ([desiredType isEqualToString:filenamesType]) {
             for (NSString *path in (NSArray *)pboardPlist) {
                 NSURL *fileURL = [NSURL fileURLWithPath:path];
                 NSNumber *isAlias = nil;
@@ -868,7 +879,14 @@ static NSCursor *Cocoa_GetDesiredCursor(void)
 
     [view setNextResponder:self];
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
     [view setAcceptsTouchEvents:YES];
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath
@@ -2412,8 +2430,15 @@ static bool SetupWindowData(SDL_VideoDevice *_this, SDL_Window *window, NSWindow
         /* Prevents the window's "window device" from being destroyed when it is
          * hidden. See http://www.mikeash.com/pyblog/nsopenglcontext-and-one-shot.html
          */
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
         [nswindow setOneShot:NO];
-
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+        
         if (window->flags & SDL_WINDOW_EXTERNAL) {
             // Query the title from the existing window
             NSString *title = [nswindow title];
@@ -3346,8 +3371,16 @@ void Cocoa_AcceptDragAndDrop(SDL_Window *window, bool accept)
     @autoreleasepool {
         SDL_CocoaWindowData *data = (__bridge SDL_CocoaWindowData *)window->internal;
         if (accept) {
-            [data.nswindow registerForDraggedTypes:@[ (NSString *)kUTTypeFileURL,
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+            // UTTypeFileURL / UTTypeUTF8PlainText don't exist before macOS 11.0.
+           [data.nswindow registerForDraggedTypes:@[ (NSString *)kUTTypeFileURL,
                                                       (NSString *)kUTTypeUTF8PlainText ]];
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
         } else {
             [data.nswindow unregisterDraggedTypes];
         }


### PR DESCRIPTION
- [X] I confirm that I am the author of this code and release it to the SDL project under the zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Note that the code is written (well copied and pasted all over :)) by me, but the comments are a mix of my comments and what Claude told me to make sure that I was giving accurate notes.

## Description
Wrapped the deprecation warnings in:
`clang diagnostic ignored "-Wdeprecated-declarations"`

Also added swiftpm related directories to the .gitignore in preparation for another PR.

NOTE: This only hides the warnings to clean up the build. It does not attempt to modernize the calling sites. I looked at that as well, but because of support back to 10.13, many of the sites couldn't be fully modernized.


## Existing Issue(s)
<!--- If it fixes an open issue, please link to the issue here. -->
