### PR TITLE
Android: add SDL3 static build to Android.mk

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -121,6 +121,19 @@ include $(BUILD_SHARED_LIBRARY)
 
 ###########################
 #
+# SDL static library
+#
+###########################
+
+LOCAL_MODULE := SDL3_static
+
+LOCAL_MODULE_FILENAME := libSDL3
+
+include $(BUILD_STATIC_LIBRARY)
+
+
+###########################
+#
 # SDL_test static library
 #
 ###########################


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the SDL project under the zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

I use static build for Android with Android.mk compilation. This is a few lines to add it.